### PR TITLE
Implement Gradle plugin

### DIFF
--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -2,12 +2,54 @@
 
 ## Running the plugin
 
-To execute the plugin, build the `dist` target and then
+To execute the plugin in another project, make sure you've installed the plugin to your local
+Maven repository (`./gradlew install`) and then use the Gradle plugin in your project.
+
+In `settings.gradle.kts`, configure your Gradle plugin repositories to allow local plugins:
+
+```kotlin
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+```
+
+Then in `build.gradle.kts`, enable the plugin.  Make sure that you also enable the Maven
+local respository here: it's necessary to find the standard library for the plugin.
+
+```kotlin
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.9.10"
+    id("org.jetbrains.kotlin.plugin.formver") version "1.9.255-SNAPSHOT"
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+```
+
+Command-line options can be enabled using the `formver` configuration block:
+
+```kotlin
+formver {
+    setLogLevel("full_viper_dump")
+}
+```
+
+However, keep in mind that the Viper is dump is provided as an info message: this message will not be shown
+unless you run `gradle` with the `--info` flag.
+
+### Running from the command line
+
+To execute the plugin directly, build the `dist` target and then
 specify the plugin `.jar` with `-Xplugin=`:
 
 ```sh
 ./gradlew dist
-dist/kotlinc/bin/kotlinc -language-version 2.0 -Xplugin=dist/kotlinc/lib/formver-compiler-plugin.jar,$HOME/.m2/repository/viper/silicon/1.1-SNAPSHOT/silicon-1.1-SNAPSHOT.jar myfile.kt
+dist/kotlinc/bin/kotlinc -language-version 2.0 -Xplugin=dist/kotlinc/lib/formver-compiler-plugin.jar myfile.kt
 ```
 
 The plugin accepts a number of command line options which can be passed via `-P plugin:org.jetbrains.kotlin.formver:OPTION=SETTING`:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -405,6 +405,7 @@ val gradlePluginProjects = listOf(
     ":kotlin-gradle-plugin-model",
     ":kotlin-gradle-plugin-tcs-android",
     ":kotlin-allopen",
+    ":kotlin-formver",
     ":kotlin-noarg",
     ":kotlin-sam-with-receiver",
     ":kotlin-parcelize-compiler",

--- a/libraries/tools/kotlin-formver/build.gradle.kts
+++ b/libraries/tools/kotlin-formver/build.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.kotlin.pill.PillExtension
+
+plugins {
+    id("gradle-plugin-common-configuration")
+    id("jps-compatible")
+}
+
+pill {
+    variant = PillExtension.Variant.FULL
+}
+
+dependencies {
+    commonApi(platform(project(":kotlin-gradle-plugins-bom")))
+    commonApi(project(":kotlin-gradle-plugin-model"))
+
+    commonCompileOnly(project(":kotlin-compiler-embeddable"))
+    commonCompileOnly(project(":kotlin-formver-compiler-plugin"))
+}
+
+gradlePlugin {
+    plugins {
+        create("kotlinFormVerPlugin") {
+            id = "org.jetbrains.kotlin.plugin.formver"
+            displayName = "Kotlin Formal Verification compiler plugin"
+            description = displayName
+            implementationClass = "org.jetbrains.kotlin.formver.gradle.FormVerGradleSubplugin"
+        }
+    }
+}

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.gradle
+
+open class FormVerExtension {
+    internal var myLogLevel: String? = null
+
+    open fun setLogLevel(logLevel: String) {
+        myLogLevel = logLevel
+    }
+}

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.jetbrains.kotlin.formver.gradle.model.builder.FormVerModelBuilder
+import org.jetbrains.kotlin.gradle.plugin.*
+import javax.inject.Inject
+
+class FormVerGradleSubplugin
+@Inject internal constructor(
+    private val registry: ToolingModelBuilderRegistry,
+) : KotlinCompilerPluginSupportPlugin {
+    companion object {
+        private const val FORMVER_ARTIFACT_NAME = "kotlin-formver-compiler-plugin-embeddable"
+
+        private const val LOG_LEVEL_ARG_NAME = "log_level"
+    }
+
+    override fun apply(target: Project) {
+        target.extensions.create("formver", FormVerExtension::class.java)
+        registry.register(FormVerModelBuilder())
+    }
+
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+
+    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
+        val project = kotlinCompilation.target.project
+
+        val formVerExtension = project.extensions.getByType(FormVerExtension::class.java)
+
+        return project.provider {
+            val options = mutableListOf<SubpluginOption>()
+
+            formVerExtension.myLogLevel?.let {
+                options += SubpluginOption(LOG_LEVEL_ARG_NAME, it)
+            }
+
+            options
+        }
+    }
+
+    override fun getCompilerPluginId(): String = "org.jetbrains.kotlin.formver"
+
+    override fun getPluginArtifact(): SubpluginArtifact =
+        JetBrainsSubpluginArtifact(artifactId = FORMVER_ARTIFACT_NAME)
+}

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.gradle.model.builder
+
+import org.gradle.api.Project
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import org.jetbrains.kotlin.formver.gradle.FormVerExtension
+import org.jetbrains.kotlin.formver.gradle.model.impl.FormVerImpl
+import org.jetbrains.kotlin.gradle.model.FormVer
+
+class FormVerModelBuilder : ToolingModelBuilder {
+    override fun canBuild(modelName: String): Boolean =
+        modelName == FormVer::class.java.name
+
+    override fun buildAll(modelName: String, project: Project): Any {
+        require(canBuild(modelName)) { "buildAll(\"$modelName\") has been called while canBeBuild is false" }
+        val extension = project.extensions.getByType(FormVerExtension::class.java)
+        return FormVerImpl(project.name, extension.myLogLevel)
+    }
+
+}

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.gradle.model.impl
+
+import org.jetbrains.kotlin.gradle.model.FormVer
+import java.io.Serializable
+
+/**
+ * Implementation of the [FormVer] interface.
+ */
+data class FormVerImpl(
+    override val name: String,
+    override val logLevel: String?,
+) : FormVer, Serializable {
+    override val modelVersion = serialVersionUID
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/libraries/tools/kotlin-formver/src/common/resources/META-INF/gradle-plugins/kotlin-formver.properties
+++ b/libraries/tools/kotlin-formver/src/common/resources/META-INF/gradle-plugins/kotlin-formver.properties
@@ -1,0 +1,1 @@
+implementation-class=org.jetbrains.kotlin.formver.gradle.FormVerGradleSubplugin

--- a/libraries/tools/kotlin-formver/src/common/resources/META-INF/services/org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
+++ b/libraries/tools/kotlin-formver/src/common/resources/META-INF/services/org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.formver.gradle.FormVerGradleSubplugin

--- a/libraries/tools/kotlin-gradle-plugin-model/src/common/kotlin/org/jetbrains/kotlin/gradle/model/FormVer.kt
+++ b/libraries/tools/kotlin-gradle-plugin-model/src/common/kotlin/org/jetbrains/kotlin/gradle/model/FormVer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.gradle.model
+
+interface FormVer {
+    /**
+     * Return a number representing the version of this API.
+     * Always increasing if changed.
+     *
+     * @return the version of this model.
+     */
+    val modelVersion: Long
+
+    /**
+     * Returns the module (Gradle project) name.
+     *
+     * @return the module name.
+     */
+    val name: String
+
+    /**
+     * Return the desired Viper log level.
+     *
+     * @return the Viper log level
+     */
+    val logLevel: String?
+}

--- a/libraries/tools/kotlin-gradle-plugins-bom/build.gradle.kts
+++ b/libraries/tools/kotlin-gradle-plugins-bom/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
         api(project(":kotlin-gradle-plugin"))
         api(project(":atomicfu"))
         api(project(":kotlin-allopen"))
+        api(project(":kotlin-formver"))
         api(project(":kotlin-lombok"))
         api(project(":kotlin-noarg"))
         api(project(":kotlin-sam-with-receiver"))

--- a/plugins/formal-verification/build.gradle.kts
+++ b/plugins/formal-verification/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     embedded(project(":kotlin-formver-compiler-plugin.common")) { isTransitive = false }
     embedded(project(":kotlin-formver-compiler-plugin.core")) { isTransitive = false }
     embedded(project(":kotlin-formver-compiler-plugin.plugin")) { isTransitive = false }
-    embedded(project(":kotlin-formver-compiler-plugin.viper")) { isTransitive = false }
+    embedded(project(":kotlin-formver-compiler-plugin.viper")) { isTransitive = true }
 
     testApiJUnit5()
     testApi(projectTests(":compiler:tests-common-new"))

--- a/plugins/formal-verification/formver.embeddable/build.gradle.kts
+++ b/plugins/formal-verification/formver.embeddable/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+}
+
+dependencies {
+    embedded(project(":kotlin-formver-compiler-plugin")) { isTransitive = false }
+}
+
+publish {
+    artifactId = artifactId.replace(".", "-")
+}
+
+runtimeJar(rewriteDefaultJarDepsToShadedCompiler())
+sourcesJarWithSourcesFromEmbedded(
+    project(":kotlin-formver-compiler-plugin").tasks.named<Jar>("sourcesJar")
+)
+javadocJarWithJavadocFromEmbedded(
+    project(":kotlin-formver-compiler-plugin").tasks.named<Jar>("javadocJar")
+)

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/jps.gradle.kts
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/jps.gradle.kts
@@ -24,6 +24,7 @@ fun updateCompilerXml() {
         "libraries/tools/gradle",
         "libraries/tools/jdk-api-validator",
         "libraries/tools/kotlin-allopen",
+        "libraries/tools/kotlin-formver",
         "libraries/tools/kotlin-annotation-processing",
         "libraries/tools/kotlin-assignment",
         "libraries/tools/kotlin-bom",

--- a/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/tasks.kt
+++ b/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/tasks.kt
@@ -32,6 +32,7 @@ import java.nio.file.Path
 val kotlinGradlePluginAndItsRequired = arrayOf(
     ":kotlin-assignment",
     ":kotlin-allopen",
+    ":kotlin-formver",
     ":kotlin-noarg",
     ":kotlin-sam-with-receiver",
     ":kotlin-lombok",
@@ -68,6 +69,7 @@ val kotlinGradlePluginAndItsRequired = arrayOf(
     ":examples:annotation-processor-example",
     ":kotlin-assignment-compiler-plugin.embeddable",
     ":kotlin-allopen-compiler-plugin.embeddable",
+    ":kotlin-formver-compiler-plugin.embeddable",
     ":kotlin-noarg-compiler-plugin.embeddable",
     ":kotlin-sam-with-receiver-compiler-plugin.embeddable",
     ":kotlin-lombok-compiler-plugin.embeddable",

--- a/settings.gradle
+++ b/settings.gradle
@@ -138,6 +138,7 @@ include ":kotlin-allopen-compiler-plugin",
         ":kotlin-allopen-compiler-plugin.cli"
 
 include ":kotlin-formver-compiler-plugin",
+        ":kotlin-formver-compiler-plugin.embeddable",
         ":kotlin-formver-compiler-plugin.cli",
         ":kotlin-formver-compiler-plugin.common",
         ":kotlin-formver-compiler-plugin.core",
@@ -226,6 +227,7 @@ include ":kotlin-imports-dumper-compiler-plugin",
         ":kotlin-tooling-metadata",
         ":kotlin-tooling-core",
         ":kotlin-allopen",
+        ":kotlin-formver",
         ":kotlin-noarg",
         ":kotlin-sam-with-receiver",
         ":kotlin-assignment",
@@ -712,6 +714,7 @@ project(':kotlin-allopen-compiler-plugin.k2').projectDir = "$rootDir/plugins/all
 project(':kotlin-allopen-compiler-plugin.cli').projectDir = "$rootDir/plugins/allopen/allopen.cli" as File
 
 project(':kotlin-formver-compiler-plugin').projectDir = "$rootDir/plugins/formal-verification" as File
+project(':kotlin-formver-compiler-plugin.embeddable').projectDir = "$rootDir/plugins/formal-verification/formver.embeddable" as File
 project(':kotlin-formver-compiler-plugin.cli').projectDir = "$rootDir/plugins/formal-verification/formver.cli" as File
 project(':kotlin-formver-compiler-plugin.common').projectDir = "$rootDir/plugins/formal-verification/formver.common" as File
 project(':kotlin-formver-compiler-plugin.core').projectDir = "$rootDir/plugins/formal-verification/formver.core" as File
@@ -776,6 +779,7 @@ project(":gradle:regression-benchmarks").projectDir = "$rootDir/libraries/tools/
 project(':kotlin-tooling-metadata').projectDir = "$rootDir/libraries/tools/kotlin-tooling-metadata" as File
 project(':kotlin-tooling-core').projectDir = "$rootDir/libraries/tools/kotlin-tooling-core" as File
 project(':kotlin-allopen').projectDir = "$rootDir/libraries/tools/kotlin-allopen" as File
+project(':kotlin-formver').projectDir = "$rootDir/libraries/tools/kotlin-formver" as File
 project(':kotlin-noarg').projectDir = "$rootDir/libraries/tools/kotlin-noarg" as File
 project(':kotlin-sam-with-receiver').projectDir = "$rootDir/libraries/tools/kotlin-sam-with-receiver" as File
 project(':kotlin-assignment').projectDir = "$rootDir/libraries/tools/kotlin-assignment" as File


### PR DESCRIPTION
Additionally, this ensures that our Viper dependencies are packaged with the plugin, allowing it to be loaded directly.