### PR TITLE
Add initial support for classes getter and setters

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -26,7 +26,9 @@ interface StmtConversionContext<out RTC : ResultTrackingContext> : MethodConvers
     fun convertAndStore(exp: FirExpression): Exp.LocalVar
 
     fun newBlock(): StmtConversionContext<RTC>
+
     fun withoutResult(): StmtConversionContext<NoopResultTracker>
+
     fun withResult(type: TypeEmbedding): StmtConversionContext<VarResultTrackingContext>
 
     fun withInlineContext(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -18,17 +18,14 @@ interface StmtConversionContext<out RTC : ResultTrackingContext> : MethodConvers
     val resultCtx: RTC
 
     fun convert(stmt: FirStatement): Exp
+    fun convertAndStore(exp: FirExpression): Exp.LocalVar
 
     fun convertAndCapture(exp: FirExpression) {
         resultCtx.capture(convert(exp), embedType(exp))
     }
 
-    fun convertAndStore(exp: FirExpression): Exp.LocalVar
-
     fun newBlock(): StmtConversionContext<RTC>
-
     fun withoutResult(): StmtConversionContext<NoopResultTracker>
-
     fun withResult(type: TypeEmbedding): StmtConversionContext<VarResultTrackingContext>
 
     fun withInlineContext(

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -3,11 +3,6 @@ field pkg$$class_Foo$member_a: Int
 
 field pkg$$class_Foo$member_b: Int
 
-method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
 method pkg$$global$createFoo() returns (ret: dom$Unit)
 {
   var local$f: Ref
@@ -29,16 +24,13 @@ method pkg$$global$createFoo() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
 /classes_getters.kt:(280,290): info: Generated Viper text for testGetter:
 field pkg$$class_IntWrapper$member_n: Int
-
-method pkg$$class_IntWrapper$member_IntWrapper(local$n: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
-
-
-method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
-
 
 method pkg$$global$testGetter() returns (ret: dom$Unit)
 {
@@ -53,21 +45,20 @@ method pkg$$global$testGetter() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_IntWrapper$member_IntWrapper(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
+
+
+method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+
+
 /classes_getters.kt:(363,380): info: Generated Viper text for testCascadeGetter:
 field pkg$$class_Foo$member_a: Int
 
 field pkg$$class_Foo$member_b: Int
 
 field pkg$$class_Bar$member_f: Ref
-
-method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
-method pkg$$class_Bar$member_Bar(local$f: Ref) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
 
 method pkg$$global$testCascadeGetter() returns (ret: dom$Unit)
 {
@@ -104,23 +95,19 @@ method pkg$$global$testCascadeGetter() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
+method pkg$$class_Bar$member_Bar(local$f: Ref) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+
+
 /classes_getters.kt:(486,510): info: Generated Viper text for testCascadeCustomGetters:
 field pkg$$class_IntWrapper$member_n: Int
 
 field pkg$$class_IntWrapperContainer$member_i: Ref
-
-method pkg$$class_IntWrapperContainer$member_IntWrapperContainer(local$i: Ref)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapperContainer())
-
-
-method pkg$$class_IntWrapper$member_IntWrapper(local$n: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
-
-
-method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
-
 
 method pkg$$global$testCascadeCustomGetters() returns (ret: dom$Unit)
 {
@@ -141,3 +128,16 @@ method pkg$$global$testCascadeCustomGetters() returns (ret: dom$Unit)
   local$succ := anonymous$4
   label label$ret
 }
+
+method pkg$$class_IntWrapperContainer$member_IntWrapperContainer(local$i: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapperContainer())
+
+
+method pkg$$class_IntWrapper$member_IntWrapper(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
+
+
+method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -1,0 +1,143 @@
+/classes_getters.kt:(195,204): info: Generated Viper text for createFoo:
+field pkg$$class_Foo$member_a: Int
+
+field pkg$$class_Foo$member_b: Int
+
+method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
+method pkg$$global$createFoo() returns (ret: dom$Unit)
+{
+  var local$f: Ref
+  var anonymous$1: Ref
+  var local$fa: Int
+  var anonymous$2: Int
+  var local$fb: Int
+  var anonymous$3: Int
+  anonymous$1 := pkg$$class_Foo$member_Foo(10, 20)
+  local$f := anonymous$1
+  inhale acc(local$f.pkg$$class_Foo$member_a, write)
+  anonymous$2 := local$f.pkg$$class_Foo$member_a
+  exhale acc(local$f.pkg$$class_Foo$member_a, write)
+  local$fa := anonymous$2
+  inhale acc(local$f.pkg$$class_Foo$member_b, write)
+  anonymous$3 := local$f.pkg$$class_Foo$member_b
+  exhale acc(local$f.pkg$$class_Foo$member_b, write)
+  local$fb := anonymous$3
+  label label$ret
+}
+
+/classes_getters.kt:(280,290): info: Generated Viper text for testGetter:
+field pkg$$class_IntWrapper$member_n: Int
+
+method pkg$$class_IntWrapper$member_IntWrapper(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
+
+
+method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+
+
+method pkg$$global$testGetter() returns (ret: dom$Unit)
+{
+  var local$wrapper: Ref
+  var anonymous$1: Ref
+  var local$succ: Int
+  var anonymous$2: Int
+  anonymous$1 := pkg$$class_IntWrapper$member_IntWrapper(42)
+  local$wrapper := anonymous$1
+  anonymous$2 := pkg$$class_IntWrapper$getter_succ(local$wrapper)
+  local$succ := anonymous$2
+  label label$ret
+}
+
+/classes_getters.kt:(363,380): info: Generated Viper text for testCascadeGetter:
+field pkg$$class_Foo$member_a: Int
+
+field pkg$$class_Foo$member_b: Int
+
+field pkg$$class_Bar$member_f: Ref
+
+method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
+method pkg$$class_Bar$member_Bar(local$f: Ref) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+
+
+method pkg$$global$testCascadeGetter() returns (ret: dom$Unit)
+{
+  var local$foo: Ref
+  var anonymous$1: Ref
+  var local$bar: Ref
+  var anonymous$2: Ref
+  var local$bfa: Int
+  var anonymous$3: Ref
+  var anonymous$4: Int
+  var local$bfb: Int
+  var anonymous$5: Ref
+  var anonymous$6: Int
+  anonymous$1 := pkg$$class_Foo$member_Foo(10, 20)
+  local$foo := anonymous$1
+  anonymous$2 := pkg$$class_Bar$member_Bar(local$foo)
+  local$bar := anonymous$2
+  inhale acc(local$bar.pkg$$class_Bar$member_f, write)
+  anonymous$3 := local$bar.pkg$$class_Bar$member_f
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$pkg$$class_Foo())
+  exhale acc(local$bar.pkg$$class_Bar$member_f, write)
+  inhale acc(anonymous$3.pkg$$class_Foo$member_a, write)
+  anonymous$4 := anonymous$3.pkg$$class_Foo$member_a
+  exhale acc(anonymous$3.pkg$$class_Foo$member_a, write)
+  local$bfa := anonymous$4
+  inhale acc(local$bar.pkg$$class_Bar$member_f, write)
+  anonymous$5 := local$bar.pkg$$class_Bar$member_f
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$5): dom$Type), dom$Type$pkg$$class_Foo())
+  exhale acc(local$bar.pkg$$class_Bar$member_f, write)
+  inhale acc(anonymous$5.pkg$$class_Foo$member_b, write)
+  anonymous$6 := anonymous$5.pkg$$class_Foo$member_b
+  exhale acc(anonymous$5.pkg$$class_Foo$member_b, write)
+  local$bfb := anonymous$6
+  label label$ret
+}
+
+/classes_getters.kt:(486,510): info: Generated Viper text for testCascadeCustomGetters:
+field pkg$$class_IntWrapper$member_n: Int
+
+field pkg$$class_IntWrapperContainer$member_i: Ref
+
+method pkg$$class_IntWrapperContainer$member_IntWrapperContainer(local$i: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapperContainer())
+
+
+method pkg$$class_IntWrapper$member_IntWrapper(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
+
+
+method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+
+
+method pkg$$global$testCascadeCustomGetters() returns (ret: dom$Unit)
+{
+  var local$wrapper: Ref
+  var anonymous$1: Ref
+  var anonymous$2: Ref
+  var local$succ: Int
+  var anonymous$3: Ref
+  var anonymous$4: Int
+  anonymous$2 := pkg$$class_IntWrapper$member_IntWrapper(42)
+  anonymous$1 := pkg$$class_IntWrapperContainer$member_IntWrapperContainer(anonymous$2)
+  local$wrapper := anonymous$1
+  inhale acc(local$wrapper.pkg$$class_IntWrapperContainer$member_i, write)
+  anonymous$3 := local$wrapper.pkg$$class_IntWrapperContainer$member_i
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$pkg$$class_IntWrapper())
+  exhale acc(local$wrapper.pkg$$class_IntWrapperContainer$member_i, write)
+  anonymous$4 := pkg$$class_IntWrapper$getter_succ(anonymous$3)
+  local$succ := anonymous$4
+  label label$ret
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.txt
@@ -1,0 +1,64 @@
+FILE: classes_getters.kt
+    public final class Foo : R|kotlin/Any| {
+        public constructor(a: R|kotlin/Int|, b: R|kotlin/Int|): R|Foo| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val a: R|kotlin/Int| = R|<local>/a|
+            public get(): R|kotlin/Int|
+
+        public final val b: R|kotlin/Int| = R|<local>/b|
+            public get(): R|kotlin/Int|
+
+    }
+    public final class Bar : R|kotlin/Any| {
+        public constructor(f: R|Foo|): R|Bar| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val f: R|Foo| = R|<local>/f|
+            public get(): R|Foo|
+
+    }
+    public final class IntWrapper : R|kotlin/Any| {
+        public constructor(n: R|kotlin/Int|): R|IntWrapper| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val n: R|kotlin/Int| = R|<local>/n|
+            public get(): R|kotlin/Int|
+
+        public final val succ: R|kotlin/Int|
+            public get(): R|kotlin/Int| {
+                ^ this@R|/IntWrapper|.R|/IntWrapper.n|.R|kotlin/Int.plus|(Int(1))
+            }
+
+    }
+    public final class IntWrapperContainer : R|kotlin/Any| {
+        public constructor(i: R|IntWrapper|): R|IntWrapperContainer| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val i: R|IntWrapper| = R|<local>/i|
+            public get(): R|IntWrapper|
+
+    }
+    public final fun createFoo(): R|kotlin/Unit| {
+        lval f: R|Foo| = R|/Foo.Foo|(Int(10), Int(20))
+        lval fa: R|kotlin/Int| = R|<local>/f|.R|/Foo.a|
+        lval fb: R|kotlin/Int| = R|<local>/f|.R|/Foo.b|
+    }
+    public final fun testGetter(): R|kotlin/Unit| {
+        lval wrapper: R|IntWrapper| = R|/IntWrapper.IntWrapper|(Int(42))
+        lval succ: R|kotlin/Int| = R|<local>/wrapper|.R|/IntWrapper.succ|
+    }
+    public final fun testCascadeGetter(): R|kotlin/Unit| {
+        lval foo: R|Foo| = R|/Foo.Foo|(Int(10), Int(20))
+        lval bar: R|Bar| = R|/Bar.Bar|(R|<local>/foo|)
+        lval bfa: R|kotlin/Int| = R|<local>/bar|.R|/Bar.f|.R|/Foo.a|
+        lval bfb: R|kotlin/Int| = R|<local>/bar|.R|/Bar.f|.R|/Foo.b|
+    }
+    public final fun testCascadeCustomGetters(): R|kotlin/Unit| {
+        lval wrapper: R|IntWrapperContainer| = R|/IntWrapperContainer.IntWrapperContainer|(R|/IntWrapper.IntWrapper|(Int(42)))
+        lval succ: R|kotlin/Int| = R|<local>/wrapper|.R|/IntWrapperContainer.i|.R|/IntWrapper.succ|
+    }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.kt
@@ -1,0 +1,36 @@
+class Foo(val a: Int, val b: Int)
+
+class Bar(val f: Foo)
+
+class IntWrapper(val n: Int) {
+    val succ: Int get() {
+        return n + 1
+    }
+}
+
+class IntWrapperContainer(val i: IntWrapper)
+
+fun <!VIPER_TEXT!>createFoo<!>() {
+    val f: Foo = Foo(10, 20)
+    val fa = f.a
+    val fb = f.b
+}
+
+
+fun <!VIPER_TEXT!>testGetter<!>() {
+    val wrapper = IntWrapper(42)
+    val succ = wrapper.succ
+}
+
+fun <!VIPER_TEXT!>testCascadeGetter<!>() {
+    val foo = Foo(10, 20)
+    val bar = Bar(foo)
+
+    val bfa = bar.f.a
+    val bfb = bar.f.b
+}
+
+fun <!VIPER_TEXT!>testCascadeCustomGetters<!>() {
+    val wrapper = IntWrapperContainer(IntWrapper(42))
+    val succ = wrapper.i.succ
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -3,14 +3,6 @@ field pkg$$class_AlwaysPlusOne$member_b: Int
 
 field pkg$$class_AlwaysPlusOne$member_num: Int
 
-method pkg$$class_AlwaysPlusOne$member_AlwaysPlusOne() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_AlwaysPlusOne())
-
-
-method pkg$$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
-  returns (ret: dom$Unit)
-
-
 method pkg$$global$testCustomSetter() returns (ret: dom$Unit)
 {
   var local$f: Ref
@@ -25,12 +17,16 @@ method pkg$$global$testCustomSetter() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_AlwaysPlusOne$member_AlwaysPlusOne() returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_AlwaysPlusOne())
+
+
+method pkg$$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
+
 /classes_setters.kt:(434,444): info: Generated Viper text for testSetter:
 field pkg$$class_Person$member_age: Int
-
-method pkg$$class_Person$member_Person(local$age: Int) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Person())
-
 
 method pkg$$global$testSetter() returns (ret: dom$Unit)
 {
@@ -48,18 +44,14 @@ method pkg$$global$testSetter() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_Person$member_Person(local$age: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Person())
+
+
 /classes_setters.kt:(516,533): info: Generated Viper text for testSetterCascade:
 field pkg$$class_Bar$member_a: Int
 
 field pkg$$class_Foo$member_b: Ref
-
-method pkg$$class_Foo$member_Foo(local$b: Ref) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
-method pkg$$class_Bar$member_Bar(local$a: Int) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
 
 method pkg$$global$testSetterCascade() returns (ret: dom$Unit)
 {
@@ -80,16 +72,16 @@ method pkg$$global$testSetterCascade() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_Foo$member_Foo(local$b: Ref) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
+method pkg$$class_Bar$member_Bar(local$a: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+
+
 /classes_setters.kt:(585,609): info: Generated Viper text for testSetterNoBackingField:
 field pkg$$class_Baz$member__a: Int
-
-method pkg$$class_Baz$member_Baz() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Baz())
-
-
-method pkg$$class_Baz$setter_a(this: Ref, local$value: Int)
-  returns (ret: dom$Unit)
-
 
 method pkg$$global$testSetterNoBackingField() returns (ret: dom$Unit)
 {
@@ -101,6 +93,14 @@ method pkg$$global$testSetterNoBackingField() returns (ret: dom$Unit)
   anonymous$2 := pkg$$class_Baz$setter_a(local$baz, 42)
   label label$ret
 }
+
+method pkg$$class_Baz$member_Baz() returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Baz())
+
+
+method pkg$$class_Baz$setter_a(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
 
 /classes_setters.kt:(694,704): info: Generated Viper text for mockInline:
 field pkg$$class_Bar$member_a: Int
@@ -117,10 +117,6 @@ method pkg$$global$mockInline(local$b: Ref) returns (ret: dom$Unit)
 /classes_setters.kt:(735,751): info: Generated Viper text for testSetterLambda:
 field pkg$$class_Bar$member_a: Int
 
-method pkg$$class_Bar$member_Bar(local$a: Int) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
-
 method pkg$$global$testSetterLambda() returns (ret: dom$Unit)
 {
   var anonymous$1: dom$Unit
@@ -134,3 +130,7 @@ method pkg$$global$testSetterLambda() returns (ret: dom$Unit)
   }
   label label$ret
 }
+
+method pkg$$class_Bar$member_Bar(local$a: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -1,0 +1,136 @@
+/classes_setters.kt:(352,368): info: Generated Viper text for testCustomSetter:
+field pkg$$class_AlwaysPlusOne$member_b: Int
+
+field pkg$$class_AlwaysPlusOne$member_num: Int
+
+method pkg$$class_AlwaysPlusOne$member_AlwaysPlusOne() returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_AlwaysPlusOne())
+
+
+method pkg$$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
+
+method pkg$$global$testCustomSetter() returns (ret: dom$Unit)
+{
+  var local$f: Ref
+  var anonymous$1: Ref
+  var anonymous$2: dom$Unit
+  anonymous$1 := pkg$$class_AlwaysPlusOne$member_AlwaysPlusOne()
+  local$f := anonymous$1
+  inhale acc(local$f.pkg$$class_AlwaysPlusOne$member_b, write)
+  local$f.pkg$$class_AlwaysPlusOne$member_b := 1
+  exhale acc(local$f.pkg$$class_AlwaysPlusOne$member_b, write)
+  anonymous$2 := pkg$$class_AlwaysPlusOne$setter_num(local$f, 1)
+  label label$ret
+}
+
+/classes_setters.kt:(434,444): info: Generated Viper text for testSetter:
+field pkg$$class_Person$member_age: Int
+
+method pkg$$class_Person$member_Person(local$age: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Person())
+
+
+method pkg$$global$testSetter() returns (ret: dom$Unit)
+{
+  var local$person: Ref
+  var anonymous$1: Ref
+  var anonymous$2: Int
+  anonymous$1 := pkg$$class_Person$member_Person(19)
+  local$person := anonymous$1
+  inhale acc(local$person.pkg$$class_Person$member_age, write)
+  anonymous$2 := local$person.pkg$$class_Person$member_age
+  exhale acc(local$person.pkg$$class_Person$member_age, write)
+  inhale acc(local$person.pkg$$class_Person$member_age, write)
+  local$person.pkg$$class_Person$member_age := anonymous$2 + 1
+  exhale acc(local$person.pkg$$class_Person$member_age, write)
+  label label$ret
+}
+
+/classes_setters.kt:(516,533): info: Generated Viper text for testSetterCascade:
+field pkg$$class_Bar$member_a: Int
+
+field pkg$$class_Foo$member_b: Ref
+
+method pkg$$class_Foo$member_Foo(local$b: Ref) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
+method pkg$$class_Bar$member_Bar(local$a: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+
+
+method pkg$$global$testSetterCascade() returns (ret: dom$Unit)
+{
+  var local$f: Ref
+  var anonymous$1: Ref
+  var anonymous$2: Ref
+  var anonymous$3: Ref
+  anonymous$2 := pkg$$class_Bar$member_Bar(10)
+  anonymous$1 := pkg$$class_Foo$member_Foo(anonymous$2)
+  local$f := anonymous$1
+  inhale acc(local$f.pkg$$class_Foo$member_b, write)
+  anonymous$3 := local$f.pkg$$class_Foo$member_b
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$pkg$$class_Bar())
+  exhale acc(local$f.pkg$$class_Foo$member_b, write)
+  inhale acc(anonymous$3.pkg$$class_Bar$member_a, write)
+  anonymous$3.pkg$$class_Bar$member_a := 42
+  exhale acc(anonymous$3.pkg$$class_Bar$member_a, write)
+  label label$ret
+}
+
+/classes_setters.kt:(585,609): info: Generated Viper text for testSetterNoBackingField:
+field pkg$$class_Baz$member__a: Int
+
+method pkg$$class_Baz$member_Baz() returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Baz())
+
+
+method pkg$$class_Baz$setter_a(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
+
+method pkg$$global$testSetterNoBackingField() returns (ret: dom$Unit)
+{
+  var local$baz: Ref
+  var anonymous$1: Ref
+  var anonymous$2: dom$Unit
+  anonymous$1 := pkg$$class_Baz$member_Baz()
+  local$baz := anonymous$1
+  anonymous$2 := pkg$$class_Baz$setter_a(local$baz, 42)
+  label label$ret
+}
+
+/classes_setters.kt:(694,704): info: Generated Viper text for mockInline:
+field pkg$$class_Bar$member_a: Int
+
+method pkg$$global$mockInline(local$b: Ref) returns (ret: dom$Unit)
+{
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$b): dom$Type), dom$Type$pkg$$class_Bar())
+  inhale acc(local$b.pkg$$class_Bar$member_a, write)
+  local$b.pkg$$class_Bar$member_a := 42
+  exhale acc(local$b.pkg$$class_Bar$member_a, write)
+  label label$ret
+}
+
+/classes_setters.kt:(735,751): info: Generated Viper text for testSetterLambda:
+field pkg$$class_Bar$member_a: Int
+
+method pkg$$class_Bar$member_Bar(local$a: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+
+
+method pkg$$global$testSetterLambda() returns (ret: dom$Unit)
+{
+  var anonymous$1: dom$Unit
+  if (true) {
+    var anonymous$2: Ref
+    anonymous$2 := pkg$$class_Bar$member_Bar(0)
+    inhale acc(anonymous$2.pkg$$class_Bar$member_a, write)
+    anonymous$2.pkg$$class_Bar$member_a := 42
+    exhale acc(anonymous$2.pkg$$class_Bar$member_a, write)
+    label inline_label$pkg$$global$mockInline$ret
+  }
+  label label$ret
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.kt
@@ -1,0 +1,53 @@
+class Bar(var a: Int)
+
+class Foo(var b: Bar)
+
+class Person(var age: Int)
+
+class Baz {
+    private var _a: Int = 0
+    var a: Int
+        get() = _a
+        set(value) {
+            _a = value
+        }
+}
+
+class AlwaysPlusOne {
+    var b = 0
+    var num: Int = 0
+        get() = field
+        set(value) {
+            field = value + 1
+        }
+}
+
+fun <!VIPER_TEXT!>testCustomSetter<!>() {
+    val f = AlwaysPlusOne()
+    f.b = 1
+    f.num = 1
+}
+
+fun <!VIPER_TEXT!>testSetter<!>() {
+    val person = Person(19)
+    person.age = person.age + 1
+}
+
+fun <!VIPER_TEXT!>testSetterCascade<!>() {
+    val f = Foo(Bar(10))
+    f.b.a = 42
+}
+
+fun <!VIPER_TEXT!>testSetterNoBackingField<!>() {
+    val baz = Baz()
+    baz.a = 42
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <!VIPER_TEXT!>mockInline<!>(b: Bar) {
+    b.a = 42
+}
+
+fun <!VIPER_TEXT!>testSetterLambda<!>() {
+    mockInline(Bar(0))
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -139,12 +139,10 @@ field pkg$$class_Bar$member_z: Int
 
 method pkg$$global$setSuperField(local$bar: Ref) returns (ret: dom$Unit)
 {
-  var anonymous$1: Bool
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
   inhale acc(local$bar.pkg$$class_Foo$member_b, write)
-  anonymous$1 := local$bar.pkg$$class_Foo$member_b
+  local$bar.pkg$$class_Foo$member_b := true
   exhale acc(local$bar.pkg$$class_Foo$member_b, write)
-  anonymous$1 := true
   label label$ret
 }
 

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -150,6 +150,18 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("classes_getters.kt")
+        public void testClasses_getters() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.kt");
+        }
+
+        @Test
+        @TestMetadata("classes_setters.kt")
+        public void testClasses_setters() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.kt");
+        }
+
+        @Test
         @TestMetadata("extension_function.kt")
         public void testExtension_function() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.kt");


### PR DESCRIPTION
This pull request is in WIP. Currently, it implements the following features:

- [x] Getters for 'virtual' fields, such as the example shown below.
- [x] Fields setters.

Simple test-case for custom getter:
```kotlin
class IntWrapper(val n: Int) {
    val succ: Int get() {
        return n + 1
    }
}

fun testGetters() {
    val wrapper = IntWrapper(42)
    val succ = wrapper.succ
}
```

Simple test-case for predefined setter:
```kotlin
class Person(var age: Int)

fun testSetter() {
    val person = Person(19)
    person.age = person.age + 1
}
```