### PR TITLE
Restructure result tracking in `StmtConversionVisitor`

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -20,6 +20,9 @@
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
     <codeStyleSettings language="HTML">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -110,7 +110,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             }
 
             val bodySeqn = body?.let {
-                val ctx = StmtConverter(methodCtx, SeqnBuilder())
+                val ctx = StmtConverter(methodCtx, SeqnBuilder(), NoopResultTrackerFactory)
                 ctx.convert(body)
                 ctx.block
             }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ResultTracker.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ResultTracker.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.formver.domains.UnitDomain
+import org.jetbrains.kotlin.formver.domains.convertType
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+interface ResultTrackingContext {
+    /** Expression with the result of the computation.
+     */
+    val resultExp: Exp
+    fun capture(exp: Exp, expType: TypeEmbedding)
+}
+
+object NoopResultTracker : ResultTrackingContext {
+    override val resultExp = UnitDomain.element
+    override fun capture(exp: Exp, expType: TypeEmbedding) {
+        // do nothing
+    }
+}
+
+abstract class VarResultTrackingContext(val resultVar: VariableEmbedding) : ResultTrackingContext {
+    override val resultExp: Exp
+        get() = resultVar.toLocalVar()
+}
+
+interface ResultTrackerFactory<RTC : ResultTrackingContext> {
+    fun build(ctx: StmtConversionContext<RTC>): RTC
+}
+
+object NoopResultTrackerFactory : ResultTrackerFactory<NoopResultTracker> {
+    override fun build(ctx: StmtConversionContext<NoopResultTracker>): NoopResultTracker = NoopResultTracker
+}
+
+class VarResultTrackerFactory(val resultVar: VariableEmbedding) : ResultTrackerFactory<VarResultTrackingContext> {
+    override fun build(ctx: StmtConversionContext<VarResultTrackingContext>): VarResultTrackingContext =
+        object : VarResultTrackingContext(resultVar) {
+            override fun capture(exp: Exp, expType: TypeEmbedding) {
+                ctx.addStatement(Stmt.assign(resultExp, exp.convertType(expType, resultVar.type)))
+            }
+        }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFunction.kt
@@ -23,34 +23,34 @@ object KotlinContractFunction : SpecialFunction {
 }
 
 interface SpecialFunctionImplementation : SpecialFunction {
-    fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp
+    fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp
 }
 
 object KotlinIntPlusFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("plus"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Add(args[0], args[1])
 }
 
 object KotlinIntMinusFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("minus"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Sub(args[0], args[1])
 }
 
 object KotlinIntTimesFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("times"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Mul(args[0], args[1])
 }
 
 object KotlinIntDivFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("div"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp {
+    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp {
         ctx.addStatement(Stmt.Inhale(NeCmp(args[1], IntLit(0))))
         return Div(args[0], args[1])
     }
@@ -59,7 +59,7 @@ object KotlinIntDivFunctionImplementation : SpecialFunctionImplementation {
 object KotlinBooleanNotFunctionImplementation : SpecialFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Boolean"), Name.identifier("not"))
 
-    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext): Exp =
+    override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Not(args[0])
 }
 


### PR DESCRIPTION
I think this should make the lambda inlining a bit easier to fit into the structure, too.