### PR TITLE
Verify that callsInPlace lambdas do not leak.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -11,29 +11,26 @@ import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.domains.TypeDomain
 import org.jetbrains.kotlin.formver.domains.TypeOfDomain
+import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.MethodSignatureEmbedding
 import org.jetbrains.kotlin.formver.embeddings.NullableTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.*
 
-object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, MethodConversionContext, ConeKotlinType, ConeDiagnostic>() {
-    private fun KtValueParameterReference<ConeKotlinType, ConeDiagnostic>.embeddedVar(data: MethodConversionContext): VariableEmbedding =
-        if (parameterIndex == -1) data.signature.receiver!! else data.signature.params[parameterIndex]
+class ContractDescriptionConversionVisitor(
+    private val ctx: ProgramConversionContext,
+    private val signature: MethodSignatureEmbedding,
+) : KtContractDescriptionVisitor<Exp, Unit, ConeKotlinType, ConeDiagnostic>() {
+    private val duplicableParameters = (signature.params.indices.toSet() + setOfNotNull(signature.receiver?.let { -1 })).toMutableSet()
 
-    private fun VariableEmbedding.nullCmp(isNegated: Boolean): Exp =
-        if (type is NullableTypeEmbedding) {
-            if (isNegated) {
-                NeCmp(toLocalVar(), type.nullVal)
-            } else {
-                EqCmp(toLocalVar(), type.nullVal)
-            }
-        } else {
-            BoolLit(isNegated)
-        }
+    val duplicabilityPreconditions: List<Exp>
+        get() = duplicableParameters.map { embeddedVarByIndex(it) }.filter { it.type is FunctionTypeEmbedding }
+            .map { DuplicableFunction.toFuncApp(listOf(it.toLocalVar())) }
 
     override fun visitBooleanConstantDescriptor(
         booleanConstantDescriptor: KtBooleanConstantReference<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
+        data: Unit,
     ): Exp = when (booleanConstantDescriptor) {
         ConeContractConstantValues.TRUE -> BoolLit(true)
         ConeContractConstantValues.FALSE -> BoolLit(false)
@@ -42,9 +39,9 @@ object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, 
 
     override fun visitReturnsEffectDeclaration(
         returnsEffect: KtReturnsEffectDeclaration<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
+        data: Unit,
     ): Exp {
-        val retVar = data.signature.returnVar.toLocalVar()
+        val retVar = signature.returnVar.toLocalVar()
         return when (returnsEffect.value) {
             ConeContractConstantValues.WILDCARD -> BoolLit(true)
             /* NOTE: in a function that has a non-nullable return type, the compiler will not complain if there is an effect like
@@ -52,8 +49,8 @@ object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, 
              * values and null. In a function that has a non-nullable return type, returnsNotNull() is mapped to true and returns(null)
              * is mapped to false
              */
-            ConeContractConstantValues.NULL -> data.signature.returnVar.nullCmp(false)
-            ConeContractConstantValues.NOT_NULL -> data.signature.returnVar.nullCmp(true)
+            ConeContractConstantValues.NULL -> signature.returnVar.nullCmp(false)
+            ConeContractConstantValues.NOT_NULL -> signature.returnVar.nullCmp(true)
             ConeContractConstantValues.TRUE -> EqCmp(retVar, BoolLit(true))
             ConeContractConstantValues.FALSE -> EqCmp(retVar, BoolLit(false))
             else -> throw Exception("Unexpected constant: ${returnsEffect.value}")
@@ -62,24 +59,24 @@ object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, 
 
     override fun visitValueParameterReference(
         valueParameterReference: KtValueParameterReference<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
-    ): Exp = valueParameterReference.embeddedVar(data).toLocalVar()
+        data: Unit,
+    ): Exp = valueParameterReference.embeddedVar().toLocalVar()
 
     override fun visitIsNullPredicate(
         isNullPredicate: KtIsNullPredicate<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
+        data: Unit,
     ): Exp {
         /* NOTE: useless comparisons like x != null with x non-nullable will compile with just a warning.
          * So it is necessary to take care of these cases in order to avoid comparison between non-nullable
          * values and null. Let x be a non-nullable variable, then x == null is mapped to false and x != null is mapped to true
          */
-        val param = isNullPredicate.arg.embeddedVar(data)
+        val param = isNullPredicate.arg.embeddedVar()
         return param.nullCmp(isNullPredicate.isNegated)
     }
 
     override fun visitLogicalBinaryOperationContractExpression(
         binaryLogicExpression: KtBinaryLogicExpression<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
+        data: Unit,
     ): Exp {
         val left = binaryLogicExpression.left.accept(this, data)
         val right = binaryLogicExpression.right.accept(this, data)
@@ -89,14 +86,14 @@ object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, 
         }
     }
 
-    override fun visitLogicalNot(logicalNot: KtLogicalNot<ConeKotlinType, ConeDiagnostic>, data: MethodConversionContext): Exp {
+    override fun visitLogicalNot(logicalNot: KtLogicalNot<ConeKotlinType, ConeDiagnostic>, data: Unit): Exp {
         val arg = logicalNot.arg.accept(this, data)
         return Not(arg)
     }
 
     override fun visitConditionalEffectDeclaration(
         conditionalEffect: KtConditionalEffectDeclaration<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
+        data: Unit,
     ): Exp {
         val effect = conditionalEffect.effect.accept(this, data)
         val cond = conditionalEffect.condition.accept(this, data)
@@ -105,9 +102,10 @@ object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, 
 
     override fun visitCallsEffectDeclaration(
         callsEffect: KtCallsEffectDeclaration<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext,
+        data: Unit,
     ): Exp {
         val param = callsEffect.valueParameterReference.accept(this, data)
+        duplicableParameters.remove(callsEffect.valueParameterReference.parameterIndex)
         val callsFieldAccess = FieldAccess(param, SpecialFields.FunctionObjectCallCounterField)
         return when (callsEffect.kind) {
             // NOTE: case not supported for contracts
@@ -138,9 +136,26 @@ object ContractDescriptionConversionVisitor : KtContractDescriptionVisitor<Exp, 
 
     override fun visitIsInstancePredicate(
         isInstancePredicate: KtIsInstancePredicate<ConeKotlinType, ConeDiagnostic>,
-        data: MethodConversionContext
+        data: Unit,
     ): Exp {
-        val argVar = isInstancePredicate.arg.embeddedVar(data)
-        return TypeDomain.isSubtype(TypeOfDomain.typeOf(argVar.toLocalVar()), data.embedType(isInstancePredicate.type).kotlinType)
+        val argVar = isInstancePredicate.arg.embeddedVar()
+        return TypeDomain.isSubtype(TypeOfDomain.typeOf(argVar.toLocalVar()), ctx.embedType(isInstancePredicate.type).kotlinType)
     }
+
+    private fun KtValueParameterReference<ConeKotlinType, ConeDiagnostic>.embeddedVar(): VariableEmbedding =
+        embeddedVarByIndex(parameterIndex)
+
+    private fun embeddedVarByIndex(ix: Int): VariableEmbedding =
+        if (ix == -1) signature.receiver!! else signature.params[ix]
+
+    private fun VariableEmbedding.nullCmp(isNegated: Boolean): Exp =
+        if (type is NullableTypeEmbedding) {
+            if (isNegated) {
+                NeCmp(toLocalVar(), type.nullVal)
+            } else {
+                EqCmp(toLocalVar(), type.nullVal)
+            }
+        } else {
+            BoolLit(isNegated)
+        }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
@@ -32,7 +32,7 @@ data object ThisReceiverName : MangledName {
         get() = "this"
 }
 
-data class SpecialFieldName(val name: String) : MangledName {
+data class SpecialName(val name: String) : MangledName {
     override val mangled: String
         get() = "special\$$name"
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.formver.viper.ast.BuiltinField
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
 object SpecialFields {
-    val FunctionObjectCallCounterField = BuiltinField(SpecialFieldName("function_object_call_counter"), Type.Int)
+    val FunctionObjectCallCounterField = BuiltinField(SpecialName("function_object_call_counter"), Type.Int)
     val all = listOf(
         FunctionObjectCallCounterField
     )

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFunctions.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFunctions.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.BuiltinFunction
+import org.jetbrains.kotlin.formver.viper.ast.Declaration
+import org.jetbrains.kotlin.formver.viper.ast.Type
+
+object DuplicableFunction : BuiltinFunction(SpecialName("duplicable")) {
+    private val thisArg = VariableEmbedding(AnonymousName(0), FunctionTypeEmbedding)
+
+    override val formalArgs: List<Declaration.LocalVarDecl> = listOf(thisArg.toLocalVarDecl())
+    override val retType: Type = Type.Bool
+}
+
+object SpecialFunctions {
+    val all = listOf(DuplicableFunction)
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialKotlinFunction.kt
@@ -12,42 +12,42 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-interface SpecialFunction {
+interface SpecialKotlinFunction {
     // We use strings here instead of FqNames as a lightweight approximation; perhaps
     // we'll need to rethink this down the line.
     val callableId: CallableId
 }
 
-object KotlinContractFunction : SpecialFunction {
+object KotlinContractFunction : SpecialKotlinFunction {
     override val callableId = CallableId(FqName.fromSegments(listOf("kotlin", "contracts")), null, Name.identifier("contract"))
 }
 
-interface SpecialFunctionImplementation : SpecialFunction {
+interface SpecialKotlinFunctionImplementation : SpecialKotlinFunction {
     fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp
 }
 
-object KotlinIntPlusFunctionImplementation : SpecialFunctionImplementation {
+object KotlinIntPlusFunctionImplementation : SpecialKotlinFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("plus"))
 
     override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Add(args[0], args[1])
 }
 
-object KotlinIntMinusFunctionImplementation : SpecialFunctionImplementation {
+object KotlinIntMinusFunctionImplementation : SpecialKotlinFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("minus"))
 
     override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Sub(args[0], args[1])
 }
 
-object KotlinIntTimesFunctionImplementation : SpecialFunctionImplementation {
+object KotlinIntTimesFunctionImplementation : SpecialKotlinFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("times"))
 
     override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Mul(args[0], args[1])
 }
 
-object KotlinIntDivFunctionImplementation : SpecialFunctionImplementation {
+object KotlinIntDivFunctionImplementation : SpecialKotlinFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Int"), Name.identifier("div"))
 
     override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp {
@@ -56,14 +56,14 @@ object KotlinIntDivFunctionImplementation : SpecialFunctionImplementation {
     }
 }
 
-object KotlinBooleanNotFunctionImplementation : SpecialFunctionImplementation {
+object KotlinBooleanNotFunctionImplementation : SpecialKotlinFunctionImplementation {
     override val callableId = CallableId(FqName("kotlin"), FqName("Boolean"), Name.identifier("not"))
 
     override fun convertCall(args: List<Exp>, ctx: StmtConversionContext<ResultTrackingContext>): Exp =
         Not(args[0])
 }
 
-object SpecialFunctions {
+object SpecialKotlinFunctions {
     val byCallableId = listOf(
         KotlinContractFunction,
         KotlinIntPlusFunctionImplementation,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialMethods.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialMethods.kt
@@ -7,10 +7,12 @@ package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
-import org.jetbrains.kotlin.formver.viper.ast.*
+import org.jetbrains.kotlin.formver.viper.ast.BuiltInMethod
+import org.jetbrains.kotlin.formver.viper.ast.Declaration
+import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.*
 
-object InvokeFunctionObjectMethod : BuiltInMethod(SpecialFieldName("invoke_function_object")) {
+object InvokeFunctionObjectMethod : BuiltInMethod(SpecialName("invoke_function_object")) {
     private val thisArg = VariableEmbedding(AnonymousName(0), FunctionTypeEmbedding)
     private val calls = EqCmp(
         Add(Old(thisArg.toFieldAccess(SpecialFields.FunctionObjectCallCounterField)), IntLit(1)),

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -190,10 +190,10 @@ object StmtConversionVisitor : FirVisitor<Exp, StmtConversionContext<ResultTrack
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: StmtConversionContext<ResultTrackingContext>): Exp {
         val symbol = functionCall.calleeCallableSymbol
         val id = symbol.callableId
-        val specialFunc = SpecialFunctions.byCallableId[id]
+        val specialFunc = SpecialKotlinFunctions.byCallableId[id]
         val argsFir = getFunctionCallArguments(functionCall)
         if (specialFunc != null) {
-            if (specialFunc !is SpecialFunctionImplementation) return UnitDomain.element
+            if (specialFunc !is SpecialKotlinFunctionImplementation) return UnitDomain.element
             return specialFunc.convertCall(argsFir.map(data::convert), data)
         }
 

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Collections.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Collections.kt
@@ -2,7 +2,6 @@
  * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
-@file:Suppress("UNCHECKED_CAST")
 
 /**
  * Utility helper filer for creating Scala's datastructures
@@ -15,20 +14,6 @@ import scala.Tuple2
 import scala.collection.immutable.`Map$`
 import scala.collection.immutable.Seq
 import scala.jdk.javaapi.CollectionConverters
-
-interface IntoScala<T> {
-    fun toScala(): T
-}
-
-sealed class Option<in T> : IntoScala<scala.Option<@UnsafeVariance T>> {
-    class None<T> : Option<T>() {
-        override fun toScala(): scala.Option<T> = scala.`None$`.`MODULE$` as scala.Option<T>
-    }
-
-    class Some<T>(private val value: T) : Option<T>() {
-        override fun toScala(): scala.Option<T> = scala.Some(value)
-    }
-}
 
 fun Int.toScalaBigInt(): scala.math.BigInt = scala.math.BigInt.apply(this)
 
@@ -45,7 +30,5 @@ fun <T> emptySeq(): Seq<T> = CollectionConverters.asScala(emptyList<T>()).toSeq(
 
 fun <T> seqOf(vararg elements: T): Seq<T> = CollectionConverters.asScala(elements.asList()).toSeq()
 
-fun <T> seqOf(elements: List<T>): Seq<T> = CollectionConverters.asScala(elements).toSeq()
-
-fun <T> List<T>.toScalaSeq() = seqOf(this)
+fun <T> List<T>.toScalaSeq(): Seq<T> = CollectionConverters.asScala(this).toSeq()
 

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/IntoViper.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/IntoViper.kt
@@ -5,9 +5,13 @@
 
 package org.jetbrains.kotlin.formver.viper
 
+import scala.Option
+
 interface IntoViper<out T> {
     fun toViper(): T
 }
+
+fun <T, V> Option<T>.toViper(): Option<V> where T : IntoViper<V> = map { it.toViper() }
 
 fun <T, V> List<T>.toViper(): List<V> where T : IntoViper<V> =
     map { it.toViper() }

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
@@ -61,7 +61,7 @@ class Verifier {
         val viperProgram = program.toViper()
         var success = true
 
-        val results = verifier.verify(viperProgram, emptySeq<SilverCfg>(), Option.None<String>().toScala())
+        val results = verifier.verify(viperProgram, emptySeq<SilverCfg>(), null.toScalaOption<String?>())
 
         for (result in results) {
             if (result.isFatal) {

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -351,6 +351,24 @@ sealed interface Exp : IntoViper<viper.silver.ast.Exp> {
         override fun toViper(): viper.silver.ast.Result = Result(type.toViper(), pos.toViper(), info.toViper(), trafos.toViper())
     }
 
+    data class FuncApp(
+        val functionName: MangledName,
+        val args: List<Exp>,
+        override val type: Type,
+        val pos: Position = Position.NoPosition,
+        val info: Info = Info.NoInfo,
+        val trafos: Trafos = Trafos.NoTrafos,
+    ) : Exp {
+        override fun toViper(): viper.silver.ast.FuncApp = FuncApp(
+            functionName.mangled,
+            args.toViper().toScalaSeq(),
+            pos.toViper(),
+            info.toViper(),
+            type.toViper(),
+            trafos.toViper()
+        )
+    }
+
     /**
      * IMPORTANT: typeVarMap needs to be set even when the type variables are
      * not instantiated. In that case map the generic type variables to themselves.

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Function.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Function.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.viper.ast
+
+import org.jetbrains.kotlin.formver.viper.*
+
+abstract class Function(
+    val name: MangledName,
+    val pos: Position = Position.NoPosition,
+    val info: Info = Info.NoInfo,
+    val trafos: Trafos = Trafos.NoTrafos,
+) : IntoViper<viper.silver.ast.Function> {
+    abstract val includeInShortDump: Boolean
+    abstract val formalArgs: List<Declaration.LocalVarDecl>
+    abstract val retType: Type
+    open val pres: List<Exp> = listOf()
+    open val posts: List<Exp> = listOf()
+    open val body: Exp? = null
+
+    override fun toViper(): viper.silver.ast.Function = viper.silver.ast.Function(
+        name.mangled, formalArgs.map { it.toViper() }.toScalaSeq(),
+        retType.toViper(), pres.toViper().toScalaSeq(), posts.toViper().toScalaSeq(), body.toScalaOption().toViper(),
+        pos.toViper(), info.toViper(), trafos.toViper()
+    )
+
+    fun toFuncApp(
+        args: List<Exp>,
+        pos: Position = Position.NoPosition,
+        info: Info = Info.NoInfo,
+        trafos: Trafos = Trafos.NoTrafos,
+    ): Exp.FuncApp = Exp.FuncApp(name, args, retType, pos, info, trafos)
+}
+
+abstract class BuiltinFunction(
+    name: MangledName,
+    pos: Position = Position.NoPosition,
+    info: Info = Info.NoInfo,
+    trafos: Trafos = Trafos.NoTrafos,
+) : Function(name, pos, info, trafos) {
+    override val includeInShortDump: Boolean = false
+}

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Method.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Method.kt
@@ -5,10 +5,7 @@
 
 package org.jetbrains.kotlin.formver.viper.ast
 
-import org.jetbrains.kotlin.formver.viper.IntoViper
-import org.jetbrains.kotlin.formver.viper.MangledName
-import org.jetbrains.kotlin.formver.viper.toScalaOption
-import org.jetbrains.kotlin.formver.viper.toScalaSeq
+import org.jetbrains.kotlin.formver.viper.*
 
 abstract class Method(
     val name: MangledName,
@@ -28,8 +25,8 @@ abstract class Method(
             name.mangled,
             formalArgs.map { it.toViper() }.toScalaSeq(),
             formalReturns.map { it.toViper() }.toScalaSeq(),
-            pres.map { it.toViper() }.toScalaSeq(),
-            posts.map { it.toViper() }.toScalaSeq(),
+            pres.toViper().toScalaSeq(),
+            posts.toViper().toScalaSeq(),
             body.toScalaOption().map { it.toViper() },
             pos.toViper(),
             info.toViper(),

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.formver.viper.toViper
 data class Program(
     val domains: List<Domain>,
     val fields: List<Field>,
-    /* no functions */
+    val functions: List<Function>,
     /* no predicates */
     val methods: List<Method>,
     /* no extensions */
@@ -24,7 +24,7 @@ data class Program(
     override fun toViper(): viper.silver.ast.Program = viper.silver.ast.Program(
         domains.toViper().toScalaSeq(),
         fields.toViper().toScalaSeq(),
-        emptySeq(), /* functions */
+        functions.toViper().toScalaSeq(),
         emptySeq(), /* predicates */
         methods.toViper().toScalaSeq(),
         emptySeq(), /* extensions */
@@ -36,6 +36,7 @@ data class Program(
     fun toShort(): Program = Program(
         domains.filter { it.includeInShortDump },
         fields.filter { it.includeInShortDump },
+        functions.filter { it.includeInShortDump },
         methods.filter { it.includeInShortDump },
         pos,
         info,

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -14,7 +14,7 @@ method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
   label label$ret
 }
 
-/calls_in_place.kt:(345,367): info: Generated Viper text for incorrect_at_most_once:
+/calls_in_place.kt:(380,402): info: Generated Viper text for incorrect_at_most_once:
 method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -41,14 +41,12 @@ method pkg$$global$incorrect_at_most_once(local$f: Ref) returns (ret: Int)
   label label$ret
 }
 
-/calls_in_place.kt:(345,367): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_most_once might not hold. Assertion local$f.special$function_object_call_counter <= old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
+/calls_in_place.kt:(380,402): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_most_once might not hold. Assertion local$f.special$function_object_call_counter <= old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
 
-/calls_in_place.kt:(345,367): warning: Function incorrect_at_most_once may not satisfy its contract.
+/calls_in_place.kt:(380,402): warning: Function incorrect_at_most_once may not satisfy its contract.
 
-/calls_in_place.kt:(397,451): warning: Wrong invocation kind 'AT_MOST_ONCE' for 'f: (Int) -> Int' specified, the actual invocation kind is 'AT_LEAST_ONCE'.
-
-/calls_in_place.kt:(521,543): info: Generated Viper text for incorrect_exactly_once:
+/calls_in_place.kt:(591,613): info: Generated Viper text for incorrect_exactly_once:
 method pkg$$global$incorrect_exactly_once(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -67,14 +65,12 @@ method pkg$$global$incorrect_exactly_once(local$f: Ref) returns (ret: Int)
   label label$ret
 }
 
-/calls_in_place.kt:(521,543): warning: Viper verification error: Postcondition of pkg$$global$incorrect_exactly_once might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
+/calls_in_place.kt:(591,613): warning: Viper verification error: Postcondition of pkg$$global$incorrect_exactly_once might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
 
-/calls_in_place.kt:(521,543): warning: Function incorrect_exactly_once may not satisfy its contract.
+/calls_in_place.kt:(591,613): warning: Function incorrect_exactly_once may not satisfy its contract.
 
-/calls_in_place.kt:(573,627): warning: Wrong invocation kind 'EXACTLY_ONCE' for 'f: (Int) -> Int' specified, the actual invocation kind is 'MORE_THAN_ONCE'.
-
-/calls_in_place.kt:(691,714): info: Generated Viper text for incorrect_at_least_once:
+/calls_in_place.kt:(796,819): info: Generated Viper text for incorrect_at_least_once:
 method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -99,9 +95,7 @@ method pkg$$global$incorrect_at_least_once(local$f: Ref) returns (ret: Int)
   label label$ret
 }
 
-/calls_in_place.kt:(691,714): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_least_once might not hold. Assertion local$f.special$function_object_call_counter > old(local$f.special$function_object_call_counter) might not hold. (<no position>)
+/calls_in_place.kt:(796,819): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_least_once might not hold. Assertion local$f.special$function_object_call_counter > old(local$f.special$function_object_call_counter) might not hold. (<no position>)
 
 
-/calls_in_place.kt:(691,714): warning: Function incorrect_at_least_once may not satisfy its contract.
-
-/calls_in_place.kt:(744,799): warning: Wrong invocation kind 'AT_LEAST_ONCE' for 'f: (Int) -> Int' specified, the actual invocation kind is 'UNKNOWN'.
+/calls_in_place.kt:(796,819): warning: Function incorrect_at_least_once may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.txt
@@ -14,7 +14,7 @@ FILE: calls_in_place.kt
 
         ^unknown R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(Int(1))
     }
-    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun incorrect_at_most_once(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun incorrect_at_most_once(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
         [R|Contract description]
          <
             CallsInPlace(f, AT_MOST_ONCE)
@@ -29,7 +29,7 @@ FILE: calls_in_place.kt
 
         ^incorrect_at_most_once R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(R|/unknown|(R|<local>/f|))
     }
-    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun incorrect_exactly_once(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun incorrect_exactly_once(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
         [R|Contract description]
          <
             CallsInPlace(f, EXACTLY_ONCE)
@@ -44,7 +44,7 @@ FILE: calls_in_place.kt
 
         ^incorrect_exactly_once R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(R|<local>/f|.R|SubstitutionOverride<kotlin/Function1.invoke: R|kotlin/Int|>|(Int(1)))
     }
-    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun incorrect_at_least_once(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
+    @R|kotlin/Suppress|(names = vararg(String(WRONG_INVOCATION_KIND))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun incorrect_at_least_once(f: R|(kotlin/Int) -> kotlin/Int|): R|kotlin/Int|
         [R|Contract description]
          <
             CallsInPlace(f, AT_LEAST_ONCE)

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.kt
@@ -11,26 +11,29 @@ fun <!VIPER_TEXT!>unknown<!>(f : (Int) -> Int) : Int{
     return f(1)
 }
 
+@Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
 fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>incorrect_at_most_once<!>(f : (Int) -> Int) : Int{
-    <!WRONG_INVOCATION_KIND!>contract {
+    contract {
         callsInPlace(f, AT_MOST_ONCE)
-    }<!>
+    }
     return f(unknown(f))
 }
 
+@Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
 fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>incorrect_exactly_once<!>(f : (Int) -> Int) : Int{
-    <!WRONG_INVOCATION_KIND!>contract {
+    contract {
         callsInPlace(f, EXACTLY_ONCE)
-    }<!>
+    }
     return f(f(1))
 }
 
+@Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
 fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>incorrect_at_least_once<!>(f : (Int) -> Int) : Int{
-    <!WRONG_INVOCATION_KIND!>contract {
+    contract {
         callsInPlace(f, AT_LEAST_ONCE)
-    }<!>
+    }
     return unknown(f)
 }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
@@ -1,0 +1,41 @@
+/calls_in_place_leak.kt:(84,90): info: Generated Viper text for escape:
+method pkg$$global$escape(local$f: Ref) returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+{
+  var anonymous$1: dom$Unit
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
+  special$invoke_function_object(local$f)
+  label label$ret
+}
+
+/calls_in_place_leak.kt:(294,316): info: Generated Viper text for invalid_calls_in_place:
+method pkg$$global$escape(local$f: Ref) returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+
+
+method pkg$$global$invalid_calls_in_place(local$f: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures true
+{
+  var anonymous$1: dom$Unit
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
+  anonymous$1 := pkg$$global$escape(local$f)
+  label label$ret
+}
+
+/calls_in_place_leak.kt:(294,316): warning: Viper verification error: The precondition of method pkg$$global$escape might not hold. Assertion special$duplicable(local$f) might not hold. (<no position>)
+
+
+/calls_in_place_leak.kt:(294,316): warning: Function invalid_calls_in_place may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.txt
@@ -1,0 +1,19 @@
+FILE: calls_in_place_leak.kt
+    public final fun escape(f: R|() -> kotlin/Unit|): R|kotlin/Unit| {
+        R|<local>/f|.R|SubstitutionOverride<kotlin/Function0.invoke: R|kotlin/Unit|>|()
+    }
+    @R|kotlin/Suppress|(names = vararg(String(LEAKED_IN_PLACE_LAMBDA))) @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlin/contracts/ExperimentalContracts|))) public final fun invalid_calls_in_place(f: R|() -> kotlin/Unit|): R|kotlin/Unit|
+        [R|Contract description]
+         <
+            CallsInPlace(f, UNKNOWN)
+        >
+     {
+         {
+            R|kotlin/contracts/contract|(<L> = contract@fun R|kotlin/contracts/ContractBuilder|.<anonymous>(): R|kotlin/Unit| <inline=Inline, kind=UNKNOWN>  {
+                this@R|special/anonymous|.R|kotlin/contracts/ContractBuilder.callsInPlace|<R|kotlin/Unit|>(R|<local>/f|)
+            }
+            )
+        }
+
+        R|/escape|(R|<local>/f|)
+    }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt
@@ -1,0 +1,17 @@
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+fun <!VIPER_TEXT!>escape<!>(f : () -> Unit) {
+    // No contract means that we assume this function may leak the function object passed to it.
+    f()
+}
+
+@Suppress("LEAKED_IN_PLACE_LAMBDA")
+@OptIn(ExperimentalContracts::class)
+fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>invalid_calls_in_place<!>(f : () -> Unit) {
+    contract {
+        callsInPlace(f)
+    }
+    escape(f)
+}
+

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/inlining.fir.diag.txt
@@ -1,6 +1,7 @@
 /inlining.kt:(132,138): info: Generated Viper text for invoke:
 method pkg$$global$invoke(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=
     local$f.special$function_object_call_counter
@@ -21,6 +22,7 @@ method pkg$$global$invoke(local$f: Ref) returns (ret: Int)
 method pkg$$global$invoke_with_int(local$f: Ref, local$n: Int)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=
     local$f.special$function_object_call_counter

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -235,6 +235,9 @@ domain dom$Any  {
 
 field special$function_object_call_counter: Int
 
+function special$duplicable(anonymous$0: Ref): Bool
+
+
 method special$invoke_function_object(anonymous$0: Ref)
   requires acc(anonymous$0.special$function_object_call_counter, write)
   ensures acc(anonymous$0.special$function_object_call_counter, write)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
@@ -1,6 +1,7 @@
 /function_object.kt:(4,17): info: Generated Viper text for unit_function:
 method pkg$$global$unit_function(local$f: Ref) returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=
     local$f.special$function_object_call_counter
@@ -12,6 +13,7 @@ method pkg$$global$unit_function(local$f: Ref) returns (ret: dom$Unit)
 /function_object.kt:(72,92): info: Generated Viper text for function_object_call:
 method pkg$$global$function_object_call(local$g: Ref) returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
+  requires special$duplicable(local$g)
   ensures acc(local$g.special$function_object_call_counter, write)
   ensures old(local$g.special$function_object_call_counter) <=
     local$g.special$function_object_call_counter
@@ -29,6 +31,8 @@ method pkg$$global$function_object_nested_call(local$f: Ref, local$g: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   requires acc(local$g.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
+  requires special$duplicable(local$g)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$g.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
@@ -13,6 +13,7 @@ method pkg$$global$returns_boolean() returns (ret: Bool)
 method pkg$$global$dynamic_lambda_invariant(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=
     local$f.special$function_object_call_counter
@@ -45,6 +46,7 @@ method pkg$$global$returns_boolean() returns (ret: Bool)
 method pkg$$global$function_assignment(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=
     local$f.special$function_object_call_counter
@@ -81,6 +83,8 @@ method pkg$$global$conditional_function_assignment(local$b: Bool, local$f: Ref,
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   requires acc(local$h.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
+  requires special$duplicable(local$h)
   ensures acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$h.special$function_object_call_counter, write)
   ensures old(local$f.special$function_object_call_counter) <=

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -40,6 +40,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("calls_in_place_leak.kt")
+        public void testCalls_in_place_leak() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt");
+        }
+
+        @Test
         @TestMetadata("is_type_contract.kt")
         public void testIs_type_contract() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.kt");


### PR DESCRIPTION
To this end, we introduce a `duplicable` function that is assumed as a precondition for function objects that *may* be leaked.