### PR TITLE
Configure tests to report one error at a time

### DIFF
--- a/compiler/fir/analysis-tests/test/org/jetbrains/kotlin/test/LoadedMetadataDumpHandler.kt
+++ b/compiler/fir/analysis-tests/test/org/jetbrains/kotlin/test/LoadedMetadataDumpHandler.kt
@@ -128,9 +128,7 @@ abstract class AbstractLoadedMetadataDumpHandler<A : ResultingArtifact.Binary<A>
     override val artifactKind: BinaryKind<A>
 ) : BinaryArtifactHandler<A>(
     testServices,
-    artifactKind,
-    failureDisablesNextSteps = false,
-    doNotRunIfThereWerePreviousFailures = false
+    artifactKind
 ) {
     private val dumper: MultiModuleInfoDumper = MultiModuleInfoDumper()
 

--- a/compiler/test-infrastructure/tests/org/jetbrains/kotlin/test/TestRunner.kt
+++ b/compiler/test-infrastructure/tests/org/jetbrains/kotlin/test/TestRunner.kt
@@ -85,8 +85,9 @@ class TestRunner(private val testConfiguration: TestConfiguration) {
             preprocessor.prepareSealedClassInheritors(moduleStructure)
         }
 
+        var shouldProcessNextModules = true
         for (module in modules) {
-            val shouldProcessNextModules = processModule(module, dependencyProvider)
+            shouldProcessNextModules = processModule(module, dependencyProvider)
             if (!shouldProcessNextModules) break
         }
 
@@ -99,7 +100,7 @@ class TestRunner(private val testConfiguration: TestConfiguration) {
                 }
             }
         }
-        if (testConfiguration.metaInfoHandlerEnabled) {
+        if (testConfiguration.metaInfoHandlerEnabled && shouldProcessNextModules) {
             withAssertionCatching(WrappedException::FromMetaInfoHandler) {
                 globalMetadataInfoHandler.compareAllMetaDataInfos()
             }
@@ -148,9 +149,9 @@ class TestRunner(private val testConfiguration: TestConfiguration) {
                     return false
                 }
                 is TestStep.StepResult.HandlersResult -> {
-                    val (exceptionsFromHandlers, shouldRunNextSteps) = result
+                    val (exceptionsFromHandlers, ranHandlers, shouldRunNextSteps) = result
                     require(step is TestStep.HandlersStep<*>)
-                    allRanHandlers += step.handlers
+                    allRanHandlers += ranHandlers
                     allFailedExceptions += exceptionsFromHandlers
                     if (!shouldRunNextSteps) {
                         return false

--- a/compiler/test-infrastructure/tests/org/jetbrains/kotlin/test/model/AnalysisHandler.kt
+++ b/compiler/test-infrastructure/tests/org/jetbrains/kotlin/test/model/AnalysisHandler.kt
@@ -10,10 +10,10 @@ import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.assertions
 
 abstract class AnalysisHandler<A : ResultingArtifact<A>>(
-    val testServices: TestServices,
-    val failureDisablesNextSteps: Boolean,
-    val doNotRunIfThereWerePreviousFailures: Boolean
+    val testServices: TestServices
 ) : ServicesAndDirectivesContainer {
+    open val failureDisablesNextSteps: Boolean = false
+    open val doNotRunIfThereWerePreviousFailures: Boolean = false
     protected val assertions: Assertions
         get() = testServices.assertions
 
@@ -27,20 +27,14 @@ abstract class AnalysisHandler<A : ResultingArtifact<A>>(
 abstract class FrontendOutputHandler<R : ResultingArtifact.FrontendOutput<R>>(
     testServices: TestServices,
     override val artifactKind: FrontendKind<R>,
-    failureDisablesNextSteps: Boolean,
-    doNotRunIfThereWerePreviousFailures: Boolean
-) : AnalysisHandler<R>(testServices, failureDisablesNextSteps, doNotRunIfThereWerePreviousFailures)
+) : AnalysisHandler<R>(testServices)
 
 abstract class BackendInputHandler<I : ResultingArtifact.BackendInput<I>>(
     testServices: TestServices,
     override val artifactKind: BackendKind<I>,
-    failureDisablesNextSteps: Boolean,
-    doNotRunIfThereWerePreviousFailures: Boolean
-) : AnalysisHandler<I>(testServices, failureDisablesNextSteps, doNotRunIfThereWerePreviousFailures)
+) : AnalysisHandler<I>(testServices)
 
 abstract class BinaryArtifactHandler<A : ResultingArtifact.Binary<A>>(
     testServices: TestServices,
     override val artifactKind: BinaryKind<A>,
-    failureDisablesNextSteps: Boolean,
-    doNotRunIfThereWerePreviousFailures: Boolean
-) : AnalysisHandler<A>(testServices, failureDisablesNextSteps, doNotRunIfThereWerePreviousFailures)
+) : AnalysisHandler<A>(testServices)

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/AbstractIrHandler.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/AbstractIrHandler.kt
@@ -13,7 +13,5 @@ import org.jetbrains.kotlin.test.services.TestServices
 
 abstract class AbstractIrHandler(
     testServices: TestServices,
-    artifactKind: BackendKind<IrBackendInput> = BackendKinds.IrBackend,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
-) : BackendInputHandler<IrBackendInput>(testServices, artifactKind, failureDisablesNextSteps, doNotRunIfThereWerePreviousFailures)
+    artifactKind: BackendKind<IrBackendInput> = BackendKinds.IrBackend
+) : BackendInputHandler<IrBackendInput>(testServices, artifactKind)

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/BinaryArtifactHandlers.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/BinaryArtifactHandlers.kt
@@ -12,54 +12,37 @@ import org.jetbrains.kotlin.test.services.TestServices
 
 abstract class JvmBinaryArtifactHandler(
     testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
 ) : BinaryArtifactHandler<BinaryArtifacts.Jvm>(
     testServices,
-    ArtifactKinds.Jvm,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures = true,
-)
+    ArtifactKinds.Jvm
+) {
+    override val doNotRunIfThereWerePreviousFailures: Boolean = true
+}
 
 abstract class JsBinaryArtifactHandler(
-    testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
+    testServices: TestServices
 ) : BinaryArtifactHandler<BinaryArtifacts.Js>(
     testServices,
-    ArtifactKinds.Js,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures
+    ArtifactKinds.Js
 )
 
 abstract class KlibArtifactHandler(
-    testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
+    testServices: TestServices
 ) : BinaryArtifactHandler<BinaryArtifacts.KLib>(
     testServices,
-    ArtifactKinds.KLib,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures
+    ArtifactKinds.KLib
 )
 
 abstract class NativeBinaryArtifactHandler(
     testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
 ) : BinaryArtifactHandler<BinaryArtifacts.Native>(
     testServices,
-    ArtifactKinds.Native,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures
+    ArtifactKinds.Native
 )
 
 abstract class WasmBinaryArtifactHandler(
     testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
 ) : BinaryArtifactHandler<BinaryArtifacts.Wasm>(
     testServices,
-    ArtifactKinds.Wasm,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures
+    ArtifactKinds.Wasm
 )

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/NoCompilationErrorsHandler.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/NoCompilationErrorsHandler.kt
@@ -15,9 +15,9 @@ import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestServices
 
 class NoCompilationErrorsHandler(testServices: TestServices) : ClassicFrontendAnalysisHandler(
-    testServices,
-    failureDisablesNextSteps = true
+    testServices
 ) {
+    override val failureDisablesNextSteps: Boolean = true
     override val directiveContainers: List<DirectivesContainer>
         get() = listOf(CodegenTestDirectives)
 

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/NoFirCompilationErrorsHandler.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/backend/handlers/NoFirCompilationErrorsHandler.kt
@@ -17,7 +17,8 @@ import org.jetbrains.kotlin.test.frontend.fir.handlers.FirAnalysisHandler
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestServices
 
-class NoFirCompilationErrorsHandler(testServices: TestServices) : FirAnalysisHandler(testServices, failureDisablesNextSteps = true) {
+class NoFirCompilationErrorsHandler(testServices: TestServices) : FirAnalysisHandler(testServices) {
+    override val failureDisablesNextSteps: Boolean = true
     override val directiveContainers: List<DirectivesContainer>
         get() = listOf(CodegenTestDirectives)
 

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/directives/DiagnosticsDirectives.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/directives/DiagnosticsDirectives.kt
@@ -96,4 +96,11 @@ object DiagnosticsDirectives : SimpleDirectivesContainer() {
     val RENDER_IR_DIAGNOSTICS_FULL_TEXT by directive(
         description = "Render IR diagnostic texts to .ir.diag.txt"
     )
+
+    val STOP_ON_FAILURE by directive(
+        description = """
+           Stop tests when a failure is encountered.  This enables both doNotRunIfThereWerePreviousFailures
+           and failureDisablesNextSteps.
+        """
+    )
 }

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/classic/handlers/ClassicFrontendAnalysisHandler.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/classic/handlers/ClassicFrontendAnalysisHandler.kt
@@ -11,14 +11,10 @@ import org.jetbrains.kotlin.test.model.FrontendOutputHandler
 import org.jetbrains.kotlin.test.services.TestServices
 
 abstract class ClassicFrontendAnalysisHandler(
-    testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
+    testServices: TestServices
 ) : FrontendOutputHandler<ClassicFrontendOutputArtifact>(
     testServices,
-    FrontendKinds.ClassicFrontend,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures
+    FrontendKinds.ClassicFrontend
 )
 
 

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/fir/handlers/FirAnalysisHandler.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/fir/handlers/FirAnalysisHandler.kt
@@ -5,10 +5,12 @@
 
 package org.jetbrains.kotlin.test.frontend.fir.handlers
 
+import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives
 import org.jetbrains.kotlin.test.frontend.fir.FirOutputArtifact
 import org.jetbrains.kotlin.test.model.FrontendKinds
 import org.jetbrains.kotlin.test.model.FrontendOutputHandler
 import org.jetbrains.kotlin.test.services.TestServices
+import org.jetbrains.kotlin.test.services.defaultDirectives
 import java.io.File
 
 abstract class FirAnalysisHandler(
@@ -17,6 +19,10 @@ abstract class FirAnalysisHandler(
     testServices,
     FrontendKinds.FIR
 ) {
+    override val doNotRunIfThereWerePreviousFailures: Boolean
+        get() = DiagnosticsDirectives.STOP_ON_FAILURE in testServices.defaultDirectives
+    override val failureDisablesNextSteps: Boolean
+        get() = DiagnosticsDirectives.STOP_ON_FAILURE in testServices.defaultDirectives
     protected val File.nameWithoutFirExtension: String
         get() = nameWithoutExtension.removeSuffix(".fir")
 }

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/fir/handlers/FirAnalysisHandler.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/fir/handlers/FirAnalysisHandler.kt
@@ -12,14 +12,10 @@ import org.jetbrains.kotlin.test.services.TestServices
 import java.io.File
 
 abstract class FirAnalysisHandler(
-    testServices: TestServices,
-    failureDisablesNextSteps: Boolean = false,
-    doNotRunIfThereWerePreviousFailures: Boolean = false
+    testServices: TestServices
 ) : FrontendOutputHandler<FirOutputArtifact>(
     testServices,
-    FrontendKinds.FIR,
-    failureDisablesNextSteps,
-    doNotRunIfThereWerePreviousFailures
+    FrontendKinds.FIR
 ) {
     protected val File.nameWithoutFirExtension: String
         get() = nameWithoutExtension.removeSuffix(".fir")

--- a/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/fir/handlers/FirResolvedTypesVerifier.kt
+++ b/compiler/tests-common-new/tests/org/jetbrains/kotlin/test/frontend/fir/handlers/FirResolvedTypesVerifier.kt
@@ -22,7 +22,8 @@ import org.jetbrains.kotlin.test.frontend.fir.FirOutputArtifact
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestServices
 
-class FirResolvedTypesVerifier(testServices: TestServices) : FirAnalysisHandler(testServices, failureDisablesNextSteps = true) {
+class FirResolvedTypesVerifier(testServices: TestServices) : FirAnalysisHandler(testServices) {
+    override val failureDisablesNextSteps: Boolean = true
     override val directiveContainers: List<DirectivesContainer>
         get() = listOf(FirDiagnosticsDirectives)
 

--- a/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/runners/PluginPrototypeTests.kt
+++ b/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/runners/PluginPrototypeTests.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.plugin.runners
 import org.jetbrains.kotlin.formver.plugin.services.ExtensionRegistrarConfigurator
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.RENDER_DIAGNOSTICS_FULL_TEXT
+import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.STOP_ON_FAILURE
 import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives.ENABLE_PLUGIN_PHASES
 import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives.FIR_DUMP
 import org.jetbrains.kotlin.test.runners.AbstractFirLightTreeDiagnosticsTest
@@ -27,6 +28,7 @@ fun TestConfigurationBuilder.commonFirWithPluginFrontendConfiguration() {
         +ENABLE_PLUGIN_PHASES
         +FIR_DUMP
         +RENDER_DIAGNOSTICS_FULL_TEXT
+        +STOP_ON_FAILURE
     }
 
     useConfigurators(


### PR DESCRIPTION
Previously, the test would report all errors, which was not very readable in IntelliJ and was often not useful (as a crashed plugin doesn't give useful diagnostics).  With this change, only the first error is reported.