### PR TITLE
Add command-line flag for unsupported features

### DIFF
--- a/libraries/tools/kotlin-formver/build.gradle.kts
+++ b/libraries/tools/kotlin-formver/build.gradle.kts
@@ -10,6 +10,8 @@ pill {
 }
 
 dependencies {
+    implementation(project(":kotlin-formver-compiler-plugin.common"))
+
     commonApi(platform(project(":kotlin-gradle-plugins-bom")))
     commonApi(project(":kotlin-gradle-plugin-model"))
 

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
@@ -7,8 +7,13 @@ package org.jetbrains.kotlin.formver.gradle
 
 open class FormVerExtension {
     internal var myLogLevel: String? = null
+    internal var myUnsupportedFeatureBehaviour: String? = null
 
     open fun setLogLevel(logLevel: String) {
         myLogLevel = logLevel
+    }
+
+    open fun setUnsupportedFeatureBehaviour(behaviour: String) {
+        myUnsupportedFeatureBehaviour = behaviour
     }
 }

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.jetbrains.kotlin.formver.gradle.model.builder.FormVerModelBuilder
+import org.jetbrains.kotlin.formver.FormalVerificationPluginNames
 import org.jetbrains.kotlin.gradle.plugin.*
 import javax.inject.Inject
 
@@ -18,8 +19,6 @@ class FormVerGradleSubplugin
 ) : KotlinCompilerPluginSupportPlugin {
     companion object {
         private const val FORMVER_ARTIFACT_NAME = "kotlin-formver-compiler-plugin-embeddable"
-
-        private const val LOG_LEVEL_ARG_NAME = "log_level"
     }
 
     override fun apply(target: Project) {
@@ -38,7 +37,11 @@ class FormVerGradleSubplugin
             val options = mutableListOf<SubpluginOption>()
 
             formVerExtension.myLogLevel?.let {
-                options += SubpluginOption(LOG_LEVEL_ARG_NAME, it)
+                options += SubpluginOption(FormalVerificationPluginNames.LOG_LEVEL_OPTION_NAME, it)
+            }
+
+            formVerExtension.myUnsupportedFeatureBehaviour?.let {
+                options += SubpluginOption(FormalVerificationPluginNames.UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME, it)
             }
 
             options

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
@@ -18,7 +18,7 @@ class FormVerModelBuilder : ToolingModelBuilder {
     override fun buildAll(modelName: String, project: Project): Any {
         require(canBuild(modelName)) { "buildAll(\"$modelName\") has been called while canBeBuild is false" }
         val extension = project.extensions.getByType(FormVerExtension::class.java)
-        return FormVerImpl(project.name, extension.myLogLevel)
+        return FormVerImpl(project.name, extension.myLogLevel, extension.myUnsupportedFeatureBehaviour)
     }
 
 }

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
@@ -14,6 +14,7 @@ import java.io.Serializable
 data class FormVerImpl(
     override val name: String,
     override val logLevel: String?,
+    override val unsupportedFeatureBehaviour: String?,
 ) : FormVer, Serializable {
     override val modelVersion = serialVersionUID
 

--- a/libraries/tools/kotlin-gradle-plugin-model/src/common/kotlin/org/jetbrains/kotlin/gradle/model/FormVer.kt
+++ b/libraries/tools/kotlin-gradle-plugin-model/src/common/kotlin/org/jetbrains/kotlin/gradle/model/FormVer.kt
@@ -27,4 +27,11 @@ interface FormVer {
      * @return the Viper log level
      */
     val logLevel: String?
+
+    /**
+     * Returns the desired behaviour when encountering unsupported Kotlin features.
+     *
+     * @return the behaviour for unsupported features
+     */
+    val unsupportedFeatureBehaviour: String?
 }

--- a/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationCommandLineProcessor.kt
+++ b/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationCommandLineProcessor.kt
@@ -12,10 +12,14 @@ import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.LOG_LEVEL
+import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.UNSUPPORTED_FEATURE_BEHAVIOUR
 import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.LOG_LEVEL_OPTION_NAME
+import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME
 
 object FormalVerificationConfigurationKeys {
     val LOG_LEVEL: CompilerConfigurationKey<LogLevel> = CompilerConfigurationKey.create("viper log level")
+    val UNSUPPORTED_FEATURE_BEHAVIOUR: CompilerConfigurationKey<UnsupportedFeatureBehaviour> =
+        CompilerConfigurationKey.create("unsupported feature behaviour")
 }
 
 class FormalVerificationCommandLineProcessor : CommandLineProcessor {
@@ -24,10 +28,17 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
             LOG_LEVEL_OPTION_NAME, "<log_level>", "Viper log level",
             required = false, allowMultipleOccurrences = false
         )
+        val UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION = CliOption(
+            UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME,
+            "<unsupported_feature_behaviour>",
+            "Selected behaviour when encountering unsupported Kotlin features",
+            required = false,
+            allowMultipleOccurrences = false
+        )
     }
 
     override val pluginId: String = FormalVerificationPluginNames.PLUGIN_ID
-    override val pluginOptions: Collection<AbstractCliOption> = listOf(LOG_LEVEL_OPTION)
+    override val pluginOptions: Collection<AbstractCliOption> = listOf(LOG_LEVEL_OPTION, UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION)
 
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) =
         when (option) {
@@ -35,6 +46,11 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
                 "only_warnings" -> configuration.put(LOG_LEVEL, LogLevel.ONLY_WARNINGS)
                 "short_viper_dump" -> configuration.put(LOG_LEVEL, LogLevel.SHORT_VIPER_DUMP)
                 "full_viper_dump" -> configuration.put(LOG_LEVEL, LogLevel.FULL_VIPER_DUMP)
+                else -> throw CliOptionProcessingException("Invalid setting $value for ${option.optionName}")
+            }
+            UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION -> when (value) {
+                "throw_exception" -> configuration.put(UNSUPPORTED_FEATURE_BEHAVIOUR, UnsupportedFeatureBehaviour.THROW_EXCEPTION)
+                "assume_unreachable" -> configuration.put(UNSUPPORTED_FEATURE_BEHAVIOUR, UnsupportedFeatureBehaviour.ASSUME_UNREACHABLE)
                 else -> throw CliOptionProcessingException("Invalid setting $value for ${option.optionName}")
             }
             else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")

--- a/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationPluginComponentRegistrar.kt
+++ b/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationPluginComponentRegistrar.kt
@@ -15,6 +15,11 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         val logLevel = configuration.get(FormalVerificationConfigurationKeys.LOG_LEVEL, LogLevel.defaultLogLevel())
-        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(logLevel))
+        val behaviour = configuration.get(
+            FormalVerificationConfigurationKeys.UNSUPPORTED_FEATURE_BEHAVIOUR,
+            UnsupportedFeatureBehaviour.defaultBehaviour()
+        )
+        val config = PluginConfiguration(logLevel, behaviour)
+        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
     }
 }

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
@@ -5,8 +5,4 @@
 
 package org.jetbrains.kotlin.formver
 
-object FormalVerificationPluginNames {
-    const val PLUGIN_ID = "org.jetbrains.kotlin.formver"
-    const val LOG_LEVEL_OPTION_NAME = "log_level"
-    const val UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME = "unsupported_feature_behaviour"
-}
+class PluginConfiguration(val logLevel: LogLevel, val behaviour: UnsupportedFeatureBehaviour)

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/UnsupportedFeatureBehaviour.java
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/UnsupportedFeatureBehaviour.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum UnsupportedFeatureBehaviour {
+    THROW_EXCEPTION, ASSUME_UNREACHABLE;
+
+    @NotNull
+    public static UnsupportedFeatureBehaviour defaultBehaviour() {
+        return THROW_EXCEPTION;
+    }
+}

--- a/plugins/formal-verification/formver.core/build.gradle.kts
+++ b/plugins/formal-verification/formver.core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+    compileOnly(project(":kotlin-formver-compiler-plugin.common"))
     compileOnly(project(":kotlin-formver-compiler-plugin.viper"))
     compileOnly(project(":compiler:fir:cones"))
     compileOnly(project(":compiler:fir:tree"))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -10,11 +10,13 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.formver.PluginConfiguration
 import org.jetbrains.kotlin.formver.embeddings.ClassEmbedding
 import org.jetbrains.kotlin.formver.embeddings.MethodSignatureEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 
 interface ProgramConversionContext {
+    val config: PluginConfiguration
 
     fun add(symbol: FirFunctionSymbol<*>): MethodSignatureEmbedding
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginExtensionRegistrar.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginExtensionRegistrar.kt
@@ -7,9 +7,9 @@ package org.jetbrains.kotlin.formver
 
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
-class FormalVerificationPluginExtensionRegistrar(private val logLevel: LogLevel) : FirExtensionRegistrar() {
+class FormalVerificationPluginExtensionRegistrar(private val config: PluginConfiguration) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
-        +PluginAdditionalCheckers.getFactory(logLevel)
+        +PluginAdditionalCheckers.getFactory(config)
     }
 }
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginAdditionalCheckers.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginAdditionalCheckers.kt
@@ -11,17 +11,17 @@ import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionC
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension.Factory
 
-class PluginAdditionalCheckers(session: FirSession, logLevel: org.jetbrains.kotlin.formver.LogLevel) :
+class PluginAdditionalCheckers(session: FirSession, config: PluginConfiguration) :
     FirAdditionalCheckersExtension(session) {
     companion object {
-        fun getFactory(logLevel: org.jetbrains.kotlin.formver.LogLevel): Factory {
-            return Factory { session -> PluginAdditionalCheckers(session, logLevel) }
+        fun getFactory(config: PluginConfiguration): Factory {
+            return Factory { session -> PluginAdditionalCheckers(session, config) }
         }
     }
 
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
         override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
-            get() = setOf(ViperPoweredDeclarationChecker(session, logLevel))
+            get() = setOf(ViperPoweredDeclarationChecker(session, config))
     }
 }
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -25,9 +25,10 @@ private val VerifierError.error: KtDiagnosticFactory1<String>
         is VerificationError -> PluginErrors.VIPER_VERIFICATION_ERROR
     }
 
-class ViperPoweredDeclarationChecker(private val session: FirSession, private val logLevel: LogLevel) : FirSimpleFunctionChecker() {
+class ViperPoweredDeclarationChecker(private val session: FirSession, private val config: PluginConfiguration) :
+    FirSimpleFunctionChecker() {
     override fun check(declaration: FirSimpleFunction, context: CheckerContext, reporter: DiagnosticReporter) {
-        val programConversionContext = ProgramConverter(session)
+        val programConversionContext = ProgramConverter(session, config)
         programConversionContext.addWithBody(declaration)
         val program = programConversionContext.program
 
@@ -52,7 +53,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
     }
 
 
-    private fun getProgramForLogging(program: Program): Program? = when (logLevel) {
+    private fun getProgramForLogging(program: Program): Program? = when (config.logLevel) {
         LogLevel.ONLY_WARNINGS -> null
         LogLevel.SHORT_VIPER_DUMP -> program.toShort()
         LogLevel.FULL_VIPER_DUMP -> program

--- a/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.FormalVerificationPluginExtensionRegistrar
 import org.jetbrains.kotlin.formver.LogLevel
+import org.jetbrains.kotlin.formver.PluginConfiguration
+import org.jetbrains.kotlin.formver.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.TestServices
@@ -19,6 +21,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
         val logLevel =
             if (module.files.any { it.name.contains("full_viper_dump") }) LogLevel.FULL_VIPER_DUMP
             else LogLevel.SHORT_VIPER_DUMP
-        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(logLevel))
+        val config = PluginConfiguration(logLevel, UnsupportedFeatureBehaviour.THROW_EXCEPTION)
+        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
     }
 }


### PR DESCRIPTION
This allows us to attempt to verify code even in the presence of features we know we can't correctly compile.

No tests included because they would be a pain to maintain as we add new features, and this mode is intended for manual testing anyway.