### PR TITLE
Replace pre + post conditions on types with invariants

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedMethodSignature.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedMethodSignature.kt
@@ -24,9 +24,9 @@ class ConvertedMethodSignature(val name: ConvertedName, val params: List<Convert
             name.asString,
             params.map { it.toLocalVarDecl() },
             returns.map { it.toLocalVarDecl() },
-            params.flatMap { it.preconditions() } + pres,
-            params.flatMap { it.postconditions() } +
-                    returns.flatMap { it.preconditions() } + posts,
+            params.flatMap { it.invariants() } + pres,
+            params.flatMap { it.invariants() } +
+                    returns.flatMap { it.invariants() } + posts,
             body, pos, info, trafos,
         )
     }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedType.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedType.kt
@@ -12,8 +12,7 @@ import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
 
 interface ConvertedType {
     val viperType: Type
-    fun preconditions(v: Exp): List<Exp> = emptyList()
-    fun postconditions(v: Exp): List<Exp> = emptyList()
+    fun invariants(v: Exp): List<Exp> = emptyList()
 }
 
 object ConvertedUnit : ConvertedType {
@@ -23,7 +22,7 @@ object ConvertedUnit : ConvertedType {
 object ConvertedNothing : ConvertedType {
     override val viperType: Type = UnitDomain.toType()
 
-    override fun preconditions(v: Exp): List<Exp> = listOf(Exp.BoolLit(false))
+    override fun invariants(v: Exp): List<Exp> = listOf(Exp.BoolLit(false))
 }
 
 object ConvertedInt : ConvertedType {
@@ -37,5 +36,5 @@ object ConvertedBoolean : ConvertedType {
 class ConvertedClassType : ConvertedType {
     override val viperType: Type = Type.Ref
 
-    override fun preconditions(v: Exp): List<Exp> = listOf(Exp.NeCmp(v, Exp.NullLit()))
+    override fun invariants(v: Exp): List<Exp> = listOf(Exp.NeCmp(v, Exp.NullLit()))
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedVar.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ConvertedVar.kt
@@ -21,6 +21,5 @@ class ConvertedVar(val name: ConvertedName, val type: ConvertedType) {
         trafos: Trafos = Trafos.NoTrafos,
     ): Exp.LocalVar = Exp.LocalVar(name.asString, type.viperType, pos, info, trafos)
 
-    fun preconditions(): List<Exp> = type.preconditions(toLocalVar())
-    fun postconditions(): List<Exp> = type.postconditions(toLocalVar())
+    fun invariants(): List<Exp> = type.invariants(toLocalVar())
 }


### PR DESCRIPTION
I think this makes more sense; there are cases when the invariant is stronger than the postcondition (e.g. nullability of references) but I don't think it is worth distinguishing.