### PR TITLE
Generalise receiver support

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -86,7 +86,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         val params = symbol.valueParameterSymbols.map {
             VariableEmbedding(it.embedName(), embedType(it.resolvedReturnType))
         }
-        val receiver = symbol.dispatchReceiverType?.let { VariableEmbedding(ThisReceiverName, embedType(it)) }
+        val receiver = symbol.receiverType?.let { VariableEmbedding(ThisReceiverName, embedType(it)) }
         return MethodSignatureEmbedding(
             symbol,
             receiver,
@@ -94,6 +94,9 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             embedType(retType)
         )
     }
+
+    private val FirFunctionSymbol<*>.receiverType: ConeKotlinType?
+        get() = dispatchReceiverType ?: resolvedReceiverTypeRef?.type
 
     private fun <D : FirFunction> processFunction(symbol: FirFunctionSymbol<D>, body: FirBlock?): MethodSignatureEmbedding {
         val signature = embedSignature(symbol)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
@@ -1,0 +1,5 @@
+/extension_function.kt:(8,11): info: Generated Viper text for inc:
+method pkg_$global$inc(this: Int) returns (ret: Int)
+{
+  ret := this + 1
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.txt
@@ -1,0 +1,4 @@
+FILE: extension_function.kt
+    public final fun R|kotlin/Int|.inc(): R|kotlin/Int| {
+        ^inc this@R|/inc|.R|kotlin/Int.plus|(Int(1))
+    }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.kt
@@ -1,0 +1,1 @@
+fun Int.<!VIPER_TEXT!>inc<!>(): Int = this + 1

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -94,6 +94,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("extension_function.kt")
+        public void testExtension_function() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.kt");
+        }
+
+        @Test
         @TestMetadata("full_viper_dump.kt")
         public void testFull_viper_dump() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.kt");


### PR DESCRIPTION
Previously only member functions were supported; now also extension functions work.