### PR TITLE
Migrate newly added handlers to our flags.

### DIFF
--- a/compiler/util-klib-abi/test/org/jetbrains/kotlin/library/abi/handlers/LibraryAbiDumpHandler.kt
+++ b/compiler/util-klib-abi/test/org/jetbrains/kotlin/library/abi/handlers/LibraryAbiDumpHandler.kt
@@ -22,10 +22,10 @@ import org.jetbrains.kotlin.test.utils.withExtension
 @OptIn(ExperimentalLibraryAbiReader::class)
 class LibraryAbiDumpHandler(testServices: TestServices) : BinaryArtifactHandler<BinaryArtifacts.KLib>(
     testServices,
-    ArtifactKinds.KLib,
-    failureDisablesNextSteps = true,
-    doNotRunIfThereWerePreviousFailures = true,
+    ArtifactKinds.KLib
 ) {
+    override val failureDisablesNextSteps: Boolean = true
+    override val doNotRunIfThereWerePreviousFailures: Boolean = true
     override val directiveContainers get() = listOf(LibraryAbiDumpDirectives)
 
     private val dumpers = KotlinIrSignatureVersion.CURRENTLY_SUPPORTED_VERSIONS.map { irSignatureVersion ->

--- a/plugins/kapt4/test/org/jetbrains/kotlin/kapt4/Kapt4Handler.kt
+++ b/plugins/kapt4/test/org/jetbrains/kotlin/kapt4/Kapt4Handler.kt
@@ -34,10 +34,10 @@ import java.io.File
 import java.util.*
 
 internal class Kapt4Handler(testServices: TestServices) : AnalysisHandler<Kapt4ContextBinaryArtifact>(
-    testServices,
-    failureDisablesNextSteps = true,
-    doNotRunIfThereWerePreviousFailures = true
+    testServices
 ) {
+    override val failureDisablesNextSteps: Boolean = true
+    override val doNotRunIfThereWerePreviousFailures: Boolean = true
     override val artifactKind: TestArtifactKind<Kapt4ContextBinaryArtifact>
         get() = Kapt4ContextBinaryArtifact.Kind
 


### PR DESCRIPTION
Necessary to get :generators:generateTests to run.

I don't think there's much we can do about this, people will add new handlers and use the existing machinery... if the number of PRs gets too large, we can look into doing something more structured.