### PR TITLE
Add Subtyping

### DIFF
--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/SpecialFunction.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/conversion/SpecialFunction.kt
@@ -5,10 +5,8 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp
-import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp.*
+import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.scala.silicon.ast.Stmt
-import org.jetbrains.kotlin.formver.scala.toScalaBigInt
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -24,35 +22,35 @@ object KotlinContractFunction : SpecialFunction {
 }
 
 interface SpecialFunctionImplementation : SpecialFunction {
-    fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp
+    fun convertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding
 }
 
 object KotlinIntPlusFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("plus"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding =
         Add(args[0], args[1])
 }
 
 object KotlinIntMinusFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("minus"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding =
         Sub(args[0], args[1])
 }
 
 object KotlinIntTimesFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("times"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding =
         Mul(args[0], args[1])
 }
 
 object KotlinIntDivFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("div"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp {
-        ctx.addStatement(Stmt.Inhale(NeCmp(args[1], IntLit(0.toScalaBigInt()))))
+    override fun convertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding {
+        ctx.addStatement(Stmt.Inhale(NeCmp(args[1], IntLit(0)).viperExp))
         return Div(args[0], args[1])
     }
 }
@@ -60,7 +58,7 @@ object KotlinIntDivFunctionImplementation : SpecialFunctionImplementation {
 object KotlinBooleanNotFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Boolean"), Name.identifier("not"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding =
         Not(args[0])
 }
 

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/domains/NullableDomain.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/domains/NullableDomain.kt
@@ -37,13 +37,13 @@ import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp.Companion.Trigger1
 object NullableDomain : BuiltinDomain("Nullable") {
     val T = Type.TypeVar("T")
     override val typeVars: List<Type.TypeVar> = listOf(T)
-    val Nullable: Type = this.toType()
+    fun nullableType(elemType: Type): Type = this.toType(mapOf(T to elemType))
 
     private val xVar = Var("x", T)
-    private val nxVar = Var("nx", Nullable)
+    private val nxVar = Var("nx", nullableType(T))
 
-    val nullFunc = createDomainFunc("null", emptyList(), Nullable)
-    val nullableOf = createDomainFunc("nullable_of", listOf(xVar.decl()), Nullable)
+    val nullFunc = createDomainFunc("null", emptyList(), nullableType(T))
+    val nullableOf = createDomainFunc("nullable_of", listOf(xVar.decl()), nullableType(T))
     val valOf = createDomainFunc("val_of", listOf(nxVar.decl()), T)
     override val functions: List<DomainFunc> = listOf(nullFunc, nullableOf, valOf)
 

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/ExpEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/ExpEmbedding.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.domains.NullableDomain
+import org.jetbrains.kotlin.formver.domains.UnitDomain
+import org.jetbrains.kotlin.formver.scala.silicon.ast.*
+import org.jetbrains.kotlin.formver.scala.toScalaBigInt
+import viper.silver.ast.DomainType
+import javax.sound.sampled.LineEvent.Type
+
+sealed interface ExpEmbedding {
+    val type: TypeEmbedding
+    val viperExp: Exp
+
+    fun withType(newType: TypeEmbedding): ExpEmbedding =
+        when {
+            type == newType -> this
+            type !is NullableTypeEmbedding && newType is NullableTypeEmbedding -> NullableOf(this.withType(newType.elementType))
+            // This NullLit conversion is just hard-coded here to not break the tests,
+            // it can be deleted once the to-do below has been solved.
+            this is NullLit && newType is NullableTypeEmbedding -> NullLit(newType)
+            type is NullableTypeEmbedding && (type as NullableTypeEmbedding).elementType.isSubTypeOf(newType) ->
+                ValOfNullable(this).withType(newType)
+            type is NullableTypeEmbedding && newType is NullableTypeEmbedding -> TODO("Add domain function in the Nullable domain to convert from one type of nullable to another if their element types are subtypes.")
+            type.isSubTypeOf(newType) -> throw NotImplementedError("Type $type is a subtype of $newType but no conversion function was specified.")
+            else -> throw IllegalArgumentException("Expression $this of type $type is not a subtype of $newType and can thus not be converted to it.")
+        }
+}
+
+fun <E : ExpEmbedding> List<E>.viperExps(): List<Exp> = map { it.viperExp }
+
+data class Add(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.Add =
+        Exp.Add(left.withType(type).viperExp, right.withType(type).viperExp)
+}
+
+data class Sub(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.Sub =
+        Exp.Sub(left.withType(type).viperExp, right.withType(type).viperExp)
+}
+
+data class Mul(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.Mul =
+        Exp.Mul(left.withType(type).viperExp, right.withType(type).viperExp)
+}
+
+data class Div(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.Div =
+        Exp.Div(left.withType(type).viperExp, right.withType(type).viperExp)
+}
+
+data class Mod(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.Mod =
+        Exp.Mod(left.withType(type).viperExp, right.withType(type).viperExp)
+}
+
+data class LtCmp(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    val cmpArgType = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.LtCmp =
+        Exp.LtCmp(left.withType(cmpArgType).viperExp, right.withType(cmpArgType).viperExp)
+}
+
+data class LeCmp(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    val cmpArgType = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.LeCmp =
+        Exp.LeCmp(left.withType(cmpArgType).viperExp, right.withType(cmpArgType).viperExp)
+}
+
+data class GtCmp(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    val cmpArgType = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.GtCmp =
+        Exp.GtCmp(left.withType(cmpArgType).viperExp, right.withType(cmpArgType).viperExp)
+}
+
+data class GeCmp(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    val cmpArgType = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.GeCmp =
+        Exp.GeCmp(left.withType(cmpArgType).viperExp, right.withType(cmpArgType).viperExp)
+}
+
+data class EqCmp(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    val cmpArgType = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.EqCmp =
+        Exp.EqCmp(left.withType(cmpArgType).viperExp, right.withType(cmpArgType).viperExp)
+}
+
+data class NeCmp(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    val cmpArgType = commonSuperType(left.type, right.type)
+    override val viperExp: Exp.NeCmp =
+        Exp.NeCmp(left.withType(cmpArgType).viperExp, right.withType(cmpArgType).viperExp)
+}
+
+data class And(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val viperExp: Exp.And =
+        Exp.And(left.viperExp, right.viperExp)
+}
+
+data class Implies(val left: ExpEmbedding, val right: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val viperExp: Exp.Implies =
+        Exp.Implies(left.viperExp, right.viperExp)
+}
+
+data class Not(val arg: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val viperExp: Exp.Not =
+        Exp.Not(arg.viperExp)
+}
+
+data class Trigger(val exps: List<ExpEmbedding>) {
+    val viperExp: Exp.Trigger =
+        Exp.Trigger(exps.viperExps())
+}
+
+data class Forall(val boundVariable: List<VariableEmbedding>, val triggers: List<Trigger>, val exp: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val viperExp: Exp.Forall =
+        Exp.Forall(
+            boundVariable.map { it.toLocalVarDecl() },
+            triggers.map { it.viperExp },
+            exp.viperExp
+        )
+}
+
+data class Exists(val boundVariable: List<VariableEmbedding>, val triggers: List<Trigger>, val exp: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val viperExp: Exp.Exists =
+        Exp.Exists(
+            boundVariable.map { it.toLocalVarDecl() },
+            triggers.map { it.viperExp },
+            exp.viperExp
+        )
+}
+
+data class IntLit(val value: Int) : ExpEmbedding {
+    override val type: TypeEmbedding = IntTypeEmbedding
+    override val viperExp: Exp.IntLit = Exp.IntLit(value.toScalaBigInt())
+}
+
+data class BoolLit(val value: Boolean) : ExpEmbedding {
+    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val viperExp: Exp.BoolLit = Exp.BoolLit(value)
+}
+
+data object UnitLit : ExpEmbedding {
+    override val type: TypeEmbedding = UnitTypeEmbedding
+    override val viperExp: Exp = UnitDomain.element
+}
+
+data class NullableOf(val nonNullExp: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = NullableTypeEmbedding(nonNullExp.type)
+    override val viperExp = NullableDomain.nullableOfApp(nonNullExp.viperExp, nonNullExp.type.type)
+}
+
+data class ValOfNullable(val exp: ExpEmbedding) : ExpEmbedding {
+    val elemType = (exp.type as NullableTypeEmbedding).elementType
+    override val type: TypeEmbedding = elemType
+    override val viperExp = NullableDomain.valOfApp(exp.viperExp, elemType.type)
+}
+
+// This class represents the Kotlin null literal and not the Viper null literal
+// and is in fact not even mapped to in but instead to a custom Nullable domain value.
+data class NullLit(override val type: NullableTypeEmbedding) : ExpEmbedding {
+    override val viperExp: Exp = NullableDomain.nullVal(type.elementType.type)
+}
+
+data class FieldAccess(val rcv: ExpEmbedding, val field: FieldEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = field.type
+    override val viperExp: Exp.FieldAccess =
+        Exp.FieldAccess(rcv.viperExp, field.field)
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.scala.MangledName
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Field
+
+class FieldEmbedding(val name: MangledName, val type: TypeEmbedding) {
+    val field = Field(name, type.type)
+}

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
@@ -7,8 +7,9 @@ package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.formver.scala.MangledName
 import org.jetbrains.kotlin.formver.scala.silicon.ast.*
+import org.jetbrains.kotlin.formver.scala.silicon.ast.Exp
 
-class VariableEmbedding(val name: MangledName, val type: TypeEmbedding) {
+class VariableEmbedding(val name: MangledName, override val type: TypeEmbedding) : ExpEmbedding {
     fun toLocalVarDecl(
         pos: Position = Position.NoPosition,
         info: Info = Info.NoInfo,
@@ -20,6 +21,8 @@ class VariableEmbedding(val name: MangledName, val type: TypeEmbedding) {
         info: Info = Info.NoInfo,
         trafos: Trafos = Trafos.NoTrafos,
     ): Exp.LocalVar = Exp.LocalVar(name, type.type, pos, info, trafos)
+
+    override val viperExp: Exp.LocalVar = toLocalVar()
 
     fun invariants(): List<Exp> = type.invariants(toLocalVar())
     fun dynamicInvariants(): List<Exp> = type.dynamicInvariants(toLocalVar())

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Domain.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Domain.kt
@@ -61,7 +61,7 @@ class DomainFunc(
         )
 
     operator fun invoke(vararg args: Exp): Exp.DomainFuncApp =
-        Exp.DomainFuncApp(name, args.toList(), typeArgs.associateWith { it }, typ)
+        Exp.DomainFuncApp(this, args.toList(), typeArgs.associateWith { it })
 }
 
 class DomainAxiom(
@@ -117,7 +117,7 @@ abstract class Domain(
             trafos.toViper()
         )
 
-    fun toType(typeParamSubst: Map<Type.TypeVar, Type> = typeVars.associateWith { it }): Type.Domain =
+    fun toType(typeParamSubst: Map<Type.TypeVar, Type> = emptyMap()): Type.Domain =
         Type.Domain(name.mangled, typeVars, typeParamSubst)
 
     fun createDomainFunc(funcName: String, args: List<Declaration.LocalVarDecl>, type: Type, unique: Boolean = false) =
@@ -129,11 +129,11 @@ abstract class Domain(
     fun funcApp(
         func: DomainFunc,
         args: List<Exp>,
-        typeVarMap: Map<Type.TypeVar, Type> = typeVars.associateWith { it },
+        typeVarMap: Map<Type.TypeVar, Type>,
         pos: Position = Position.NoPosition,
         info: Info = Info.NoInfo,
         trafos: Trafos = Trafos.NoTrafos,
-    ): Exp.DomainFuncApp = Exp.DomainFuncApp(func.name, args, typeVarMap, func.typ, pos, info, trafos)
+    ): Exp.DomainFuncApp = Exp.DomainFuncApp(func, args, typeVarMap, pos, info, trafos)
 }
 
 abstract class BuiltinDomain(

--- a/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Exp.kt
+++ b/plugins/formal-verification/src/org/jetbrains/kotlin/formver/scala/silicon/ast/Exp.kt
@@ -329,24 +329,21 @@ sealed interface Exp : IntoViper<viper.silver.ast.Exp> {
      * supplied.
      */
     data class DomainFuncApp(
-        val funcname: DomainFuncName,
+        val function: DomainFunc,
         val args: List<Exp>,
         val typeVarMap: Map<Type.TypeVar, Type>,
-        val typ: Type,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         private val scalaTypeVarMap = typeVarMap.mapKeys { it.key.toViper() }.mapValues { it.value.toViper() }.toScalaMap()
         override fun toViper(): viper.silver.ast.Exp =
-            DomainFuncApp(
-                funcname.mangled,
+            viper.silver.ast.DomainFuncApp.apply(
+                function.toViper(),
                 args.toViper().toScalaSeq(),
                 scalaTypeVarMap,
                 pos.toViper(),
                 info.toViper(),
-                typ.toViper().substitute(scalaTypeVarMap),
-                funcname.domainName.mangled,
                 trafos.toViper()
             )
     }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -1,4 +1,14 @@
-/nullable.kt:(4,22): info: Generated Viper text for use_nullable_twice:
+/nullable.kt:(4,14): info: Generated Viper text for smart_cast:
+method global$pkg_$smart_cast(local$x: dom$Nullable[Int])
+  returns (ret$: Int)
+{
+  if (local$x == (dom$Nullable$null(): dom$Nullable[Int])) {
+    ret$ := 0
+  } else {
+    ret$ := (dom$Nullable$val_of(local$x): Int)}
+}
+
+/nullable.kt:(112,130): info: Generated Viper text for use_nullable_twice:
 method global$pkg_$use_nullable_twice(local$x: dom$Nullable[Int])
   returns (ret$: dom$Nullable[Int])
 {
@@ -9,7 +19,7 @@ method global$pkg_$use_nullable_twice(local$x: dom$Nullable[Int])
   ret$ := local$a
 }
 
-/nullable.kt:(88,111): info: Generated Viper text for pass_nullable_parameter:
+/nullable.kt:(196,219): info: Generated Viper text for pass_nullable_parameter:
 method global$pkg_$use_nullable_twice(local$x: dom$Nullable[Int])
   returns (ret$: dom$Nullable[Int])
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.txt
@@ -1,4 +1,15 @@
 FILE: nullable.kt
+    public final fun smart_cast(x: R|kotlin/Int?|): R|kotlin/Int| {
+        when () {
+            ==(R|<local>/x|, Null(null)) ->  {
+                ^smart_cast Int(0)
+            }
+            else ->  {
+                ^smart_cast R|<local>/x|
+            }
+        }
+
+    }
     public final fun use_nullable_twice(x: R|kotlin/Int?|): R|kotlin/Int?| {
         lval a: R|kotlin/Int?| = R|<local>/x|
         lval b: R|kotlin/Int?| = R|<local>/x|

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.kt
@@ -1,3 +1,11 @@
+fun <!VIPER_TEXT!>smart_cast<!>(x: Int?): Int {
+    if (x == null) {
+        return 0
+    } else {
+        return x
+    }
+}
+
 fun <!VIPER_TEXT!>use_nullable_twice<!>(x: Int?): Int? {
     val a = x
     val b = x

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.diag.txt
@@ -1,0 +1,13 @@
+/subtyping.kt:(4,20): info: Generated Viper text for return_subtyping:
+method global$pkg_$return_subtyping() returns (ret$: dom$Nullable[Int])
+{
+  ret$ := (dom$Nullable$nullable_of(0): dom$Nullable[Int])
+}
+
+/subtyping.kt:(51,71): info: Generated Viper text for assignment_subtyping:
+method global$pkg_$assignment_subtyping() returns (ret$: dom$Unit)
+{
+  var local$x: dom$Nullable[Bool]
+  local$x := (dom$Nullable$nullable_of(false): dom$Nullable[Bool])
+  local$x := (dom$Nullable$nullable_of(true): dom$Nullable[Bool])
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.txt
@@ -1,0 +1,8 @@
+FILE: subtyping.kt
+    public final fun return_subtyping(): R|kotlin/Int?| {
+        ^return_subtyping Int(0)
+    }
+    public final fun assignment_subtyping(): R|kotlin/Unit| {
+        lvar x: R|kotlin/Boolean?| = Boolean(false)
+        R|<local>/x| = Boolean(true)
+    }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.kt
@@ -1,0 +1,8 @@
+fun <!VIPER_TEXT!>return_subtyping<!>(): Int? {
+    return 0
+}
+
+fun <!VIPER_TEXT!>assignment_subtyping<!>() {
+    var x: Boolean? = false
+    x = true
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -106,6 +106,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("subtyping.kt")
+        public void testSubtyping() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.kt");
+        }
+
+        @Test
         @TestMetadata("when.kt")
         public void testWhen() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/when.kt");


### PR DESCRIPTION
Added a new data structure `ExpEmbedding` as adding types to the current Exp class would mix up our stages and this also allows us to model expressions that don't directly exists in Viper (nullable values, unit value, lambdas, etc.)