### PR TITLE
Fix AnalysisHandler derived class

### DIFF
--- a/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/handlers/AbstractKaptHandler.kt
+++ b/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/handlers/AbstractKaptHandler.kt
@@ -11,10 +11,10 @@ import org.jetbrains.kotlin.test.model.TestArtifactKind
 import org.jetbrains.kotlin.test.services.TestServices
 
 abstract class AbstractKaptHandler(testServices: TestServices) : AnalysisHandler<KaptContextBinaryArtifact>(
-    testServices,
-    failureDisablesNextSteps = true,
-    doNotRunIfThereWerePreviousFailures = true
+    testServices
 ) {
+    override val failureDisablesNextSteps: Boolean = true
+    override val doNotRunIfThereWerePreviousFailures: Boolean = true
     override val artifactKind: TestArtifactKind<KaptContextBinaryArtifact>
         get() = KaptContextBinaryArtifact.Kind
 }


### PR DESCRIPTION
Apparently I missed this one when running tests earlier.  I'm not sure what the best way is to check that all test code builds (because `./gradlew test` doesn't actually work...)