### PR TITLE
Split interfaces out of converters.

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedType.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedType.kt
@@ -5,8 +5,6 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.formver.scala.silicon.ast.Domain
-import org.jetbrains.kotlin.formver.scala.silicon.ast.DomainFunc
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
 

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -1,41 +1,10 @@
-/*
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
- * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
- */
-
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.fir.expressions.FirBlock
-import org.jetbrains.kotlin.formver.scala.silicon.ast.Stmt
 import viper.silver.ast.Method
 
-/**
- * Contains the metadata for converting a single (specific) Kotlin method;
- * create a new instance for each method if you want to convert multiple.
- * Note that by default we do not convert the whole method: we expect to
- * only need the signature in most methods, as we verify methods one at a
- * time.
- */
-class MethodConversionContext(val programCtx: ProgramConversionContext, val signature: ConvertedMethodSignature, val body: FirBlock?) {
-    // Converting the body here would be too late; we want this to be a pure method, while
-    // converting the body may involve the program context.
+interface MethodConversionContext : ProgramConversionContext {
     val toMethod: Method
-        get() =
-            signature.toMethod(listOf(), listOf(), convertedBody)
-
     val returnVar: ConvertedVar
-        get() = signature.returnVar
 
-    private val convertedBody = body?.let { convertBody(it) }
-
-    private fun convertBody(body: FirBlock): Stmt.Seqn {
-        val ctx = StmtConversionContext(this)
-        ctx.convertAndAppend(body)
-        return ctx.block
-    }
-
-    private var nextAnonVarNumber = 0
-
-    fun newAnonVar(type: ConvertedType): ConvertedVar =
-        ConvertedVar(AnonymousName(++nextAnonVarNumber), type)
+    fun newAnonVar(type: ConvertedType): ConvertedVar
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.fir.expressions.FirBlock
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Stmt
+import viper.silver.ast.Method
+
+/**
+ * Contains the metadata for converting a single (specific) Kotlin method;
+ * create a new instance for each method if you want to convert multiple.
+ * Note that by default we do not convert the whole method: we expect to
+ * only need the signature in most methods, as we verify methods one at a
+ * time.
+ */
+class MethodConverter(private val programCtx: ProgramConversionContext, signature: ConvertedMethodSignature, body: FirBlock?) :
+    MethodConversionContext, ProgramConversionContext by programCtx {
+    override val returnVar: ConvertedVar = signature.returnVar
+
+    private var nextAnonVarNumber = 0
+
+    override fun newAnonVar(type: ConvertedType): ConvertedVar =
+        ConvertedVar(AnonymousName(++nextAnonVarNumber), type)
+
+    // We need to make sure everything else is initialised by the time we get here.
+    private val convertedBody = body?.let { convertBody(it) }
+
+    // Converting the body here would be too late; we want this to be a pure method, while
+    // converting the body may involve the program context.
+    override val toMethod: Method = signature.toMethod(listOf(), listOf(), convertedBody)
+
+    private fun convertBody(body: FirBlock): Stmt.Seqn {
+        val ctx = StmtConverter(this)
+        ctx.convertAndAppend(body)
+        return ctx.block
+    }
+
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -5,73 +5,10 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
-import org.jetbrains.kotlin.fir.types.*
-import org.jetbrains.kotlin.formver.scala.emptySeq
-import org.jetbrains.kotlin.formver.scala.seqOf
-import org.jetbrains.kotlin.formver.scala.silicon.ast.*
-import org.jetbrains.kotlin.formver.scala.toScalaSeq
-import viper.silver.ast.Program
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
 
-/**
- * Tracks the top-level information about the program.
- * Conversions for global entities like types should generally be
- * performed via this context to ensure they can be deduplicated.
- */
-class ProgramConversionContext {
-    private val methods: MutableMap<ConvertedName, MethodConversionContext> = mutableMapOf()
-
-    val program: Program
-        get() = Program(
-            seqOf(UnitDomain.toViper()), /* Domains */
-            seqOf(), /* Fields */
-            emptySeq(), /* Functions */
-            emptySeq(), /* Predicates */
-            methods.values.map { it.toMethod }.toList().toScalaSeq(), /* Functions */
-            emptySeq(), /* Extensions */
-            Position.NoPosition.toViper(),
-            Info.NoInfo.toViper(),
-            Trafos.NoTrafos.toViper()
-        )
-
-    fun addWithBody(declaration: FirSimpleFunction) {
-        val signature = convertSignature(declaration.symbol)
-        // NOTE: we have a problem here if we initially specify a method without a body,
-        // and then later decide to add a body anyway.  It's not a problem for now, but
-        // worth being aware of.
-        methods.getOrPut(signature.name) {
-            MethodConversionContext(this, signature, declaration.body)
-        }
-    }
-
-    fun add(symbol: FirNamedFunctionSymbol): ConvertedMethodSignature {
-        val signature = convertSignature(symbol)
-        methods.getOrPut(signature.name) {
-            MethodConversionContext(this, signature, null)
-        }
-        return signature
-    }
-
-    fun convertSignature(symbol: FirNamedFunctionSymbol): ConvertedMethodSignature {
-        val retType = symbol.resolvedReturnTypeRef.type
-
-        val params = symbol.valueParameterSymbols.map {
-            ConvertedVar(it.convertName(), convertType(it.resolvedReturnType))
-        }
-        return ConvertedMethodSignature(
-            symbol.callableId.convertName(),
-            params,
-            convertType(retType)
-        )
-    }
-
-    fun convertType(type: ConeKotlinType): ConvertedType = when {
-        type.isUnit -> ConvertedUnit
-        type.isInt -> ConvertedInt
-        type.isBoolean -> ConvertedBoolean
-        type.isNothing -> ConvertedNothing
-        else -> throw NotImplementedError("The embedding for type $type is not yet implemented.")
-    }
+interface ProgramConversionContext {
+    fun add(symbol: FirNamedFunctionSymbol): ConvertedMethodSignature
+    fun convertType(type: ConeKotlinType): ConvertedType
 }
-

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.formver.scala.emptySeq
+import org.jetbrains.kotlin.formver.scala.seqOf
+import org.jetbrains.kotlin.formver.scala.silicon.ast.*
+import org.jetbrains.kotlin.formver.scala.toScalaSeq
+import viper.silver.ast.Program
+
+/**
+ * Tracks the top-level information about the program.
+ * Conversions for global entities like types should generally be
+ * performed via this context to ensure they can be deduplicated.
+ */
+class ProgramConverter : ProgramConversionContext {
+    private val methods: MutableMap<ConvertedName, MethodConverter> = mutableMapOf()
+
+    val program: Program
+        get() = Program(
+            seqOf(UnitDomain.toViper()), /* Domains */
+            seqOf(), /* Fields */
+            emptySeq(), /* Functions */
+            emptySeq(), /* Predicates */
+            methods.values.map { it.toMethod }.toList().toScalaSeq(), /* Functions */
+            emptySeq(), /* Extensions */
+            Position.NoPosition.toViper(),
+            Info.NoInfo.toViper(),
+            Trafos.NoTrafos.toViper()
+        )
+
+    fun addWithBody(declaration: FirSimpleFunction) {
+        val signature = convertSignature(declaration.symbol)
+        // NOTE: we have a problem here if we initially specify a method without a body,
+        // and then later decide to add a body anyway.  It's not a problem for now, but
+        // worth being aware of.
+        methods.getOrPut(signature.name) {
+            MethodConverter(this, signature, declaration.body)
+        }
+    }
+
+    override fun add(symbol: FirNamedFunctionSymbol): ConvertedMethodSignature {
+        val signature = convertSignature(symbol)
+        methods.getOrPut(signature.name) {
+            MethodConverter(this, signature, null)
+        }
+        return signature
+    }
+
+    private fun convertSignature(symbol: FirNamedFunctionSymbol): ConvertedMethodSignature {
+        val retType = symbol.resolvedReturnTypeRef.type
+
+        val params = symbol.valueParameterSymbols.map {
+            ConvertedVar(it.convertName(), convertType(it.resolvedReturnType))
+        }
+        return ConvertedMethodSignature(
+            symbol.callableId.convertName(),
+            params,
+            convertType(retType)
+        )
+    }
+
+    override fun convertType(type: ConeKotlinType): ConvertedType = when {
+        type.isUnit -> ConvertedUnit
+        type.isInt -> ConvertedInt
+        type.isBoolean -> ConvertedBoolean
+        type.isNothing -> ConvertedNothing
+        else -> throw NotImplementedError("The embedding for type $type is not yet implemented.")
+    }
+}
+

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -9,19 +9,9 @@ import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Stmt
 import viper.silver.ast.Declaration
 
-/**
- * Tracks the results of converting a block of statements.
- * Kotlin statements, declarations, and expressions do not map to Viper ones one-to-one.
- * Converting a statement with multiple function calls may require storing the
- * intermediate results, which requires introducing new names.  We thus need a
- * shared context for finding fresh variable names.
- */
-class StmtConversionContext(val methodCtx: MethodConversionContext) {
-    val statements: MutableList<Stmt> = mutableListOf()
-    val declarations: MutableList<Declaration> = mutableListOf()
-    val block = Stmt.Seqn(statements, declarations)
-
-    fun convertAndAppend(stmt: FirStatement) {
-        stmt.accept(StmtConversionVisitor(), this)
-    }
+interface StmtConversionContext : MethodConversionContext {
+    val block: Stmt.Seqn
+    fun addStatement(stmt: Stmt)
+    fun addDeclaration(declaration: Declaration)
+    fun convertAndAppend(stmt: FirStatement)
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/StmtConverter.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/StmtConverter.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.fir.expressions.FirStatement
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Stmt
+import viper.silver.ast.Declaration
+
+/**
+ * Tracks the results of converting a block of statements.
+ * Kotlin statements, declarations, and expressions do not map to Viper ones one-to-one.
+ * Converting a statement with multiple function calls may require storing the
+ * intermediate results, which requires introducing new names.  We thus need a
+ * shared context for finding fresh variable names.
+ */
+class StmtConverter(private val methodCtx: MethodConversionContext) : StmtConversionContext, MethodConversionContext by methodCtx {
+    private val statements: MutableList<Stmt> = mutableListOf()
+    private val declarations: MutableList<Declaration> = mutableListOf()
+    override val block = Stmt.Seqn(statements, declarations)
+
+    override fun addStatement(stmt: Stmt) {
+        statements.add(stmt)
+    }
+
+    override fun addDeclaration(declaration: Declaration) {
+        declarations.add(declaration)
+    }
+
+    override fun convertAndAppend(stmt: FirStatement) {
+        stmt.accept(StmtConversionVisitor(), this)
+    }
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/ViperPoweredDeclarationChecker.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
-import org.jetbrains.kotlin.formver.conversion.ProgramConversionContext
+import org.jetbrains.kotlin.formver.conversion.ProgramConverter
 import org.jetbrains.kotlin.formver.scala.Option
 import org.jetbrains.kotlin.formver.scala.emptySeq
 import org.jetbrains.kotlin.formver.scala.seqOf
@@ -26,7 +26,7 @@ import viper.silver.reporter.StdIOReporter
 
 object ViperPoweredDeclarationChecker : FirSimpleFunctionChecker() {
     override fun check(declaration: FirSimpleFunction, context: CheckerContext, reporter: DiagnosticReporter) {
-        val programConversionContext = ProgramConversionContext()
+        val programConversionContext = ProgramConverter()
         programConversionContext.addWithBody(declaration)
         val program = programConversionContext.program
 


### PR DESCRIPTION
This is necessary to make nested converters down the line (e.g. for nested statements).  It should also simplify things as you don't have to worry about which context a particular function is in anymore.