### PR TITLE
Update installation and build instructions

### DIFF
--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -39,53 +39,34 @@ At the moment we use the text-based interface, meaning you need to:
 
 One way to do this is as follows:
 ```bash
-export Z3_EXE /usr/bin/z3 # or a different directory in $PATH
+export Z3_EXE=/usr/bin/z3 # or a different directory in $PATH
 sudo cp z3-4.8.7-*/bin/z3 $Z3_EXE
 echo "export Z3_EXE=$Z3_EXE" >> ~/.bashrc
 ```
 
 Make sure that running `$Z3_EXE --version` gives `Z3 version 4.8.7`.
 
-Now, we can clone `silicon` from its GitHub repository.
-Once the cloning process is complete, open `silicon`'s `build.sbt` in your favorite editor
-and modify it applying the following [patch](./resources/patches/silicon-edits.patch).
+Now, we can clone `silicon` from its GitHub repository and install the Viper's JAR file required for the plugin. Open a new terminal emulator and type
+the following commands:
 
 ```bash
-# Clone the Silicon project in a directory.
-# The flag `--recursive` will also clone `silver`.
-git clone --recursive https://github.com/viperproject/silicon
-
+# The recursive cloning pulls `silver` as well. 
+git clone --recursive https://github.com/viperproject/silicon.git
 cd silicon
-
-# Apply the patch with the needed modifications
-git apply silicon-edits.patch
+# Compile Scala code into JVM bytecode.
+sbt build
+# This command build the fat-JAR file containing all the dependencies
+# required by Silver (Silicon, Scala Library, ...)
+sbt assembly
+# We can now publish the built JAR file into our local Maven repository
+mvn install:install-file \
+  -Dfile=$(pwd)/target/scala-2.13/silicon.jar \
+  -DgroupId=viper -DartifactId=silver -Dversion=1.1-SNAPSHOT \
+  -Dpackaging=jar
 ```
 
-
-Now, open up the `silver`'s building file (located at `./silicon/silver/build.sbt`), and in the _Publishing settings_, 
-add the following lines:
-
-```sbt
-// Publishing settings
-/* ... */
-ThisBuild / publishArtifact := true
-publishTo := Some(MavenCache("local-maven", file(Path.userHome.absolutePath + "/.m2/repository")))
-```
-
-Once done with all the modifications, from the `silicon` root directory we can compile and publish the projects
-running `sbt`:
-
-```bash
-# Compile and publish silver first
-cd silver
-sbt compile && sbt publish
-# Compile and publish silicon
-cd ..
-sbt compile && sbt publish
-```
-
-If everything went well, you should see the following new directories in the local Maven repository: 
-`~/.m2/repository/viper/silicon_2.13` and `~/.m2/repository/viper/silver_2.13`.
+If everything went well, you should see the following new directory in the local Maven repository: 
+`~/.m2/repository/viper/silver/1.0/silver-1.0.jar`.
 
 ### Common Errors
 

--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -66,7 +66,7 @@ mvn install:install-file \
 ```
 
 If everything went well, you should see the following new directory in the local Maven repository: 
-`~/.m2/repository/viper/silver/1.0/silver-1.0.jar`.
+`~/.m2/repository/viper/silver/1.0/silver-1.1-SNAPSHOT.jar`.
 
 ### Common Errors
 

--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -21,8 +21,7 @@ generation the intermediate representation) and
 [silicon](https://github.com/viperproject/silicon) (the symbolic engine for
 performing the verification of Viper code).
 
-However, the `silicon` *project structure* and *building file* require some
-important modifications for allowing Gradle to resolve the dependencies required by both projects.
+
 
 Therefore, to install the dependencies, be sure to have installed locally:
 * The Java Development Kit
@@ -46,7 +45,9 @@ echo "export Z3_EXE=$Z3_EXE" >> ~/.bashrc
 
 Make sure that running `$Z3_EXE --version` gives `Z3 version 4.8.7`.
 
-Now, we can clone `silicon` from its GitHub repository and install the Viper's JAR file required for the plugin. Open a new terminal emulator and type
+Now, we can clone `silicon` from its GitHub repository and install it in our local Maven repository. 
+The compilation process, through the command `sbt assembly`, will create a new fat-JAR file containing `Silicon + Silver` and other Scala dependencies.
+Open a new terminal emulator and type
 the following commands:
 
 ```bash
@@ -54,19 +55,19 @@ the following commands:
 git clone --recursive https://github.com/viperproject/silicon.git
 cd silicon
 # Compile Scala code into JVM bytecode.
-sbt build
+sbt compile
 # This command build the fat-JAR file containing all the dependencies
 # required by Silver (Silicon, Scala Library, ...)
 sbt assembly
 # We can now publish the built JAR file into our local Maven repository
 mvn install:install-file \
   -Dfile=$(pwd)/target/scala-2.13/silicon.jar \
-  -DgroupId=viper -DartifactId=silver -Dversion=1.1-SNAPSHOT \
+  -DgroupId=viper -DartifactId=silicon -Dversion=1.1-SNAPSHOT \
   -Dpackaging=jar
 ```
 
 If everything went well, you should see the following new directory in the local Maven repository: 
-`~/.m2/repository/viper/silver/1.1-SNAPSHOT/silver-1.1-SNAPSHOT.jar`.
+`~/.m2/repository/viper/silicon/1.1-SNAPSHOT/silicon-1.1-SNAPSHOT.jar`.
 
 ### Common Errors
 

--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -66,7 +66,7 @@ mvn install:install-file \
 ```
 
 If everything went well, you should see the following new directory in the local Maven repository: 
-`~/.m2/repository/viper/silver/1.0/silver-1.1-SNAPSHOT.jar`.
+`~/.m2/repository/viper/silver/1.1-SNAPSHOT/silver-1.1-SNAPSHOT.jar`.
 
 ### Common Errors
 

--- a/plugins/formal-verification/build.gradle.kts
+++ b/plugins/formal-verification/build.gradle.kts
@@ -16,9 +16,7 @@ java {
 }
 
 dependencies {
-    implementation("viper:silver_2.13:0.1-SNAPSHOT")
-    implementation("viper:silicon_2.13:1.1-SNAPSHOT")
-    implementation("org.scala-lang:scala-library:2.13.10")
+    implementation("viper:silver:1.1-SNAPSHOT")
 
     compileOnly(project(":compiler:fir:cones"))
     compileOnly(project(":compiler:fir:tree"))

--- a/plugins/formal-verification/build.gradle.kts
+++ b/plugins/formal-verification/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 }
 
 dependencies {
-    implementation("viper:silver:1.1-SNAPSHOT")
+    implementation("viper:silicon:1.1-SNAPSHOT")
 
     compileOnly(project(":compiler:fir:cones"))
     compileOnly(project(":compiler:fir:tree"))


### PR DESCRIPTION
Refactored installation and build instructions. The changes include:
   1. Fixing a typo in Z3 variable exporting instruction.
   2. Simplifying instructions for cloning and building the Silicon project.
   3. Reducing the number of dependencies for the plugin to only a single fat-JAR file.

The changes aim at simplifying the setup process and reducing potential points of failures during the setup.