### PR TITLE
Add naive loop invariants

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -88,7 +88,6 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         val receiver = symbol.dispatchReceiverType?.let { VariableEmbedding(ThisReceiverName, embedType(it)) }
         return MethodSignatureEmbedding(
             symbol,
-            symbol.callableId.embedName(),
             receiver,
             params,
             embedType(retType)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -87,6 +87,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         }
         val receiver = symbol.dispatchReceiverType?.let { VariableEmbedding(ThisReceiverName, embedType(it)) }
         return MethodSignatureEmbedding(
+            symbol,
             symbol.callableId.embedName(),
             receiver,
             params,
@@ -108,17 +109,13 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                     VariableEmbedding(AnonymousName(++nextAnonVarNumber), type)
             }
 
-            val seqn = body?.let {
+            val bodySeqn = body?.let {
                 val ctx = StmtConverter(methodCtx, SeqnBuilder())
                 ctx.convert(body)
                 ctx.block
             }
 
-            val postconditions = symbol.resolvedContractDescription?.effects?.map {
-                it.effect.accept(ContractDescriptionConversionVisitor, methodCtx)
-            } ?: emptyList()
-
-            signature.toMethod(listOf(), postconditions, seqn)
+            signature.toMethod(bodySeqn)
         }
         return signature
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -242,7 +242,7 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext>() {
         bodyCtx.convert(whileLoop.block)
         bodyCtx.convertAndCapture(whileLoop.condition)
 
-        data.addStatement(Stmt.While(condCtx.resultVar.toLocalVar(), invariants = data.signature.postConditions, bodyCtx.block))
+        data.addStatement(Stmt.While(condCtx.resultVar.toLocalVar(), invariants = data.signature.postconditions, bodyCtx.block))
         return UnitDomain.element
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -242,7 +242,7 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext>() {
         bodyCtx.convert(whileLoop.block)
         bodyCtx.convertAndCapture(whileLoop.condition)
 
-        data.addStatement(Stmt.While(condCtx.resultVar.toLocalVar(), invariants = emptyList(), bodyCtx.block))
+        data.addStatement(Stmt.While(condCtx.resultVar.toLocalVar(), invariants = data.signature.postConditions, bodyCtx.block))
         return UnitDomain.element
     }
 

--- a/plugins/formal-verification/testData/diagnostics/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/calls_in_place.fir.diag.txt
@@ -145,3 +145,55 @@ method pkg_$global$incorrect_at_least_once(local$f: Ref) returns (ret: Int)
 /calls_in_place.kt:(1144,1167): warning: Function incorrect_at_least_once may not satisfy its contract.
 
 /calls_in_place.kt:(1197,1252): warning: Wrong invocation kind 'AT_LEAST_ONCE' for 'f: (Int) -> Int' specified, the actual invocation kind is 'UNKNOWN'.
+
+/calls_in_place.kt:(1326,1335): info: Generated Viper text for loopWhile:
+method pkg_$global$loopWhile(local$lambda: Ref) returns (ret: dom$Unit)
+  requires acc(local$lambda.special$function_object_call_counter, write)
+  ensures acc(local$lambda.special$function_object_call_counter, write)
+  ensures old(local$lambda.special$function_object_call_counter) <=
+    local$lambda.special$function_object_call_counter
+  ensures local$lambda.special$function_object_call_counter >
+    old(local$lambda.special$function_object_call_counter)
+{
+  var anonymous$1: Bool
+  var anonymous$2: Bool
+  special$invoke_function_object(local$lambda)
+  anonymous$1 := anonymous$2
+  while (anonymous$1)
+    invariant acc(local$lambda.special$function_object_call_counter, write)
+    invariant old(local$lambda.special$function_object_call_counter) <=
+      local$lambda.special$function_object_call_counter
+    invariant local$lambda.special$function_object_call_counter >
+      old(local$lambda.special$function_object_call_counter)
+  {
+    var anonymous$3: Bool
+    special$invoke_function_object(local$lambda)
+    anonymous$1 := anonymous$3
+  }
+}
+
+/calls_in_place.kt:(1516,1525): info: Generated Viper text for loopUntil:
+method pkg_$global$loopUntil(local$lambda: Ref) returns (ret: dom$Unit)
+  requires acc(local$lambda.special$function_object_call_counter, write)
+  ensures acc(local$lambda.special$function_object_call_counter, write)
+  ensures old(local$lambda.special$function_object_call_counter) <=
+    local$lambda.special$function_object_call_counter
+  ensures local$lambda.special$function_object_call_counter >
+    old(local$lambda.special$function_object_call_counter)
+{
+  var anonymous$1: Bool
+  var anonymous$2: Bool
+  special$invoke_function_object(local$lambda)
+  anonymous$1 := !anonymous$2
+  while (anonymous$1)
+    invariant acc(local$lambda.special$function_object_call_counter, write)
+    invariant old(local$lambda.special$function_object_call_counter) <=
+      local$lambda.special$function_object_call_counter
+    invariant local$lambda.special$function_object_call_counter >
+      old(local$lambda.special$function_object_call_counter)
+  {
+    var anonymous$3: Bool
+    special$invoke_function_object(local$lambda)
+    anonymous$1 := !anonymous$3
+  }
+}

--- a/plugins/formal-verification/testData/diagnostics/calls_in_place.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/calls_in_place.fir.txt
@@ -104,3 +104,37 @@ FILE: calls_in_place.kt
 
         ^incorrect_at_least_once R|/unknown|(R|<local>/f|)
     }
+    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final inline fun loopWhile(lambda: R|() -> kotlin/Boolean|): R|kotlin/Unit|
+        [R|Contract description]
+         <
+            CallsInPlace(lambda, AT_LEAST_ONCE)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Boolean|>(R|<local>/lambda|, R|kotlin/contracts/InvocationKind.AT_LEAST_ONCE|)
+            }
+            )
+        }
+
+        while(R|<local>/lambda|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Boolean|>|()) {
+        }
+
+    }
+    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final inline fun loopUntil(lambda: R|() -> kotlin/Boolean|): R|kotlin/Unit|
+        [R|Contract description]
+         <
+            CallsInPlace(lambda, AT_LEAST_ONCE)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Boolean|>(R|<local>/lambda|, R|kotlin/contracts/InvocationKind.AT_LEAST_ONCE|)
+            }
+            )
+        }
+
+        while(R|<local>/lambda|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Boolean|>|().R|kotlin/Boolean.not|()) {
+        }
+
+    }

--- a/plugins/formal-verification/testData/diagnostics/calls_in_place.kt
+++ b/plugins/formal-verification/testData/diagnostics/calls_in_place.kt
@@ -57,3 +57,21 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>i
     }<!>
     return unknown(f)
 }
+
+@OptIn(ExperimentalContracts::class)
+inline fun <!VIPER_TEXT!>loopWhile<!>(lambda: () -> Boolean)
+{
+    contract {
+        callsInPlace(lambda, AT_LEAST_ONCE)
+    }
+    while (lambda()) { /* no body */ }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <!VIPER_TEXT!>loopUntil<!>(lambda: () -> Boolean)
+{
+    contract {
+        callsInPlace(lambda, AT_LEAST_ONCE)
+    }
+    while (!lambda()) { /* no body */ }
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
@@ -1,0 +1,106 @@
+/loop_invariants.kt:(4,19): info: Generated Viper text for returns_boolean:
+method pkg_$global$returns_boolean() returns (ret: Bool)
+{
+  ret := false
+}
+
+/loop_invariants.kt:(57,81): info: Generated Viper text for dynamic_lambda_invariant:
+method pkg_$global$returns_boolean() returns (ret: Bool)
+
+
+method pkg_$global$dynamic_lambda_invariant(local$f: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+{
+  var anonymous$1: Bool
+  var anonymous$2: Bool
+  anonymous$2 := pkg_$global$returns_boolean()
+  anonymous$1 := anonymous$2
+  while (anonymous$1)
+    invariant acc(local$f.special$function_object_call_counter, write)
+    invariant old(local$f.special$function_object_call_counter) <=
+      local$f.special$function_object_call_counter
+  {
+    var anonymous$3: Int
+    var anonymous$4: Bool
+    special$invoke_function_object(local$f)
+    anonymous$4 := pkg_$global$returns_boolean()
+    anonymous$1 := anonymous$4
+  }
+}
+
+/loop_invariants.kt:(155,174): info: Generated Viper text for function_assignment:
+method pkg_$global$returns_boolean() returns (ret: Bool)
+
+
+method pkg_$global$function_assignment(local$f: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+{
+  var local$g: Ref
+  var anonymous$1: Bool
+  var anonymous$2: Bool
+  local$g := local$f
+  anonymous$2 := pkg_$global$returns_boolean()
+  anonymous$1 := anonymous$2
+  while (anonymous$1)
+    invariant acc(local$f.special$function_object_call_counter, write)
+    invariant old(local$f.special$function_object_call_counter) <=
+      local$f.special$function_object_call_counter
+  {
+    var anonymous$3: Int
+    var anonymous$4: Bool
+    special$invoke_function_object(local$g)
+    anonymous$4 := pkg_$global$returns_boolean()
+    anonymous$1 := anonymous$4
+  }
+}
+
+/loop_invariants.kt:(262,293): info: Generated Viper text for conditional_function_assignment:
+method pkg_$global$returns_boolean() returns (ret: Bool)
+
+
+method pkg_$global$conditional_function_assignment(local$b: Bool, local$f: Ref,
+  local$h: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  requires acc(local$h.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$h.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures old(local$h.special$function_object_call_counter) <=
+    local$h.special$function_object_call_counter
+{
+  var local$g: Ref
+  var anonymous$1: Ref
+  var anonymous$2: Bool
+  var anonymous$3: Bool
+  if (local$b) {
+    anonymous$1 := local$f
+  } else {
+    anonymous$1 := local$h}
+  local$g := anonymous$1
+  anonymous$3 := pkg_$global$returns_boolean()
+  anonymous$2 := anonymous$3
+  while (anonymous$2)
+    invariant acc(local$f.special$function_object_call_counter, write)
+    invariant acc(local$h.special$function_object_call_counter, write)
+    invariant old(local$f.special$function_object_call_counter) <=
+      local$f.special$function_object_call_counter
+    invariant old(local$h.special$function_object_call_counter) <=
+      local$h.special$function_object_call_counter
+  {
+    var anonymous$4: Int
+    var anonymous$5: Bool
+    special$invoke_function_object(local$g)
+    anonymous$5 := pkg_$global$returns_boolean()
+    anonymous$2 := anonymous$5
+  }
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.txt
@@ -1,0 +1,32 @@
+FILE: loop_invariants.kt
+    public final fun returns_boolean(): R|kotlin/Boolean| {
+        ^returns_boolean Boolean(false)
+    }
+    public final fun dynamic_lambda_invariant(f: R|() -> kotlin/Int|): R|kotlin/Unit| {
+        while(R|/returns_boolean|()) {
+            R|<local>/f|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Int|>|()
+        }
+
+    }
+    public final fun function_assignment(f: R|() -> kotlin/Int|): R|kotlin/Unit| {
+        lval g: R|() -> kotlin/Int| = R|<local>/f|
+        while(R|/returns_boolean|()) {
+            R|<local>/g|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Int|>|()
+        }
+
+    }
+    public final fun conditional_function_assignment(b: R|kotlin/Boolean|, f: R|() -> kotlin/Int|, h: R|() -> kotlin/Int|): R|kotlin/Unit| {
+        lval g: R|() -> kotlin/Int| = when () {
+            R|<local>/b| ->  {
+                R|<local>/f|
+            }
+            else ->  {
+                R|<local>/h|
+            }
+        }
+
+        while(R|/returns_boolean|()) {
+            R|<local>/g|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Int|>|()
+        }
+
+    }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.kt
@@ -1,0 +1,23 @@
+fun <!VIPER_TEXT!>returns_boolean<!>(): Boolean {
+    return false
+}
+
+fun <!VIPER_TEXT!>dynamic_lambda_invariant<!>(f: () -> Int) {
+    while (returns_boolean()) {
+        f()
+    }
+}
+
+fun <!VIPER_TEXT!>function_assignment<!>(f: () -> Int) {
+    val g = f
+    while (returns_boolean()) {
+        g()
+    }
+}
+
+fun <!VIPER_TEXT!>conditional_function_assignment<!>(b: Boolean, f: () -> Int, h: () -> Int) {
+    val g = if (b) f else h
+    while (returns_boolean()) {
+        g()
+    }
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -112,6 +112,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("loop_invariants.kt")
+        public void testLoop_invariants() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.kt");
+        }
+
+        @Test
         @TestMetadata("member_functions.kt")
         public void testMember_functions() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.kt");


### PR DESCRIPTION
This commit adds naive loop invariants which allows to reason about loops. However, this approach breaks down with more complicated method post conditions and especially with multiple loops which need different loop invariants.
Still this approach allows to verify simple practical examples like the ones found [here](https://github.com/AvailLang/Avail/blob/a144c7fd31801065facee30f22679d6da9c97c02/avail/src/main/kotlin/avail/utility/Loops.kt).

We can make incremental improvements to these loop invariants as we collect examples which fail with the current technique.