### PR TITLE
Report Viper Consistency Errors

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationPluginErrorMessages.kt
@@ -18,7 +18,12 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
         )
         put(
-            PluginErrors.VIPER_ERROR,
+            PluginErrors.VIPER_CONSISTENCY_ERROR,
+            "Viper consistency error: {0}",
+            CommonRenderers.STRING,
+        )
+        put(
+            PluginErrors.VIPER_VERIFICATION_ERROR,
             "Viper verification error: {0}",
             CommonRenderers.STRING,
         )

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/PluginErrors.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/PluginErrors.kt
@@ -11,7 +11,8 @@ import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 
 object PluginErrors {
     val FUNCTION_WITH_UNVERIFIED_CONTRACT by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
-    val VIPER_ERROR by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
+    val VIPER_CONSISTENCY_ERROR by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
+    val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
 
     init {

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Domain.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Domain.kt
@@ -77,7 +77,8 @@ abstract class Domain(
             trafos.toViper()
         )
 
-    fun toType(typeParamSubst: Map<Type.TypeVar, Type> = emptyMap()): Type.Domain = Type.Domain(name.asString, typeVars, typeParamSubst)
+    fun toType(typeParamSubst: Map<Type.TypeVar, Type> = typeVars.associateWith { it }): Type.Domain =
+        Type.Domain(name.asString, typeVars, typeParamSubst)
 
     fun createDomainFunc(funcName: String, args: List<LocalVarDecl>, type: Type, unique: Boolean = false) =
         DomainFunc(ConvertedDomainFuncName(this.name, funcName), args, type, unique)

--- a/plugins/formal-verification/testData/diagnostics/returns_booleans.kt
+++ b/plugins/formal-verification/testData/diagnostics/returns_booleans.kt
@@ -20,7 +20,7 @@ fun <!VIPER_TEXT!>returns_false<!>(): Boolean {
 }
 
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_ERROR, VIPER_TEXT!>incorrectly_returns_false<!>(): Boolean {
+fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>incorrectly_returns_false<!>(): Boolean {
     contract {
         returns(true)
     }


### PR DESCRIPTION
Note that in theory this consistency check should be done automatically when verifying the program. However, since this is not the case, we insert a manual check to catch these errors.
This also means that the nullable test case now fails as the conversion from non-nullables to nullables is not handles correctly.