### PR TITLE
Add a command-line processor to the compiler.

### DIFF
--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -10,6 +10,9 @@ specify the plugin `.jar` with `-Xplugin=`:
 dist/kotlinc/bin/kotlinc -language-version 2.0 -Xplugin=dist/kotlinc/lib/formver-compiler-plugin.jar,$HOME/.m2/repository/viper/silicon/1.1-SNAPSHOT/silicon-1.1-SNAPSHOT.jar myfile.kt
 ```
 
+The plugin accepts a number of command line options which can be passed via `-P plugin:org.jetbrains.kotlin.formver:OPTION=SETTING`:
+- Option `log_level`: permitted values `only_warnings`, `full_viper_dump`.
+
 ## Viper dependency
 
 To build the plugin, two main Viper dependencies are needed: 

--- a/plugins/formal-verification/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/plugins/formal-verification/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -3,4 +3,4 @@
 # Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
 #
 
-org.jetbrains.kotlin.formver.plugin.FormalVerificationPluginComponentRegistrar
+org.jetbrains.kotlin.formver.plugin.FormalVerificationCommandLineProcessor

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationCommandLineProcessor.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationCommandLineProcessor.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.plugin
+
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import org.jetbrains.kotlin.formver.plugin.FormalVerificationConfigurationKeys.LOG_LEVEL
+import org.jetbrains.kotlin.formver.plugin.FormalVerificationPluginNames.LOG_LEVEL_OPTION_NAME
+
+object FormalVerificationConfigurationKeys {
+    val LOG_LEVEL: CompilerConfigurationKey<LogLevel> = CompilerConfigurationKey.create("viper log level")
+}
+
+class FormalVerificationCommandLineProcessor : CommandLineProcessor {
+    companion object {
+        val LOG_LEVEL_OPTION = CliOption(
+            LOG_LEVEL_OPTION_NAME, "<log_level>", "Viper log level",
+            required = false, allowMultipleOccurrences = false
+        )
+    }
+
+    override val pluginId: String = FormalVerificationPluginNames.PLUGIN_ID
+    override val pluginOptions: Collection<AbstractCliOption> = listOf(LOG_LEVEL_OPTION)
+
+    override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) =
+        when (option) {
+            LOG_LEVEL_OPTION -> when (value) {
+                "only_warnings" -> configuration.put(LOG_LEVEL, LogLevel.ONLY_WARNINGS)
+                "full_viper_dump" -> configuration.put(LOG_LEVEL, LogLevel.FULL_VIPER_DUMP)
+                else -> throw CliOptionProcessingException("Invalid setting $value for ${option.optionName}")
+            }
+            else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
+        }
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationPluginExtensionRegistrar.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationPluginExtensionRegistrar.kt
@@ -10,9 +10,9 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 
-class FormalVerificationPluginExtensionRegistrar : FirExtensionRegistrar() {
+class FormalVerificationPluginExtensionRegistrar(private val logLevel: LogLevel) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
-        +::PluginAdditionalCheckers
+        +PluginAdditionalCheckers.getFactory(logLevel)
     }
 }
 
@@ -21,6 +21,7 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         get() = true
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar())
+        val logLevel = configuration.get(FormalVerificationConfigurationKeys.LOG_LEVEL, LogLevel.defaultLogLevel())
+        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(logLevel))
     }
 }

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationPluginNames.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/FormalVerificationPluginNames.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.plugin
+
+object FormalVerificationPluginNames {
+    const val PLUGIN_ID = "org.jetbrains.kotlin.formver"
+    const val LOG_LEVEL_OPTION_NAME = "log_level"
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/LogLevel.java
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/LogLevel.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.plugin;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum LogLevel {
+    ONLY_WARNINGS, FULL_VIPER_DUMP;
+
+    @NotNull
+    public static LogLevel defaultLogLevel() {
+        return ONLY_WARNINGS;
+    }
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/PluginAdditionalCheckers.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/plugin/PluginAdditionalCheckers.kt
@@ -9,11 +9,18 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
+import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension.Factory
 
-class PluginAdditionalCheckers(session: FirSession) : FirAdditionalCheckersExtension(session) {
+class PluginAdditionalCheckers(session: FirSession, logLevel: LogLevel) : FirAdditionalCheckersExtension(session) {
+    companion object {
+        fun getFactory(logLevel: LogLevel): Factory {
+            return Factory { session -> PluginAdditionalCheckers(session, logLevel) }
+        }
+    }
+
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
         override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
-            get() = setOf(ViperPoweredDeclarationChecker(session))
+            get() = setOf(ViperPoweredDeclarationChecker(session, logLevel))
     }
 }
 

--- a/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -9,12 +9,13 @@ import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar.ExtensionSto
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.plugin.FormalVerificationPluginExtensionRegistrar
+import org.jetbrains.kotlin.formver.plugin.LogLevel
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.TestServices
 
 class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
     override fun ExtensionStorage.registerCompilerExtensions(module: TestModule, configuration: CompilerConfiguration) {
-        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar())
+        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(LogLevel.FULL_VIPER_DUMP))
     }
 }


### PR DESCRIPTION
Allows enabling or disabling the VIPER_TEXT info message, which is not supposed to be shown to end users.

The `getProgramForLogging` function may seem overcomplicated; I've implemented it this way to allow for a more succinct Viper dump down the line, where we don't include standard things like domains and fields.