### PR TITLE
Remove int backing field.

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -19,8 +19,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.getOrPut
 import viper.silver.ast.Method
 import viper.silver.ast.Program
 
-const val INT_BACKING_FIELD = "backing_int"
-
 /**
  * Tracks the top-level information about the program.
  * Conversions for global entities like types should generally be
@@ -32,7 +30,7 @@ class ProgramConversionContext {
     val program: Program
         get() = Program(
             seqOf(UnitDomain.toViper()), /* Domains */
-            seqOf(field(INT_BACKING_FIELD, Type.Int)), /* Fields */
+            seqOf(), /* Fields */
             emptySeq(), /* Functions */
             emptySeq(), /* Predicates */
             methods.values.map { it.toMethod }.toList().toScalaSeq(), /* Functions */

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
@@ -3,8 +3,6 @@
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$return_unit() returns (ret$: unit$)
 {
 }
@@ -13,8 +11,6 @@ method global$pkg_$return_unit() returns (ret$: unit$)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$return_int() returns (ret$: Int)
 {
@@ -26,8 +22,6 @@ method global$pkg_$return_int() returns (ret$: Int)
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$take_int_return_unit(local$x: Int) returns (ret$: unit$)
 {
 }
@@ -36,8 +30,6 @@ method global$pkg_$take_int_return_unit(local$x: Int) returns (ret$: unit$)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$take_int_return_int(local$x: Int) returns (ret$: Int)
 {
@@ -49,8 +41,6 @@ method global$pkg_$take_int_return_int(local$x: Int) returns (ret$: Int)
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$take_int_return_int_expr(local$x: Int)
   returns (ret$: Int)
 {
@@ -61,8 +51,6 @@ method global$pkg_$take_int_return_int_expr(local$x: Int)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$with_int_declaration() returns (ret$: Int)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
@@ -3,8 +3,6 @@
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 {
   ret$ := local$x
@@ -14,8 +12,6 @@ method global$pkg_$f(local$x: Int) returns (ret$: Int)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 
@@ -32,8 +28,6 @@ method global$pkg_$function_call() returns (ret$: unit$)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
@@ -3,8 +3,6 @@
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$while_loop(local$b: Bool) returns (ret$: Int)
 {
   while (local$b) {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -3,8 +3,6 @@
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$simple_if() returns (ret$: Int)
 {
   if (true) {
@@ -17,8 +15,6 @@ method global$pkg_$simple_if() returns (ret$: Int)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$if_on_parameter(local$b: Bool) returns (ret$: Int)
 {

--- a/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
@@ -3,8 +3,6 @@
   unique function unit$element(): unit$
 }
 
-field backing_int: Int
-
 method global$pkg_$without_contract() returns (ret$: unit$)
 {
 }
@@ -13,8 +11,6 @@ method global$pkg_$without_contract() returns (ret$: unit$)
 
   unique function unit$element(): unit$
 }
-
-field backing_int: Int
 
 method global$pkg_$with_contract() returns (ret$: unit$)
 {


### PR DESCRIPTION
This was intended to be used for boxing ints, but we don't seem to be going in that direction at the moment, so it's just clutter at this point.