### PR TITLE
Start on function objects

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
@@ -21,3 +21,8 @@ data object ReturnVariableName : MangledName {
         get() = "ret\$"
 }
 
+data class SpecialFieldName(val name: String) : MangledName {
+    override val mangled: String
+        get() = "special\$$name"
+}
+

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -29,7 +29,7 @@ class ProgramConverter(val session: FirSession) : ProgramConversionContext {
     val program: Program
         get() = Program(
             listOf(UnitDomain, NullableDomain), /* Domains */
-            listOf(), /* Fields */
+            SpecialFields.all, /* Fields */
             methods.values.toList(), /* Methods */
         )
 
@@ -46,6 +46,7 @@ class ProgramConverter(val session: FirSession) : ProgramConversionContext {
         type.isInt -> IntTypeEmbedding
         type.isBoolean -> BooleanTypeEmbedding
         type.isNothing -> NothingTypeEmbedding
+        type.isSomeFunctionType(session) -> FunctionTypeEmbedding
         type.isNullable -> NullableTypeEmbedding(embedType(type.withNullability(ConeNullability.NOT_NULL, session.typeContext)))
         else -> throw NotImplementedError("The embedding for type $type is not yet implemented.")
     }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Field
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
+
+object SpecialFields {
+    val FunctionObjectCallCounterField = Field(SpecialFieldName("function_object_call_counter"), Type.Int)
+    val all = listOf(
+        FunctionObjectCallCounterField
+    )
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/MethodSignatureEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/MethodSignatureEmbedding.kt
@@ -27,6 +27,7 @@ class MethodSignatureEmbedding(val name: MangledName, val params: List<VariableE
             returns.map { it.toLocalVarDecl() },
             params.flatMap { it.invariants() } + pres,
             params.flatMap { it.invariants() } +
+                    params.flatMap { it.dynamicInvariants() } +
                     returns.flatMap { it.invariants() } + posts,
             body, pos, info, trafos,
         )

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -5,9 +5,11 @@
 
 package org.jetbrains.kotlin.formver.embeddings
 
+import org.jetbrains.kotlin.formver.conversion.SpecialFields
 import org.jetbrains.kotlin.formver.domains.NullableDomain
 import org.jetbrains.kotlin.formver.domains.UnitDomain
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp
+import org.jetbrains.kotlin.formver.scala.silicon.ast.PermExp
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
 
 interface TypeEmbedding {
@@ -39,4 +41,11 @@ class TypeVarEmbedding(val name: String) : TypeEmbedding {
 
 class NullableTypeEmbedding(val elementType: TypeEmbedding) : TypeEmbedding {
     override val type: Type = NullableDomain.toType(mapOf(NullableDomain.T to elementType.type))
+}
+
+object FunctionTypeEmbedding : TypeEmbedding {
+    override val type: Type = Type.Ref
+
+    override fun invariants(v: Exp): List<Exp> =
+        listOf(v.fieldAccessPredicate(SpecialFields.FunctionObjectCallCounterField, PermExp.FullPerm()))
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -15,6 +15,14 @@ import org.jetbrains.kotlin.formver.scala.silicon.ast.Type
 interface TypeEmbedding {
     val type: Type
     fun invariants(v: Exp): List<Exp> = emptyList()
+
+    /**
+     * Invariants that should correlate the old and new value of a value of this type
+     * over a function call.  This is exclusively necessary for CallsInPlace.
+     *
+     * TODO: add support for these in loops, too.
+     */
+    fun dynamicInvariants(v: Exp): List<Exp> = emptyList()
 }
 
 object UnitTypeEmbedding : TypeEmbedding {
@@ -48,4 +56,13 @@ object FunctionTypeEmbedding : TypeEmbedding {
 
     override fun invariants(v: Exp): List<Exp> =
         listOf(v.fieldAccessPredicate(SpecialFields.FunctionObjectCallCounterField, PermExp.FullPerm()))
+
+    override fun dynamicInvariants(v: Exp): List<Exp> =
+        listOf(
+            Exp.LeCmp(
+                Exp.Old(v.fieldAccess(SpecialFields.FunctionObjectCallCounterField)),
+                v.fieldAccess(SpecialFields.FunctionObjectCallCounterField)
+            )
+        )
 }
+

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
@@ -22,4 +22,5 @@ class VariableEmbedding(val name: MangledName, val type: TypeEmbedding) {
     ): Exp.LocalVar = Exp.LocalVar(name, type.type, pos, info, trafos)
 
     fun invariants(): List<Exp> = type.invariants(toLocalVar())
+    fun dynamicInvariants(): List<Exp> = type.dynamicInvariants(toLocalVar())
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/AccessPredicate.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/AccessPredicate.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.scala.silicon.ast
+
+sealed interface AccessPredicate : Exp {
+    override fun toViper(): viper.silver.ast.AccessPredicate
+
+    data class FieldAccessPredicate(
+        val access: Exp.FieldAccess,
+        val perm: PermExp,
+        val pos: Position = Position.NoPosition,
+        val info: Info = Info.NoInfo,
+        val trafos: Trafos = Trafos.NoTrafos,
+    ) : AccessPredicate {
+        override fun toViper(): viper.silver.ast.AccessPredicate =
+            viper.silver.ast.FieldAccessPredicate(access.toViper(), perm.toViper(), pos.toViper(), info.toViper(), trafos.toViper())
+    }
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Exp.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Exp.kt
@@ -350,4 +350,24 @@ sealed interface Exp : IntoViper<viper.silver.ast.Exp> {
                 trafos.toViper()
             )
     }
+
+    fun fieldAccess(
+        field: Field,
+        pos: Position = Position.NoPosition,
+        info: Info = Info.NoInfo,
+        trafos: Trafos = Trafos.NoTrafos,
+    ): FieldAccess =
+        FieldAccess(this, field, pos, info, trafos)
+
+    // We can't pass all the available position, info, and trafos information here.
+    // Living with that seems fine for the moment.
+    fun fieldAccessPredicate(
+        field: Field,
+        permission: PermExp,
+        pos: Position = Position.NoPosition,
+        info: Info = Info.NoInfo,
+        trafos: Trafos = Trafos.NoTrafos,
+    ): AccessPredicate.FieldAccessPredicate =
+        AccessPredicate.FieldAccessPredicate(fieldAccess(field), permission, pos, info, trafos)
+
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Exp.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Exp.kt
@@ -351,6 +351,17 @@ sealed interface Exp : IntoViper<viper.silver.ast.Exp> {
             )
     }
 
+    data class Old(
+        val exp: Exp,
+        val pos: Position = Position.NoPosition,
+        val info: Info = Info.NoInfo,
+        val trafos: Trafos = Trafos.NoTrafos,
+    ) : Exp {
+        override fun toViper(): viper.silver.ast.Old = Old(exp.toViper(), pos.toViper(), info.toViper(), trafos.toViper())
+    }
+
+    // We can't pass all the available position, info, and trafos information here.
+    // Living with that seems fine for the moment.
     fun fieldAccess(
         field: Field,
         pos: Position = Position.NoPosition,
@@ -369,5 +380,4 @@ sealed interface Exp : IntoViper<viper.silver.ast.Exp> {
         trafos: Trafos = Trafos.NoTrafos,
     ): AccessPredicate.FieldAccessPredicate =
         AccessPredicate.FieldAccessPredicate(fieldAccess(field), permission, pos, info, trafos)
-
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/PermExp.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/PermExp.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.scala.silicon.ast
+
+import org.jetbrains.kotlin.formver.scala.IntoViper
+import viper.silver.ast.FullPerm
+import viper.silver.ast.WildcardPerm
+
+sealed class PermExp : IntoViper<viper.silver.ast.PermExp> {
+    data class WildcardPerm(
+        val pos: Position = Position.NoPosition,
+        val info: Info = Info.NoInfo,
+        val trafos: Trafos = Trafos.NoTrafos,
+    ) : PermExp() {
+        override fun toViper(): viper.silver.ast.PermExp = WildcardPerm(pos.toViper(), info.toViper(), trafos.toViper())
+    }
+
+    data class FullPerm(
+        val pos: Position = Position.NoPosition,
+        val info: Info = Info.NoInfo,
+        val trafos: Trafos = Trafos.NoTrafos,
+    ) : PermExp() {
+        override fun toViper(): viper.silver.ast.PermExp = FullPerm(pos.toViper(), info.toViper(), trafos.toViper())
+    }
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/arithmetic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/arithmetic.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$addition(local$x: Int) returns (ret$: dom$Unit)
 {
   var local$y: Int
@@ -77,6 +79,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$subtraction(local$x: Int) returns (ret$: dom$Unit)
 {
@@ -121,6 +125,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$multiplication(local$x: Int) returns (ret$: dom$Unit)
 {
   var local$y: Int
@@ -163,6 +169,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$division(local$x: Int) returns (ret$: dom$Unit)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$return_unit() returns (ret$: dom$Unit)
 {
 }
@@ -75,6 +77,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$return_int() returns (ret$: Int)
 {
@@ -118,6 +122,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$take_int_return_unit(local$x: Int)
   returns (ret$: dom$Unit)
 {
@@ -160,6 +166,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$take_int_return_int(local$x: Int) returns (ret$: Int)
 {
   ret$ := local$x
@@ -201,6 +209,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$take_int_return_int_expr(local$x: Int)
   returns (ret$: Int)
@@ -245,6 +255,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$with_int_declaration() returns (ret$: Int)
 {
   var local$x: Int
@@ -288,6 +300,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$int_assignment() returns (ret$: dom$Unit)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/boolean_logic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/boolean_logic.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$negation(local$x: Bool) returns (ret$: Bool)
 {
   ret$ := !local$x
@@ -76,6 +78,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$conjunction(local$x: Bool, local$y: Bool)
   returns (ret$: Bool)
@@ -124,6 +128,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$negation(local$x: Bool) returns (ret$: Bool)
 
@@ -179,6 +185,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$disjunction(local$x: Bool, local$y: Bool)
   returns (ret$: Bool)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 {
   ret$ := local$x
@@ -76,6 +78,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 
@@ -124,6 +128,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$f(local$x: Int) returns (ret$: Int)
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
@@ -1,4 +1,4 @@
-/loop.kt:(4,14): info: Generated Viper text for while_loop:
+/function_object.kt:(4,17): info: Generated Viper text for unit_function:
 domain dom$Unit  {
 
   function dom$Unit$element(): dom$Unit
@@ -37,13 +37,8 @@ domain dom$Nullable[T]  {
 
 field special$function_object_call_counter: Int
 
-method global$pkg_$while_loop(local$b: Bool) returns (ret$: Int)
+method global$pkg_$unit_function(local$f: Ref) returns (ret$: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
 {
-  while (local$b) {
-    var local$a: Int
-    var local$c: Int
-    local$a := 1
-    local$c := 2
-  }
-  ret$ := 0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
@@ -40,5 +40,7 @@ field special$function_object_call_counter: Int
 method global$pkg_$unit_function(local$f: Ref) returns (ret$: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
 {
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.txt
@@ -1,0 +1,3 @@
+FILE: function_object.kt
+    public final fun unit_function(@R|kotlin/Suppress|(names = vararg(String(UNUSED_PARAMETER))) f: R|() -> kotlin/Unit|): R|kotlin/Unit| {
+    }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.kt
@@ -1,0 +1,2 @@
+fun <!VIPER_TEXT!>unit_function<!>(@Suppress("UNUSED_PARAMETER") f: () -> Unit) {
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$use_nullable_twice(local$x: dom$Nullable[Int])
   returns (ret$: dom$Nullable[Int])
 {
@@ -81,6 +83,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$use_nullable_twice(local$x: dom$Nullable[Int])
   returns (ret$: dom$Nullable[Int])

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$simple_if() returns (ret$: Int)
 {
   var anonymous$1: dom$Unit
@@ -84,6 +86,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$if_on_parameter(local$b: Bool) returns (ret$: Int)
 {
   var anonymous$1: dom$Unit
@@ -132,6 +136,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$simple_if() returns (ret$: Int)
 

--- a/plugins/formal-verification/testData/diagnostics/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/returns_booleans.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$returns_true() returns (ret$: Bool)
   ensures true
   ensures ret$ == true
@@ -79,6 +81,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$returns_false() returns (ret$: Bool)
   ensures true
   ensures ret$ == false
@@ -122,6 +126,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$incorrectly_returns_false() returns (ret$: Bool)
   ensures ret$ == true
@@ -171,6 +177,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$conditional_basic(local$b: Bool) returns (ret$: Bool)
   ensures ret$ == true ==> true
   ensures ret$ == false ==> local$b
@@ -214,6 +222,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$binary_logic_expressions(local$a: Bool, local$b: Bool)
   returns (ret$: Bool)
@@ -260,6 +270,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$logical_not(local$b: Bool) returns (ret$: Bool)
   ensures ret$ == true ==> !local$b && local$b
   ensures ret$ == false ==> local$b || !local$b
@@ -303,6 +315,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$binary_logic_expressions(local$a: Bool, local$b: Bool)
   returns (ret$: Bool)

--- a/plugins/formal-verification/testData/diagnostics/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/returns_null.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$simple_returns_null(local$x: dom$Nullable[Int])
   returns (ret$: dom$Nullable[Int])
   ensures ret$ == (dom$Nullable$null(): dom$Nullable[Int])
@@ -79,6 +81,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$returns_null_implies(local$x: dom$Nullable[Bool])
   returns (ret$: dom$Nullable[Bool])
@@ -126,6 +130,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$returns_null_with_if(local$x: dom$Nullable[Int], local$y: dom$Nullable[Int],
   local$z: dom$Nullable[Int])
@@ -185,6 +191,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$non_nullable_returns_not_null(local$x: Int)
   returns (ret$: Int)
   ensures true
@@ -228,6 +236,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$non_nullable_returns_null(local$x: Int)
   returns (ret$: Int)
@@ -277,6 +287,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$non_nullable_compared_to_null(local$x: Int, local$y: Int)
   returns (ret$: Int)

--- a/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/simple.fir.diag.txt
@@ -35,6 +35,8 @@ domain dom$Nullable[T]  {
   }
 }
 
+field special$function_object_call_counter: Int
+
 method global$pkg_$without_contract() returns (ret$: dom$Unit)
 {
 }
@@ -75,6 +77,8 @@ domain dom$Nullable[T]  {
       nx)
   }
 }
+
+field special$function_object_call_counter: Int
 
 method global$pkg_$with_contract() returns (ret$: dom$Unit)
   ensures true

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -76,6 +76,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("function_object.kt")
+        public void testFunction_object() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/function_object.kt");
+        }
+
+        @Test
         @TestMetadata("loop.kt")
         public void testLoop() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/loop.kt");


### PR DESCRIPTION
This PR implements a representation of function objects as function parameters, including the number-of-calls tracking field.  Support for calling the function will be in a follow-up PR.