### PR TITLE
Add inline function encoding

### DIFF
--- a/plugins/formal-verification/build.gradle.kts
+++ b/plugins/formal-verification/build.gradle.kts
@@ -55,7 +55,10 @@ projectTest(parallel = true, jUnitMode = JUnitMode.JUnit5) {
     dependsOn(":dist")
     workingDir = rootDir
     useJUnitPlatform()
-    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11))})
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(11))
+        jvmArgs = listOf("-Xss30M")
+    })
 }.also { confugureFirPluginAnnotationsDependency(it) }
 
 runtimeJar()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
@@ -36,3 +36,8 @@ data class SpecialFieldName(val name: String) : MangledName {
     override val mangled: String
         get() = "special\$$name"
 }
+
+data class InlineName(val inlineFunctionName: MangledName, val name: MangledName) : MangledName {
+    override val mangled: String
+        get() = "inline\$${inlineFunctionName.mangled}\$${name.mangled}"
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/NameResolutionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/NameResolutionContext.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.MangledName
+
+interface NameResolutionContext {
+    fun resolveName(name: MangledName): MangledName
+}
+
+class SimpleNameResolver : NameResolutionContext {
+    override fun resolveName(name: MangledName) = name
+}
+
+class InlineCallNameResolver(
+    private val inlineFunctionName: MangledName,
+    private val resultVar: VariableEmbedding,
+    private val substitutionParams: Map<MangledName, MangledName>
+) :
+    NameResolutionContext {
+    override fun resolveName(name: MangledName): MangledName =
+        when {
+            name == ReturnVariableName -> resultVar.name
+            else -> substitutionParams[name] ?: InlineName(inlineFunctionName, name)
+        }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/NameResolutionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/NameResolutionContext.kt
@@ -18,7 +18,7 @@ class SimpleNameResolver : NameResolutionContext {
 
 class InlineCallNameResolver(
     private val inlineFunctionName: MangledName,
-    private val resultVar: VariableEmbedding,
+    val resultVar: VariableEmbedding,
     private val substitutionParams: Map<MangledName, MangledName>
 ) :
     NameResolutionContext {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ResultTracker.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ResultTracker.kt
@@ -27,7 +27,7 @@ object NoopResultTracker : ResultTrackingContext {
 }
 
 abstract class VarResultTrackingContext(val resultVar: VariableEmbedding) : ResultTrackingContext {
-    override val resultExp: Exp
+    override val resultExp: Exp.LocalVar
         get() = resultVar.toLocalVar()
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.formver.conversion
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 interface StmtConversionContext<out RTC : ResultTrackingContext> : MethodConversionContext, SeqnBuildContext, ResultTrackingContext {
@@ -19,13 +21,25 @@ interface StmtConversionContext<out RTC : ResultTrackingContext> : MethodConvers
         resultCtx.capture(convert(exp), embedType(exp))
     }
 
+    fun convertAndStore(exp: FirExpression): Exp.LocalVar
+
     fun newBlock(): StmtConversionContext<RTC>
     fun withoutResult(): StmtConversionContext<NoopResultTracker>
     fun withResult(type: TypeEmbedding): StmtConversionContext<VarResultTrackingContext>
+
+    fun withInlineResolver(
+        inlineFunctionName: MangledName,
+        resultVar: VariableEmbedding,
+        substitutionParams: Map<MangledName, MangledName>,
+    ): StmtConversionContext<RTC>
 
     fun withResult(type: TypeEmbedding, action: StmtConversionContext<VarResultTrackingContext>.() -> Unit): Exp {
         val ctx = withResult(type)
         ctx.action()
         return ctx.resultExp
     }
+
+    fun getVariableEmbedding(name: MangledName, type: TypeEmbedding): VariableEmbedding
+
+    fun getReturnVariableEmbedding(): VariableEmbedding
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -13,13 +13,16 @@ import org.jetbrains.kotlin.fir.expressions.impl.FirElseIfTrueCondition
 import org.jetbrains.kotlin.fir.expressions.impl.FirNoReceiverExpression
 import org.jetbrains.kotlin.fir.references.toResolvedBaseSymbol
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.references.toResolvedNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.coneTypeOrNull
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.formver.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.AccessPredicate
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -52,7 +55,7 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
         val expr = data.convert(returnExpression.result)
         val exprType = data.embedType(returnExpression.result)
         // TODO: respect return-based control flow
-        val returnVar = data.signature.returnVar
+        val returnVar = data.getReturnVariableEmbedding()
         data.addStatement(Stmt.LocalVarAssign(returnVar.toLocalVar(), expr.convertType(exprType, returnVar.type)))
         return UnitDomain.element
     }
@@ -112,9 +115,9 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
     ): Exp {
         val type = data.embedType(propertyAccessExpression)
         return when (val symbol = propertyAccessExpression.calleeSymbol) {
-            is FirValueParameterSymbol -> VariableEmbedding(symbol.callableId.embedName(), type).toLocalVar()
+            is FirValueParameterSymbol -> data.getVariableEmbedding(symbol.callableId.embedName(), type).toLocalVar()
             is FirPropertySymbol -> {
-                val varEmbedding = VariableEmbedding(symbol.callableId.embedName(), type)
+                val varEmbedding = data.getVariableEmbedding(symbol.callableId.embedName(), type)
                 if (symbol.isLocal) {
                     return varEmbedding.toLocalVar()
                 } else {
@@ -190,6 +193,13 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
             return specialFunc.convertCall(argsFir.map(data::convert), data)
         }
 
+        val isInline = functionCall.calleeCallableSymbol.resolvedStatus.isInline
+        if (isInline) {
+            return data.withResult(data.embedType(functionCall)) {
+                processInlineFunctionCall(functionCall, this)
+            }
+        }
+
         val calleeSig = when (symbol) {
             is FirNamedFunctionSymbol -> data.embedFunction(symbol)
             is FirConstructorSymbol -> data.embedFunction(symbol)
@@ -203,6 +213,22 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
 
             data.addStatement(calleeSig.toMethodCall(args, this.resultCtx.resultVar))
         }
+    }
+
+    @OptIn(SymbolInternals::class)
+    private fun processInlineFunctionCall(functionCall: FirFunctionCall, data: StmtWithResultConversionContext) {
+        val symbol = functionCall.calleeNamedFunctionSymbol
+        val inlineBody = symbol.fir.body ?: throw Exception("Function symbol $symbol has a null body")
+        val ctx = data.newBlockShareResult()
+        val inlineArgs: List<MangledName> = symbol.valueParameterSymbols.map { it.embedName() }
+        val callArgs = getFunctionCallArguments(functionCall).map { ctx.convertAndStore(it).name }
+        val substitutionParams = inlineArgs.zip(callArgs).toMap()
+
+        val name = symbol.callableId.embedName()
+        val inlineCtx = ctx.withInlineResolver(name, substitutionParams)
+        inlineCtx.convert(inlineBody)
+        // Note: Putting the block inside the then branch of an if-true statement is a little a hack to make Viper respect the scoping
+        data.addStatement(Stmt.If(Exp.BoolLit(true), inlineCtx.block, Stmt.Seqn(listOf(), listOf())))
     }
 
     override fun visitImplicitInvokeCall(
@@ -233,7 +259,7 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
         if (!symbol.isLocal) {
             throw Exception("StmtConversionVisitor should not encounter non-local properties.")
         }
-        val cvar = VariableEmbedding(symbol.callableId.embedName(), data.embedType(type))
+        val cvar = data.getVariableEmbedding(symbol.callableId.embedName(), data.embedType(type))
         data.addDeclaration(cvar.toLocalVarDecl())
         property.initializer?.let {
             val initializerExp = data.convert(it)
@@ -314,6 +340,8 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
         get() = calleeReference.toResolvedBaseSymbol()!!
     private val FirResolvable.calleeCallableSymbol: FirCallableSymbol<*>
         get() = calleeReference.toResolvedCallableSymbol()!!
+    private val FirResolvable.calleeNamedFunctionSymbol: FirNamedFunctionSymbol
+        get() = calleeReference.toResolvedNamedFunctionSymbol()!!
 
     private fun handleUnimplementedElement(msg: String, data: StmtConversionContext<ResultTrackingContext>): Exp =
         when (data.config.behaviour) {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConverter.kt
@@ -5,10 +5,11 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
+import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirStatement
-import org.jetbrains.kotlin.formver.domains.UnitDomain
-import org.jetbrains.kotlin.formver.domains.convertType
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 /**
@@ -22,11 +23,22 @@ class StmtConverter<out RTC : ResultTrackingContext>(
     private val methodCtx: MethodConversionContext,
     private val seqnCtx: SeqnBuildContext,
     private val resultCtxFactory: ResultTrackerFactory<RTC>,
+    private val nameResolver: NameResolutionContext = SimpleNameResolver(),
 ) : StmtConversionContext<RTC>, SeqnBuildContext by seqnCtx, MethodConversionContext by methodCtx, ResultTrackingContext {
     override val resultCtx: RTC
         get() = resultCtxFactory.build(this)
 
     override fun convert(stmt: FirStatement): Exp = stmt.accept(StmtConversionVisitor, this)
+    override fun convertAndStore(exp: FirExpression): Exp.LocalVar {
+        val convertedExp = convert(exp)
+        return convertedExp as? Exp.LocalVar ?: withResult(embedType(exp)) {
+            capture(
+                convertedExp,
+                methodCtx.embedType(exp)
+            )
+        } as Exp.LocalVar
+    }
+
     override fun newBlock(): StmtConverter<RTC> = StmtConverter(this, SeqnBuilder(), resultCtxFactory)
     override fun withoutResult(): StmtConversionContext<NoopResultTracker> = StmtConverter(this, this.seqnCtx, NoopResultTrackerFactory)
 
@@ -35,6 +47,30 @@ class StmtConverter<out RTC : ResultTrackingContext>(
         addDeclaration(newResultVar.toLocalVarDecl())
         return StmtConverter(this, seqnCtx, VarResultTrackerFactory(newResultVar))
     }
+
+    override fun withInlineResolver(
+        inlineFunctionName: MangledName,
+        resultVar: VariableEmbedding,
+        substitutionParams: Map<MangledName, MangledName>,
+    ): StmtConversionContext<RTC> {
+        return StmtConverter(
+            this,
+            seqnCtx,
+            resultCtxFactory,
+            InlineCallNameResolver(inlineFunctionName, resultVar, substitutionParams)
+        )
+    }
+
+    override fun getVariableEmbedding(name: MangledName, type: TypeEmbedding): VariableEmbedding =
+        VariableEmbedding(nameResolver.resolveName(name), type)
+
+    override fun getReturnVariableEmbedding(): VariableEmbedding =
+        if (nameResolver is InlineCallNameResolver) {
+            getVariableEmbedding(ReturnVariableName, nameResolver.resultVar.type)
+        } else {
+            getVariableEmbedding(ReturnVariableName, methodCtx.signature.returnType)
+        }
+
 
     // We can't implement these members using `by` due to Kotlin shenanigans.
     override val resultExp: Exp

--- a/plugins/formal-verification/testData/diagnostics/inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/inlining.fir.diag.txt
@@ -1,0 +1,164 @@
+/inlining.kt:(132,138): info: Generated Viper text for invoke:
+method pkg_$global$invoke(local$f: Ref) returns (ret: Int)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+{
+  var local$x: Int
+  var anonymous$1: Int
+  var anonymous$2: Int
+  special$invoke_function_object(local$f)
+  local$x := anonymous$1
+  special$invoke_function_object(local$f)
+  ret := anonymous$2
+}
+
+/inlining.kt:(210,225): info: Generated Viper text for invoke_with_int:
+method pkg_$global$invoke_with_int(local$f: Ref, local$n: Int)
+  returns (ret: Int)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+{
+  var local$x: Int
+  var anonymous$1: Int
+  local$x := local$n + local$n
+  special$invoke_function_object(local$f)
+  ret := anonymous$1
+}
+
+/inlining.kt:(397,408): info: Generated Viper text for call_invoke:
+method pkg_$global$call_invoke(local$g: Ref) returns (ret: Int)
+  requires acc(local$g.special$function_object_call_counter, write)
+  ensures acc(local$g.special$function_object_call_counter, write)
+  ensures old(local$g.special$function_object_call_counter) <=
+    local$g.special$function_object_call_counter
+  ensures local$g.special$function_object_call_counter >
+    old(local$g.special$function_object_call_counter)
+{
+  var local$z: Int
+  var anonymous$1: Int
+  var anonymous$4: Int
+  if (true) {
+    var inline$pkg_$global$invoke$local$x: Int
+    var anonymous$2: Int
+    var anonymous$3: Int
+    special$invoke_function_object(local$g)
+    inline$pkg_$global$invoke$local$x := anonymous$2
+    special$invoke_function_object(local$g)
+    anonymous$1 := anonymous$3
+  }
+  local$z := anonymous$1
+  if (true) {
+    var inline$pkg_$global$invoke$local$x: Int
+    var anonymous$5: Int
+    var anonymous$6: Int
+    special$invoke_function_object(local$g)
+    inline$pkg_$global$invoke$local$x := anonymous$5
+    special$invoke_function_object(local$g)
+    anonymous$4 := anonymous$6
+  }
+  ret := anonymous$4
+}
+
+/inlining.kt:(641,661): info: Generated Viper text for call_invoke_with_int:
+method pkg_$global$call_invoke_with_int(local$g: Ref) returns (ret: Int)
+  requires acc(local$g.special$function_object_call_counter, write)
+  ensures acc(local$g.special$function_object_call_counter, write)
+  ensures old(local$g.special$function_object_call_counter) <=
+    local$g.special$function_object_call_counter
+  ensures local$g.special$function_object_call_counter >
+    old(local$g.special$function_object_call_counter)
+{
+  var local$z: Int
+  var anonymous$1: Int
+  var anonymous$4: Int
+  if (true) {
+    var anonymous$2: Int
+    var inline$pkg_$global$invoke_with_int$local$x: Int
+    var anonymous$3: Int
+    anonymous$2 := 1
+    inline$pkg_$global$invoke_with_int$local$x := anonymous$2 + anonymous$2
+    special$invoke_function_object(local$g)
+    anonymous$1 := anonymous$3
+  }
+  local$z := anonymous$1
+  if (true) {
+    var anonymous$5: Int
+    var inline$pkg_$global$invoke_with_int$local$x: Int
+    var anonymous$6: Int
+    special$invoke_function_object(local$g)
+    inline$pkg_$global$invoke_with_int$local$x := anonymous$5 + anonymous$5
+    special$invoke_function_object(local$g)
+    anonymous$4 := anonymous$6
+  }
+  ret := anonymous$4
+}
+
+/inlining.kt:(921,933): info: Generated Viper text for name_clashes:
+method pkg_$global$name_clashes(local$f: Ref) returns (ret: Int)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures local$f.special$function_object_call_counter >
+    old(local$f.special$function_object_call_counter)
+{
+  var local$x: Int
+  var anonymous$1: Int
+  var anonymous$4: Int
+  if (true) {
+    var inline$pkg_$global$invoke$local$x: Int
+    var anonymous$2: Int
+    var anonymous$3: Int
+    special$invoke_function_object(local$f)
+    inline$pkg_$global$invoke$local$x := anonymous$2
+    special$invoke_function_object(local$f)
+    anonymous$1 := anonymous$3
+  }
+  local$x := anonymous$1
+  if (true) {
+    var inline$pkg_$global$invoke_with_int$local$x: Int
+    var anonymous$5: Int
+    inline$pkg_$global$invoke_with_int$local$x := local$x + local$x
+    special$invoke_function_object(local$f)
+    anonymous$4 := anonymous$5
+  }
+  ret := anonymous$4
+}
+
+/inlining.kt:(1178,1199): info: Generated Viper text for different_return_type:
+method pkg_$global$different_return_type(local$f: Ref) returns (ret: Bool)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures local$f.special$function_object_call_counter >
+    old(local$f.special$function_object_call_counter)
+{
+  var local$x: Int
+  var anonymous$1: Int
+  var anonymous$4: Int
+  if (true) {
+    var inline$pkg_$global$invoke$local$x: Int
+    var anonymous$2: Int
+    var anonymous$3: Int
+    special$invoke_function_object(local$f)
+    inline$pkg_$global$invoke$local$x := anonymous$2
+    special$invoke_function_object(local$f)
+    anonymous$1 := anonymous$3
+  }
+  local$x := anonymous$1
+  if (true) {
+    var inline$pkg_$global$invoke$local$x: Int
+    var anonymous$5: Int
+    var anonymous$6: Int
+    special$invoke_function_object(local$f)
+    inline$pkg_$global$invoke$local$x := anonymous$5
+    special$invoke_function_object(local$f)
+    anonymous$4 := anonymous$6
+  }
+  ret := local$x == anonymous$4
+}

--- a/plugins/formal-verification/testData/diagnostics/inlining.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/inlining.fir.txt
@@ -1,0 +1,73 @@
+FILE: inlining.kt
+    public final inline fun invoke(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int| {
+        lval x: R|kotlin/Int| = R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(Int(0))
+        ^invoke R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(Int(0))
+    }
+    public final inline fun invoke_with_int(f: R|(kotlin/Int) -> kotlin/Int|, n: R|kotlin/Int|): R|kotlin/Int| {
+        lval x: R|kotlin/Int| = R|<local>/n|.R|kotlin/Int.plus|(R|<local>/n|)
+        ^invoke_with_int R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(R|<local>/x|)
+    }
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND), String(LEAKED_IN_PLACE_LAMBDA))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun call_invoke(g: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
+        [R|Contract description]
+         <
+            CallsInPlace(g, AT_LEAST_ONCE)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Int|>(R|<local>/g|, R|kotlin/contracts/InvocationKind.AT_LEAST_ONCE|)
+            }
+            )
+        }
+
+        lval z: R|kotlin/Int| = R|/invoke|(R|<local>/g|)
+        ^call_invoke R|/invoke|(R|<local>/g|)
+    }
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND), String(LEAKED_IN_PLACE_LAMBDA))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun call_invoke_with_int(g: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
+        [R|Contract description]
+         <
+            CallsInPlace(g, AT_LEAST_ONCE)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Int|>(R|<local>/g|, R|kotlin/contracts/InvocationKind.AT_LEAST_ONCE|)
+            }
+            )
+        }
+
+        lval z: R|kotlin/Int| = R|/invoke_with_int|(R|<local>/g|, Int(1))
+        ^call_invoke_with_int R|/invoke_with_int|(R|<local>/g|, R|<local>/g|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(Int(1)))
+    }
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND), String(LEAKED_IN_PLACE_LAMBDA))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun name_clashes(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
+        [R|Contract description]
+         <
+            CallsInPlace(f, AT_LEAST_ONCE)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Int|>(R|<local>/f|, R|kotlin/contracts/InvocationKind.AT_LEAST_ONCE|)
+            }
+            )
+        }
+
+        lval x: R|kotlin/Int| = R|/invoke|(R|<local>/f|)
+        ^name_clashes R|/invoke_with_int|(R|<local>/f|, R|<local>/x|)
+    }
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND), String(LEAKED_IN_PLACE_LAMBDA))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun different_return_type(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Boolean|
+        [R|Contract description]
+         <
+            CallsInPlace(f, AT_LEAST_ONCE)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Int|>(R|<local>/f|, R|kotlin/contracts/InvocationKind.AT_LEAST_ONCE|)
+            }
+            )
+        }
+
+        lval x: R|kotlin/Int| = R|/invoke|(R|<local>/f|)
+        ^different_return_type ==(R|<local>/x|, R|/invoke|(R|<local>/f|))
+    }

--- a/plugins/formal-verification/testData/diagnostics/inlining.kt
+++ b/plugins/formal-verification/testData/diagnostics/inlining.kt
@@ -1,0 +1,53 @@
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind.*
+import kotlin.contracts.contract
+
+inline fun <!VIPER_TEXT!>invoke<!>(f: (Int) -> Int): Int {
+    val x = f(0)
+    return f(0)
+}
+
+inline fun <!VIPER_TEXT!>invoke_with_int<!>(f: (Int) -> Int, n: Int): Int {
+    val x = n + n
+    return f(x)
+}
+
+@Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>call_invoke<!>(g: (Int) -> Int): Int {
+    contract {
+        callsInPlace(g, AT_LEAST_ONCE)
+    }
+    val z = invoke(g)
+    return invoke(g)
+}
+
+@Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>call_invoke_with_int<!>(g: (Int) -> Int): Int {
+    contract {
+        callsInPlace(g, AT_LEAST_ONCE)
+    }
+    val z = invoke_with_int(g, 1)
+    return invoke_with_int(g, g(1))
+}
+
+@Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>name_clashes<!>(f: (Int) -> Int): Int {
+    contract {
+        callsInPlace(f, AT_LEAST_ONCE)
+    }
+    val x = invoke(f)
+    return invoke_with_int(f, x)
+}
+
+@Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>different_return_type<!>(f: (Int) -> Int): Boolean {
+    contract {
+        callsInPlace(f, AT_LEAST_ONCE)
+    }
+    val x = invoke(f)
+    return x == invoke(f)
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -31,6 +31,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("inlining.kt")
+    public void testInlining() throws Exception {
+        runTest("plugins/formal-verification/testData/diagnostics/inlining.kt");
+    }
+
+    @Test
     @TestMetadata("returns_booleans.kt")
     public void testReturns_booleans() throws Exception {
         runTest("plugins/formal-verification/testData/diagnostics/returns_booleans.kt");


### PR DESCRIPTION
Substitution are now performed by the context when the visitor asks for a VariableEmbedding.
Doing this required some patches especially for substitutions like $f(0) [f / \lbrace g(it); g(it) \rbrace ]$ in which `special$invoke_function_object(f)` has to be replaced by two statements.
Unfortunately I'm still blocked with the problem of the stack size, and I cannot add more complex examples. I know that in order to solve the problem we have to add the argument `-Xss30M` while running java, but I am not able to find where. If you want to have a look at the problem, you can try to add the following example:
```
@Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
@OptIn(ExperimentalContracts::class)
fun <!VIPER_TEXT!>pass_lambda_nested<!>(f: (Int) -> Int, g: (Int) -> Int): Int {
    contract {
        callsInPlace(g, AT_LEAST_ONCE)
    }
    return invoke { f(g(it)) }
}
```