### PR TITLE
Represent valueless expressions as having type Unit.

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedMethodSignature.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedMethodSignature.kt
@@ -8,11 +8,9 @@ package org.jetbrains.kotlin.formver.conversion
 import org.jetbrains.kotlin.formver.scala.silicon.ast.*
 import viper.silver.ast.Method
 
-class ConvertedMethodSignature(val name: ConvertedName, val params: List<ConvertedVar>, val returnType: ConvertedOptionalType) {
-    val returnVarType: ConvertedType?
-        get() = returnType as? ConvertedType
-    val returnVar: ConvertedVar?
-        get() = returnVarType?.let { ConvertedVar(ReturnVariableName, it) }
+class ConvertedMethodSignature(val name: ConvertedName, val params: List<ConvertedVar>, val returnType: ConvertedType) {
+    val returnVar: ConvertedVar
+        get() = ConvertedVar(ReturnVariableName, returnType)
 
     fun toMethod(
         pres: List<Exp>, posts: List<Exp>,
@@ -21,7 +19,7 @@ class ConvertedMethodSignature(val name: ConvertedName, val params: List<Convert
         info: Info = Info.NoInfo,
         trafos: Trafos = Trafos.NoTrafos,
     ): Method {
-        val returns = listOfNotNull(returnVar)
+        val returns = listOf(returnVar)
         return method(
             name.asString,
             params.map { it.toLocalVarDecl() },

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedType.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedType.kt
@@ -5,25 +5,23 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Domain
+import org.jetbrains.kotlin.formver.scala.silicon.ast.DomainFunc
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
 
-interface ConvertedOptionalType {
-    val viperType: Type?
+interface ConvertedType {
+    val viperType: Type
     fun preconditions(v: Exp): List<Exp> = emptyList()
     fun postconditions(v: Exp): List<Exp> = emptyList()
 }
 
-interface ConvertedType : ConvertedOptionalType {
-    override val viperType: Type
+object ConvertedUnit : ConvertedType {
+    override val viperType: Type = UnitDomain.toType()
 }
 
-object ConvertedUnit : ConvertedOptionalType {
-    override val viperType: Type? = null
-}
-
-object ConvertedNothing : ConvertedOptionalType {
-    override val viperType: Type? = null
+object ConvertedNothing : ConvertedType {
+    override val viperType: Type = UnitDomain.toType()
 
     override fun preconditions(v: Exp): List<Exp> = listOf(Exp.BoolLit(false))
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -23,7 +23,7 @@ class MethodConversionContext(val programCtx: ProgramConversionContext, val sign
         get() =
             signature.toMethod(listOf(), listOf(), convertedBody)
 
-    val returnVar: ConvertedVar?
+    val returnVar: ConvertedVar
         get() = signature.returnVar
 
     private val convertedBody = body?.let { convertBody(it) }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -31,7 +31,7 @@ class ProgramConversionContext {
 
     val program: Program
         get() = Program(
-            emptySeq(), /* Domains */
+            seqOf(UnitDomain.toViper()), /* Domains */
             seqOf(field(INT_BACKING_FIELD, Type.Int)), /* Fields */
             emptySeq(), /* Functions */
             emptySeq(), /* Predicates */
@@ -64,7 +64,7 @@ class ProgramConversionContext {
         val retType = symbol.resolvedReturnTypeRef.type
 
         val params = symbol.valueParameterSymbols.map {
-            ConvertedVar(it.convertName(), convertVarType(it.resolvedReturnType))
+            ConvertedVar(it.convertName(), convertType(it.resolvedReturnType))
         }
         return ConvertedMethodSignature(
             symbol.callableId.convertName(),
@@ -73,14 +73,11 @@ class ProgramConversionContext {
         )
     }
 
-    fun convertType(type: ConeKotlinType): ConvertedOptionalType = when {
+    fun convertType(type: ConeKotlinType): ConvertedType = when {
         type.isUnit -> ConvertedUnit
         type.isInt -> ConvertedInt
         type.isBoolean -> ConvertedBoolean
         else -> throw NotImplementedError("The embedding for type $type is not yet implemented.")
     }
-
-    fun convertVarType(type: ConeKotlinType): ConvertedType =
-        convertType(type) as? ConvertedType ?: throw Exception("Type $type was expected to be a valid variable type, but isn't.")
 }
 

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/UnitDomain.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/UnitDomain.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Domain
+import org.jetbrains.kotlin.formver.scala.silicon.ast.DomainFunc
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
+
+const val UNIT_DOMAIN_NAME: String = "unit$"
+const val UNIT_DOMAIN_ELEMENT: String = "unit\$element"
+
+/** A representation of the unit type as a Viper domain.
+ *
+ * We would typically expect a unit type to have only one element, but it doesn't seem possible (or at
+ * least easy) to ensure this in Viper: even an axiom of the form `x: Unit, y: Unit :: x == y` doesn't
+ * seem to suffice (hence why it is not present here).  It isn't quite clear why this is the case, but
+ * since we don't generally need to talk about equality of units this should be fine.
+ */
+object UnitDomain : Domain(
+    UNIT_DOMAIN_NAME,
+    listOf(
+        DomainFunc(UNIT_DOMAIN_ELEMENT, listOf(), Type.Domain(UNIT_DOMAIN_NAME), true)
+    ),
+    listOf(),
+) {
+    val element: Exp = getDomainFuncApp(UNIT_DOMAIN_ELEMENT, listOf())
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Domain.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Domain.kt
@@ -52,7 +52,7 @@ class DomainAxiom(
             AnonymousDomainAxiom(exp.toViper(), pos.toViper(), info.toViper(), domainName, trafos.toViper())
 }
 
-class Domain(
+open class Domain(
     val name: String,
     functions: List<DomainFunc>,
     val axioms: List<DomainAxiom>,

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
@@ -1,30 +1,55 @@
-/basic.kt:(4,15): info: field backing_int: Int
+/basic.kt:(4,15): info: domain unit$  {
 
-method global$pkg_$return_unit()
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
+
+method global$pkg_$return_unit() returns (ret$: unit$)
 {
 }
 
-/basic.kt:(25,35): info: field backing_int: Int
+/basic.kt:(25,35): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$return_int() returns (ret$: Int)
 {
   ret$ := 0
 }
 
-/basic.kt:(60,80): info: field backing_int: Int
+/basic.kt:(60,80): info: domain unit$  {
 
-method global$pkg_$take_int_return_unit(local$x: Int)
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
+
+method global$pkg_$take_int_return_unit(local$x: Int) returns (ret$: unit$)
 {
 }
 
-/basic.kt:(126,145): info: field backing_int: Int
+/basic.kt:(126,145): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$take_int_return_int(local$x: Int) returns (ret$: Int)
 {
   ret$ := local$x
 }
 
-/basic.kt:(176,200): info: field backing_int: Int
+/basic.kt:(176,200): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$take_int_return_int_expr(local$x: Int)
   returns (ret$: Int)
@@ -32,7 +57,12 @@ method global$pkg_$take_int_return_int_expr(local$x: Int)
   ret$ := local$x
 }
 
-/basic.kt:(222,242): info: field backing_int: Int
+/basic.kt:(222,242): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$with_int_declaration() returns (ret$: Int)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
@@ -1,16 +1,26 @@
-/function_call.kt:(4,5): info: field backing_int: Int
+/function_call.kt:(4,5): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 {
   ret$ := local$x
 }
 
-/function_call.kt:(27,40): info: field backing_int: Int
+/function_call.kt:(27,40): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 
 
-method global$pkg_$function_call()
+method global$pkg_$function_call() returns (ret$: unit$)
 {
   var anonymous$1: Int
   var anonymous$2: Int
@@ -18,12 +28,17 @@ method global$pkg_$function_call()
   anonymous$2 := global$pkg_$f(0)
 }
 
-/function_call.kt:(69,89): info: field backing_int: Int
+/function_call.kt:(69,89): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 
 
-method global$pkg_$function_call_nested()
+method global$pkg_$function_call_nested() returns (ret$: unit$)
 {
   var anonymous$1: Int
   var anonymous$2: Int

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
@@ -1,4 +1,9 @@
-/loop.kt:(4,14): info: field backing_int: Int
+/loop.kt:(4,14): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$while_loop(local$b: Bool) returns (ret$: Int)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -1,4 +1,9 @@
-/when.kt:(4,13): info: field backing_int: Int
+/when.kt:(4,13): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$simple_if() returns (ret$: Int)
 {
@@ -8,7 +13,12 @@ method global$pkg_$simple_if() returns (ret$: Int)
     ret$ := 1}
 }
 
-/when.kt:(98,113): info: field backing_int: Int
+/when.kt:(98,113): info: domain unit$  {
+
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
 
 method global$pkg_$if_on_parameter(local$b: Bool) returns (ret$: Int)
 {

--- a/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
@@ -1,11 +1,21 @@
-/simple.kt:(84,100): info: field backing_int: Int
+/simple.kt:(84,100): info: domain unit$  {
 
-method global$pkg_$without_contract()
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
+
+method global$pkg_$without_contract() returns (ret$: unit$)
 {
 }
 
-/simple.kt:(148,161): info: field backing_int: Int
+/simple.kt:(148,161): info: domain unit$  {
 
-method global$pkg_$with_contract()
+  unique function unit$element(): unit$
+}
+
+field backing_int: Int
+
+method global$pkg_$with_contract() returns (ret$: unit$)
 {
 }


### PR DESCRIPTION
This introduces a Unit domain and uses it to represent expressions that do not return a value (as well as actual `Unit` type values in Kotlin).