### PR TITLE
Split name logic into separate classes.

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedName.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedName.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Represents a Kotlin name with its Viper equivalent.
+ *
+ * We could directly convert names and pass them around as strings, but this
+ * approach makes it easier to see where they came from during debugging.
+ */
+interface ConvertedName {
+    val asString: String
+}
+
+/**
+ * Representation for Kotlin local variable names.
+ */
+data class LocalName(val name: Name) : ConvertedName {
+    override val asString: String
+        get() = "local\$${name.asStringStripSpecialMarkers()}"
+}
+
+/**
+ * Representation for names not present in the original source,
+ * e.g. storage for the result of subexpressions.
+ */
+data class AnonymousName(val n: Int) : ConvertedName {
+    override val asString: String
+        get() = "anonymous\$$n"
+}
+
+/**
+ * This is a barebones representation of global names.  We'll need to
+ * expand it to include classes, but let's keep things simple for now.
+ */
+data class GlobalName(val packageName: FqName, val name: Name) : ConvertedName {
+    override val asString: String
+        get() = "global\$pkg_${packageName.asString()}\$${name.asStringStripSpecialMarkers()}"
+}
+
+data object ReturnVariableName : ConvertedName {
+    override val asString: String
+        get() = "ret\$"
+}
+
+fun FirValueParameter.convertName(): LocalName = LocalName(name)
+fun CallableId.convertName(): ConvertedName = if (isLocal) LocalName(callableName) else GlobalName(packageName, callableName)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts.fir.diag.txt
@@ -1,32 +1,33 @@
 /no_contracts.kt:(4,15): info: field backing_int: Int
 
-method return_unit()
+method global$pkg_$return_unit()
 {
 }
 
 /no_contracts.kt:(25,35): info: field backing_int: Int
 
-method return_int() returns (ret: Int)
+method global$pkg_$return_int() returns (ret$: Int)
 {
-  ret := 0
+  ret$ := 0
 }
 
 /no_contracts.kt:(60,80): info: field backing_int: Int
 
-method take_int_return_unit(x: Int)
+method global$pkg_$take_int_return_unit(local$x: Int)
 {
 }
 
 /no_contracts.kt:(126,145): info: field backing_int: Int
 
-method take_int_return_int(x: Int) returns (ret: Int)
+method global$pkg_$take_int_return_int(local$x: Int) returns (ret$: Int)
 {
-  ret := x
+  ret$ := local$x
 }
 
 /no_contracts.kt:(176,200): info: field backing_int: Int
 
-method take_int_return_int_expr(x: Int) returns (ret: Int)
+method global$pkg_$take_int_return_int_expr(local$x: Int)
+  returns (ret$: Int)
 {
-  ret := x
+  ret$ := local$x
 }

--- a/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
@@ -1,11 +1,11 @@
 /simple.kt:(84,100): info: field backing_int: Int
 
-method without_contract()
+method global$pkg_$without_contract()
 {
 }
 
 /simple.kt:(148,161): info: field backing_int: Int
 
-method with_contract()
+method global$pkg_$with_contract()
 {
 }


### PR DESCRIPTION
Saves us the trouble of passing strings around everywhere.