### PR TITLE
Move method call logic to `MethodEmbedding`

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver
+
+import org.jetbrains.kotlin.fir.contracts.FirEffectDeclaration
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirResolvable
+import org.jetbrains.kotlin.fir.references.toResolvedBaseSymbol
+import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.references.toResolvedNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+
+val FirResolvable.calleeSymbol: FirBasedSymbol<*>
+    get() = calleeReference.toResolvedBaseSymbol()!!
+val FirResolvable.calleeCallableSymbol: FirCallableSymbol<*>
+    get() = calleeReference.toResolvedCallableSymbol()!!
+val FirResolvable.calleeNamedFunctionSymbol: FirNamedFunctionSymbol
+    get() = calleeReference.toResolvedNamedFunctionSymbol()!!
+val FirFunctionCall.functionCallArguments: List<FirExpression>
+    get() = listOfNotNull(dispatchReceiver) + argumentList.arguments
+val FirFunctionSymbol<*>.effects: List<FirEffectDeclaration>
+    get() = this.resolvedContractDescription?.effects ?: emptyList()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -6,13 +6,13 @@
 package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.contracts.description.*
-import org.jetbrains.kotlin.fir.contracts.FirEffectDeclaration
 import org.jetbrains.kotlin.fir.contracts.description.ConeContractConstantValues
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.domains.TypeDomain
 import org.jetbrains.kotlin.formver.domains.TypeOfDomain
+import org.jetbrains.kotlin.formver.effects
 import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.MethodSignatureEmbedding
 import org.jetbrains.kotlin.formver.embeddings.NullableTypeEmbedding
@@ -172,6 +172,4 @@ class ContractDescriptionConversionVisitor(
         }
 }
 
-val FirFunctionSymbol<*>.effects: List<FirEffectDeclaration>
-    get() = this.resolvedContractDescription?.effects ?: emptyList()
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -6,11 +6,14 @@
 package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.contracts.description.*
+import org.jetbrains.kotlin.fir.contracts.FirEffectDeclaration
 import org.jetbrains.kotlin.fir.contracts.description.ConeContractConstantValues
 import org.jetbrains.kotlin.fir.diagnostics.ConeDiagnostic
+import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.domains.TypeDomain
 import org.jetbrains.kotlin.formver.domains.TypeOfDomain
+import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.MethodSignatureEmbedding
 import org.jetbrains.kotlin.formver.embeddings.NullableTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
@@ -21,6 +24,23 @@ class ContractDescriptionConversionVisitor(
     private val ctx: ProgramConversionContext,
     private val signature: MethodSignatureEmbedding,
 ) : KtContractDescriptionVisitor<Exp, Unit, ConeKotlinType, ConeDiagnostic>() {
+    private val parameterIndices = signature.params.indices.toSet() + setOfNotNull(signature.receiver?.let { -1 })
+
+    fun getPreconditions(symbol: FirFunctionSymbol<*>): List<Exp> {
+        val nonDuplicableIndices = symbol.effects
+            .mapNotNull { (it.effect as? KtCallsEffectDeclaration<*, *>)?.valueParameterReference?.parameterIndex }
+            .toSet()
+
+        return (parameterIndices - nonDuplicableIndices)
+            .map { embeddedVarByIndex(it) }
+            .filter { it.type is FunctionTypeEmbedding }
+            .map { DuplicableFunction.toFuncApp(listOf(it.toLocalVar())) }
+    }
+
+    fun getPostconditions(symbol: FirFunctionSymbol<*>): List<Exp> =
+        symbol.effects.map { it.effect.accept(this, Unit) }
+
+
     override fun visitBooleanConstantDescriptor(
         booleanConstantDescriptor: KtBooleanConstantReference<ConeKotlinType, ConeDiagnostic>,
         data: Unit,
@@ -137,7 +157,7 @@ class ContractDescriptionConversionVisitor(
     private fun KtValueParameterReference<ConeKotlinType, ConeDiagnostic>.embeddedVar(): VariableEmbedding =
         embeddedVarByIndex(parameterIndex)
 
-    fun embeddedVarByIndex(ix: Int): VariableEmbedding =
+    private fun embeddedVarByIndex(ix: Int): VariableEmbedding =
         if (ix == -1) signature.receiver!! else signature.params[ix]
 
     private fun VariableEmbedding.nullCmp(isNegated: Boolean): Exp =
@@ -151,3 +171,7 @@ class ContractDescriptionConversionVisitor(
             BoolLit(isNegated)
         }
 }
+
+val FirFunctionSymbol<*>.effects: List<FirEffectDeclaration>
+    get() = this.resolvedContractDescription?.effects ?: emptyList()
+

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -27,11 +27,12 @@ class ContractDescriptionConversionVisitor(
     private val parameterIndices = signature.params.indices.toSet() + setOfNotNull(signature.receiver?.let { -1 })
 
     fun getPreconditions(symbol: FirFunctionSymbol<*>): List<Exp> {
-        val nonDuplicableIndices = symbol.effects
+        val callsInPlaceIndices = symbol.effects
             .mapNotNull { (it.effect as? KtCallsEffectDeclaration<*, *>)?.valueParameterReference?.parameterIndex }
             .toSet()
 
-        return (parameterIndices - nonDuplicableIndices)
+        // All parameters of function type that are not callsInPlace should be marked duplicable.
+        return (parameterIndices - callsInPlaceIndices)
             .map { embeddedVarByIndex(it) }
             .filter { it.type is FunctionTypeEmbedding }
             .map { DuplicableFunction.toFuncApp(listOf(it.toLocalVar())) }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -17,8 +17,6 @@ interface MethodConversionContext : ProgramConversionContext {
     val returnLabel: Label
     val returnVar: VariableEmbedding
 
-    val preconditions: List<Exp>
-    val postconditions: List<Exp>
     fun resolveName(name: MangledName): MangledName
 
     fun getVariableEmbedding(name: MangledName, type: TypeEmbedding): VariableEmbedding =

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -10,14 +10,14 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.PluginConfiguration
-import org.jetbrains.kotlin.formver.embeddings.MethodSignatureEmbedding
+import org.jetbrains.kotlin.formver.embeddings.MethodEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 
 interface ProgramConversionContext {
     val config: PluginConfiguration
 
-    fun embedFunction(symbol: FirFunctionSymbol<*>): MethodSignatureEmbedding
+    fun embedFunction(symbol: FirFunctionSymbol<*>): MethodEmbedding
     fun embedType(type: ConeKotlinType): TypeEmbedding
     fun embedType(exp: FirExpression): TypeEmbedding = embedType(exp.resolvedType)
     fun newAnonName(): AnonymousName

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -9,8 +9,6 @@ import org.jetbrains.kotlin.contracts.description.KtCallsEffectDeclaration
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.hasBackingField
-import org.jetbrains.kotlin.fir.declarations.utils.isInline
-import org.jetbrains.kotlin.fir.expressions.FirBlock
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
@@ -30,6 +28,7 @@ import org.jetbrains.kotlin.formver.viper.ast.*
  */
 class ProgramConverter(val session: FirSession, override val config: PluginConfiguration) : ProgramConversionContext {
     private val methods: MutableMap<MangledName, MethodEmbedding> = mutableMapOf()
+    private val methodsToVerify: MutableList<FirFunctionSymbol<*>> = mutableListOf()
     private val classes: MutableMap<ClassName, ClassTypeEmbedding> = mutableMapOf()
     private val fields: MutableList<Field> = mutableListOf()
 
@@ -41,12 +40,34 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             methods = SpecialMethods.all + methods.values.filter { it.shouldIncludeInProgram }.map { it.viperMethod }.toList(),
         )
 
+    fun processRegisteredMethods() {
+        for (method in methodsToVerify) {
+            val embedding = embedFunction(method)
+            embedding.convertBody(this)
+        }
+    }
+
     fun registerForVerification(declaration: FirSimpleFunction) {
-        processFunction(declaration.symbol, declaration.body)
+        methodsToVerify.add(declaration.symbol)
     }
 
     override fun embedFunction(symbol: FirFunctionSymbol<*>): MethodEmbedding {
-        return processFunction(symbol, null)
+        val signature = embedSignature(symbol)
+        return methods.getOrPut(signature.name) {
+            val contractVisitor = ContractDescriptionConversionVisitor(this@ProgramConverter, signature)
+
+            val preconditions = signature.formalArgs.flatMap { it.invariants() } +
+                    signature.formalArgs.flatMap { it.accessInvariants() } +
+                    contractVisitor.getPreconditions(symbol)
+
+            val postconditions = signature.formalArgs.flatMap { it.accessInvariants() } +
+                    signature.params.flatMap { it.dynamicInvariants() } +
+                    signature.returnVar.invariants() +
+                    signature.returnVar.provenInvariants() +
+                    contractVisitor.getPostconditions(symbol)
+
+            UserMethodEmbedding(signature, preconditions, postconditions, symbol)
+        }
     }
 
     private fun embedClass(symbol: FirRegularClassSymbol): ClassTypeEmbedding {
@@ -104,66 +125,6 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
 
     private val FirFunctionSymbol<*>.receiverType: ConeKotlinType?
         get() = dispatchReceiverType ?: resolvedReceiverTypeRef?.type
-
-    private fun processFunction(symbol: FirFunctionSymbol<*>, body: FirBlock?): MethodEmbedding {
-        val signature = embedSignature(symbol)
-        // NOTE: we have a problem here if we initially specify a method without a body,
-        // and then later decide to add a body anyway.  It's not a problem for now, but
-        // worth being aware of.
-        return methods.getOrPut(signature.name) {
-            val contractVisitor = ContractDescriptionConversionVisitor(this@ProgramConverter, signature)
-            val parameterIndices = (signature.params.indices.toSet() + setOfNotNull(signature.receiver?.let { -1 })).toMutableSet()
-            val nonDuplicableIndices = symbol.resolvedContractDescription?.effects?.mapNotNull { decl ->
-                (decl.effect as? KtCallsEffectDeclaration<*, *>)?.valueParameterReference?.parameterIndex
-            }?.toSet() ?: emptySet()
-
-            val duplicableParameters =
-                (parameterIndices - nonDuplicableIndices).map { contractVisitor.embeddedVarByIndex(it) }.filter { it.type is FunctionTypeEmbedding }
-                    .map { DuplicableFunction.toFuncApp(listOf(it.toLocalVar())) }
-            val contractPostconditions =
-                symbol.resolvedContractDescription?.effects?.map {
-                    it.effect.accept(contractVisitor, Unit)
-                } ?: emptyList()
-
-            val methodCtx = object : MethodConversionContext, ProgramConversionContext by this {
-                override val signature: MethodSignatureEmbedding = signature
-
-                // It seems like Viper will propagate the weakest precondition through the label correctly even in the absence of
-                // explicit invariants; we only need to add those if we want to make a stronger claim.
-                override val returnLabel: Label = Label(ReturnLabelName, listOf())
-                override val returnVar: VariableEmbedding = VariableEmbedding(ReturnVariableName, signature.returnType)
-
-                override val preconditions =
-                    signature.formalArgs.flatMap { it.invariants() } + signature.formalArgs.flatMap { it.accessInvariants() } + duplicableParameters
-
-                override val postconditions = signature.formalArgs.flatMap { it.accessInvariants() } +
-                        signature.params.flatMap { it.dynamicInvariants() } +
-                        signature.returnVar.invariants() +
-                        signature.returnVar.provenInvariants() +
-                        contractPostconditions
-
-                override fun resolveName(name: MangledName): MangledName = name
-            }
-
-            val bodySeqn = body?.let {
-                val ctx = StmtConverter(methodCtx, SeqnBuilder(), NoopResultTrackerFactory)
-                signature.formalArgs.forEach { arg ->
-                    arg.provenInvariants().forEach {
-                        // Ideally we would want to assume these rather than inhale them to prevent inconsistencies with permissions.
-                        // Unfortunately Silicon for some reason does not allow Assumes. However, it doesn't matter as long as the
-                        // provenInvariants don't contain permissions.
-                        ctx.addStatement(Stmt.Inhale(it))
-                    }
-                }
-                ctx.addDeclaration(methodCtx.returnLabel.toDecl())
-                ctx.convert(body)
-                ctx.addStatement(methodCtx.returnLabel.toStmt())
-                ctx.block
-            }
-
-            MethodEmbedding(signature, methodCtx.preconditions, methodCtx.postconditions, bodySeqn, symbol.isInline)
-        }
-    }
 
     private fun processClass(symbol: FirRegularClassSymbol) {
         val concreteFields = symbol.declarationSymbols

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.formver.viper.ast.*
  */
 class ProgramConverter(val session: FirSession, override val config: PluginConfiguration) : ProgramConversionContext {
     private val methods: MutableMap<MangledName, MethodEmbedding> = mutableMapOf()
-    private val methodsToVerify: MutableList<FirFunctionSymbol<*>> = mutableListOf()
     private val classes: MutableMap<ClassName, ClassTypeEmbedding> = mutableMapOf()
     private val fields: MutableList<Field> = mutableListOf()
 
@@ -40,15 +39,9 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             methods = SpecialMethods.all + methods.values.filter { it.shouldIncludeInProgram }.map { it.viperMethod }.toList(),
         )
 
-    fun processRegisteredMethods() {
-        for (method in methodsToVerify) {
-            val embedding = embedFunction(method)
-            embedding.convertBody(this)
-        }
-    }
-
     fun registerForVerification(declaration: FirSimpleFunction) {
-        methodsToVerify.add(declaration.symbol)
+        val embedding = embedFunction(declaration.symbol)
+        embedding.convertBody(this)
     }
 
     override fun embedFunction(symbol: FirFunctionSymbol<*>): MethodEmbedding {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -35,9 +35,9 @@ interface StmtConversionContext<out RTC : ResultTrackingContext> : MethodConvers
         substitutionParams: Map<MangledName, MangledName>,
     ): StmtConversionContext<RTC>
 
-    fun withResult(type: TypeEmbedding, action: StmtConversionContext<VarResultTrackingContext>.() -> Unit): Exp {
+    fun withResult(type: TypeEmbedding, action: StmtConversionContext<VarResultTrackingContext>.() -> Unit): Exp.LocalVar {
         val ctx = withResult(type)
         ctx.action()
-        return ctx.resultExp
+        return ctx.resultCtx.resultVar.toLocalVar()
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/MethodEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/MethodEmbedding.kt
@@ -5,24 +5,110 @@
 
 package org.jetbrains.kotlin.formver.embeddings
 
-import org.jetbrains.kotlin.formver.viper.ast.Exp
-import org.jetbrains.kotlin.formver.viper.ast.Stmt
-import org.jetbrains.kotlin.formver.viper.ast.UserMethod
+import org.jetbrains.kotlin.fir.declarations.utils.isInline
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.formver.conversion.*
+import org.jetbrains.kotlin.formver.domains.convertType
+import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.formver.viper.ast.*
 
-class MethodEmbedding(
+interface MethodEmbedding : MethodSignatureEmbedding {
+    val shouldIncludeInProgram: Boolean
+    val viperMethod: Method
+    fun convertBody(ctx: ProgramConverter)
+    fun insertCall(argsFir: List<FirExpression>, ctx: StmtConversionContext<ResultTrackingContext>): Exp.LocalVar
+}
+
+abstract class BaseMethodEmbedding(
     val signature: MethodSignatureEmbedding,
-    val preconditions: List<Exp>,
-    val postconditions: List<Exp>,
-    val body: Stmt.Seqn?,
-    val isInline: Boolean,
-) : MethodSignatureEmbedding by signature {
-    val shouldIncludeInProgram = !isInline || body != null
-    val viperMethod = UserMethod(
-        name,
-        formalArgs.map { it.toLocalVarDecl() },
-        returnVar.toLocalVarDecl(),
-        preconditions,
-        postconditions,
-        body
-    )
+) : MethodEmbedding, MethodSignatureEmbedding by signature {
+    abstract val preconditions: List<Exp>
+    abstract val postconditions: List<Exp>
+    abstract val body: Stmt.Seqn?
+
+    override val viperMethod
+        get() = UserMethod(
+            name,
+            formalArgs.map { it.toLocalVarDecl() },
+            returnVar.toLocalVarDecl(),
+            preconditions,
+            postconditions,
+            body
+        )
+}
+
+class UserMethodEmbedding(
+    signature: MethodSignatureEmbedding,
+    override val preconditions: List<Exp>,
+    override val postconditions: List<Exp>,
+    val symbol: FirFunctionSymbol<*>,
+) : BaseMethodEmbedding(signature) {
+    override var body: Stmt.Seqn? = null
+    override val shouldIncludeInProgram
+        get() = !symbol.isInline || body != null
+
+    @OptIn(SymbolInternals::class)
+    override fun convertBody(ctx: ProgramConverter) {
+        val methodCtx = object : MethodConversionContext, ProgramConversionContext by ctx {
+            override val signature: MethodSignatureEmbedding = this@UserMethodEmbedding
+
+            // It seems like Viper will propagate the weakest precondition through the label correctly even in the absence of
+            // explicit invariants; we only need to add those if we want to make a stronger claim.
+            override val returnLabel: Label = Label(ReturnLabelName, listOf())
+            override val returnVar: VariableEmbedding = VariableEmbedding(ReturnVariableName, signature.returnType)
+
+            override val preconditions: List<Exp> = this@UserMethodEmbedding.preconditions
+            override val postconditions: List<Exp> = this@UserMethodEmbedding.postconditions
+
+            override fun resolveName(name: MangledName): MangledName = name
+        }
+
+        body = symbol.fir.body?.let {
+            val stmtCtx = StmtConverter(methodCtx, SeqnBuilder(), NoopResultTrackerFactory)
+            signature.formalArgs.forEach { arg ->
+                // Ideally we would want to assume these rather than inhale them to prevent inconsistencies with permissions.
+                // Unfortunately Silicon for some reason does not allow Assumes. However, it doesn't matter as long as the
+                // provenInvariants don't contain permissions.
+                arg.provenInvariants().forEach { invariant ->
+                    stmtCtx.addStatement(Stmt.Inhale(invariant))
+                }
+            }
+            stmtCtx.addDeclaration(methodCtx.returnLabel.toDecl())
+            stmtCtx.convert(it)
+            stmtCtx.addStatement(methodCtx.returnLabel.toStmt())
+            stmtCtx.block
+        }
+    }
+
+    @OptIn(SymbolInternals::class)
+    override fun insertCall(argsFir: List<FirExpression>, ctx: StmtConversionContext<ResultTrackingContext>): Exp.LocalVar =
+        ctx.withResult(returnType) {
+            if (!symbol.isInline) {
+                val args = argsFir
+                    .zip(formalArgs)
+                    .map { (arg, formalArg) -> convert(arg).convertType(embedType(arg), formalArg.type) }
+
+                addStatement(toMethodCall(args, this.resultCtx.resultVar))
+            } else {
+                val inlineBody = symbol.fir.body ?: throw Exception("Function symbol $symbol has a null body")
+                val inlineBodyCtx = newBlock()
+                val inlineArgs: List<MangledName> = symbol.valueParameterSymbols.map { it.embedName() }
+                val callArgs = argsFir.map { inlineBodyCtx.convertAndStore(it).name }
+                val substitutionParams = inlineArgs.zip(callArgs).toMap()
+
+                val inlineCtx = inlineBodyCtx.withInlineContext(
+                    this@UserMethodEmbedding.signature,
+                    inlineBodyCtx.resultCtx.resultVar,
+                    substitutionParams
+                )
+                inlineCtx.convert(inlineBody)
+                // TODO: add these labels automatically.
+                inlineCtx.addDeclaration(inlineCtx.returnLabel.toDecl())
+                inlineCtx.addStatement(inlineCtx.returnLabel.toStmt())
+                // Note: Putting the block inside the then branch of an if-true statement is a little a hack to make Viper respect the scoping
+                addStatement(Stmt.If(Exp.BoolLit(true), inlineCtx.block, Stmt.Seqn(listOf(), listOf())))
+            }
+        }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -47,6 +47,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
         try {
             val programConversionContext = ProgramConverter(session, config)
             programConversionContext.registerForVerification(declaration)
+            programConversionContext.processRegisteredMethods()
             program = programConversionContext.program
 
             getProgramForLogging(program)?.let {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -15,14 +15,6 @@ method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
 }
 
 /calls_in_place.kt:(380,402): info: Generated Viper text for incorrect_at_most_once:
-method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
-  requires acc(local$f.special$function_object_call_counter, write)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
-  ensures true
-
-
 method pkg$$global$incorrect_at_most_once(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -40,6 +32,14 @@ method pkg$$global$incorrect_at_most_once(local$f: Ref) returns (ret: Int)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures true
+
 
 /calls_in_place.kt:(380,402): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_most_once might not hold. Assertion local$f.special$function_object_call_counter <= old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
@@ -71,14 +71,6 @@ method pkg$$global$incorrect_exactly_once(local$f: Ref) returns (ret: Int)
 /calls_in_place.kt:(591,613): warning: Function incorrect_exactly_once may not satisfy its contract.
 
 /calls_in_place.kt:(796,819): info: Generated Viper text for incorrect_at_least_once:
-method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
-  requires acc(local$f.special$function_object_call_counter, write)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
-  ensures true
-
-
 method pkg$$global$incorrect_at_least_once(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -94,6 +86,14 @@ method pkg$$global$incorrect_at_least_once(local$f: Ref) returns (ret: Int)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$unknown(local$f: Ref) returns (ret: Int)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures true
+
 
 /calls_in_place.kt:(796,819): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_least_once might not hold. Assertion local$f.special$function_object_call_counter > old(local$f.special$function_object_call_counter) might not hold. (<no position>)
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
@@ -13,14 +13,6 @@ method pkg$$global$escape(local$f: Ref) returns (ret: dom$Unit)
 }
 
 /calls_in_place_leak.kt:(294,316): info: Generated Viper text for invalid_calls_in_place:
-method pkg$$global$escape(local$f: Ref) returns (ret: dom$Unit)
-  requires acc(local$f.special$function_object_call_counter, write)
-  requires special$duplicable(local$f)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
-
-
 method pkg$$global$invalid_calls_in_place(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
@@ -34,6 +26,14 @@ method pkg$$global$invalid_calls_in_place(local$f: Ref)
   anonymous$1 := pkg$$global$escape(local$f)
   label label$ret
 }
+
+method pkg$$global$escape(local$f: Ref) returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+
 
 /calls_in_place_leak.kt:(294,316): warning: Viper verification error: The precondition of method pkg$$global$escape might not hold. Assertion special$duplicable(local$f) might not hold. (<no position>)
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/calls_in_place.fir.diag.txt
@@ -49,15 +49,6 @@ method pkg$$global$exactly_once(local$f: Ref) returns (ret: Int)
 }
 
 /calls_in_place.kt:(623,636): info: Generated Viper text for at_least_once:
-method pkg$$global$exactly_once(local$f: Ref) returns (ret: Int)
-  requires acc(local$f.special$function_object_call_counter, write)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
-  ensures local$f.special$function_object_call_counter ==
-    old(local$f.special$function_object_call_counter) + 1
-
-
 method pkg$$global$at_least_once(local$f: Ref) returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -73,6 +64,15 @@ method pkg$$global$at_least_once(local$f: Ref) returns (ret: Int)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$exactly_once(local$f: Ref) returns (ret: Int)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures local$f.special$function_object_call_counter ==
+    old(local$f.special$function_object_call_counter) + 1
+
 
 /calls_in_place.kt:(800,809): info: Generated Viper text for loopWhile:
 method pkg$$global$loopWhile(local$lambda: Ref) returns (ret: dom$Unit)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -37,10 +37,6 @@ method pkg$$global$subtypeTransitive(local$x: dom$Unit)
 /is_type_contract.kt:(686,707): info: Generated Viper text for constructorReturnType:
 field pkg$$class_Foo$member_bar: Ref
 
-method pkg$$class_Foo$member_Foo() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
 method pkg$$global$constructorReturnType() returns (ret: Bool)
   ensures ret == true
 {
@@ -50,6 +46,10 @@ method pkg$$global$constructorReturnType() returns (ret: Bool)
   goto label$ret
   label label$ret
 }
+
+method pkg$$class_Foo$member_Foo() returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
 
 /is_type_contract.kt:(832,848): info: Generated Viper text for subtypeSuperType:
 field pkg$$class_Foo$member_bar: Ref

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -50,12 +50,6 @@ method pkg$$global$logical_not(local$b: Bool) returns (ret: Bool)
 }
 
 /returns_booleans.kt:(1052,1075): info: Generated Viper text for call_fun_with_contracts:
-method pkg$$global$binary_logic_expressions(local$a: Bool, local$b: Bool)
-  returns (ret: Bool)
-  ensures ret == false ==> local$b && false
-  ensures ret == true ==> (true || local$a) && (local$b || true)
-
-
 method pkg$$global$call_fun_with_contracts(local$b: Bool)
   returns (ret: Bool)
   ensures ret == true
@@ -68,3 +62,9 @@ method pkg$$global$call_fun_with_contracts(local$b: Bool)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$binary_logic_expressions(local$a: Bool, local$b: Bool)
+  returns (ret: Bool)
+  ensures ret == false ==> local$b && false
+  ensures ret == true ==> (true || local$a) && (local$b || true)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/boolean_logic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/boolean_logic.fir.diag.txt
@@ -21,9 +21,6 @@ method pkg$$global$conjunction(local$x: Bool, local$y: Bool)
 }
 
 /boolean_logic.kt:(127,151): info: Generated Viper text for conjunction_side_effects:
-method pkg$$global$negation(local$x: Bool) returns (ret: Bool)
-
-
 method pkg$$global$conjunction_side_effects(local$x: Bool, local$y: Bool)
   returns (ret: Bool)
 {
@@ -40,6 +37,9 @@ method pkg$$global$conjunction_side_effects(local$x: Bool, local$y: Bool)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$negation(local$x: Bool) returns (ret: Bool)
+
 
 /boolean_logic.kt:(324,335): info: Generated Viper text for disjunction:
 method pkg$$global$disjunction(local$x: Bool, local$y: Bool)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -3,11 +3,6 @@ field pkg$$class_Foo$member_a: Int
 
 field pkg$$class_Foo$member_b: Int
 
-method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
 method pkg$$global$createFoo() returns (ret: dom$Unit)
 {
   var local$f: Ref
@@ -29,13 +24,13 @@ method pkg$$global$createFoo() returns (ret: dom$Unit)
   label label$ret
 }
 
+method pkg$$class_Foo$member_Foo(local$a: Int, local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
 /classes.kt:(147,156): info: Generated Viper text for createBar:
 field pkg$$class_Bar$member_a: dom$Nullable[Ref]
-
-method pkg$$class_Bar$member_Bar(local$a: dom$Nullable[Ref])
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
 
 method pkg$$global$createBar() returns (ret: dom$Unit)
 {
@@ -46,3 +41,8 @@ method pkg$$global$createBar() returns (ret: dom$Unit)
   local$b := anonymous$1
   label label$ret
 }
+
+method pkg$$class_Bar$member_Bar(local$a: dom$Nullable[Ref])
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
@@ -7,12 +7,12 @@ method pkg$$global$inc(this: Int) returns (ret: Int)
 }
 
 /extension_function.kt:(35,56): info: Generated Viper text for extension_method_call:
-method pkg$kotlin$class_Int$member_inc(this: Int) returns (ret: Int)
-
-
 method pkg$$global$extension_method_call() returns (ret: dom$Unit)
 {
   var anonymous$1: Int
   anonymous$1 := pkg$kotlin$class_Int$member_inc(3)
   label label$ret
 }
+
+method pkg$kotlin$class_Int$member_inc(this: Int) returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
@@ -7,9 +7,6 @@ method pkg$$global$f(local$x: Int) returns (ret: Int)
 }
 
 /function_call.kt:(27,40): info: Generated Viper text for function_call:
-method pkg$$global$f(local$x: Int) returns (ret: Int)
-
-
 method pkg$$global$function_call() returns (ret: dom$Unit)
 {
   var anonymous$1: Int
@@ -19,10 +16,10 @@ method pkg$$global$function_call() returns (ret: dom$Unit)
   label label$ret
 }
 
-/function_call.kt:(69,89): info: Generated Viper text for function_call_nested:
 method pkg$$global$f(local$x: Int) returns (ret: Int)
 
 
+/function_call.kt:(69,89): info: Generated Viper text for function_call_nested:
 method pkg$$global$function_call_nested() returns (ret: dom$Unit)
 {
   var anonymous$1: Int
@@ -33,3 +30,6 @@ method pkg$$global$function_call_nested() returns (ret: dom$Unit)
   anonymous$1 := pkg$$global$f(anonymous$2)
   label label$ret
 }
+
+method pkg$$global$f(local$x: Int) returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
@@ -25,12 +25,6 @@ method pkg$$global$if_on_parameter(local$b: Bool) returns (ret: Int)
 }
 
 /if.kt:(205,221): info: Generated Viper text for if_as_expression:
-method pkg$$global$simple_if() returns (ret: Int)
-
-
-method pkg$$global$if_on_parameter(local$b: Bool) returns (ret: Int)
-
-
 method pkg$$global$if_as_expression() returns (ret: Bool)
 {
   var local$b: Bool
@@ -49,3 +43,9 @@ method pkg$$global$if_as_expression() returns (ret: Bool)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$simple_if() returns (ret: Int)
+
+
+method pkg$$global$if_on_parameter(local$b: Bool) returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -51,9 +51,6 @@ field pkg$$class_Foo$member_b: Bool
 
 field pkg$$class_Bar$member_z: Int
 
-method pkg$$class_Foo$member_getY(this: Ref) returns (ret: Int)
-
-
 method pkg$$global$callSuperMethod(local$bar: Ref) returns (ret: Int)
 {
   var anonymous$1: Int
@@ -63,6 +60,9 @@ method pkg$$global$callSuperMethod(local$bar: Ref) returns (ret: Int)
   goto label$ret
   label label$ret
 }
+
+method pkg$$class_Foo$member_getY(this: Ref) returns (ret: Int)
+
 
 /inheritance.kt:(279,295): info: Generated Viper text for accessSuperField:
 field pkg$$class_Foo$member_x: Int
@@ -115,9 +115,6 @@ field pkg$$class_Foo$member_b: Bool
 
 field pkg$$class_Bar$member_z: Int
 
-method pkg$$class_Bar$member_sum(this: Ref) returns (ret: Int)
-
-
 method pkg$$global$callNewMethod(local$bar: Ref) returns (ret: Int)
 {
   var anonymous$1: Int
@@ -127,6 +124,9 @@ method pkg$$global$callNewMethod(local$bar: Ref) returns (ret: Int)
   goto label$ret
   label label$ret
 }
+
+method pkg$$class_Bar$member_sum(this: Ref) returns (ret: Int)
+
 
 /inheritance.kt:(456,469): info: Generated Viper text for setSuperField:
 field pkg$$class_Foo$member_x: Int

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
@@ -18,9 +18,6 @@ method pkg$$global$while_loop(local$b: Bool) returns (ret: Bool)
 }
 
 /loop.kt:(120,144): info: Generated Viper text for while_function_condition:
-method pkg$$global$while_loop(local$b: Bool) returns (ret: Bool)
-
-
 method pkg$$global$while_function_condition() returns (ret: dom$Unit)
 {
   var anonymous$1: Bool
@@ -36,3 +33,6 @@ method pkg$$global$while_function_condition() returns (ret: dom$Unit)
   label label$break$1
   label label$ret
 }
+
+method pkg$$global$while_loop(local$b: Bool) returns (ret: Bool)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
@@ -7,9 +7,6 @@ method pkg$$global$returns_boolean() returns (ret: Bool)
 }
 
 /loop_invariants.kt:(57,81): info: Generated Viper text for dynamic_lambda_invariant:
-method pkg$$global$returns_boolean() returns (ret: Bool)
-
-
 method pkg$$global$dynamic_lambda_invariant(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
@@ -39,10 +36,10 @@ method pkg$$global$dynamic_lambda_invariant(local$f: Ref)
   label label$ret
 }
 
-/loop_invariants.kt:(155,174): info: Generated Viper text for function_assignment:
 method pkg$$global$returns_boolean() returns (ret: Bool)
 
 
+/loop_invariants.kt:(155,174): info: Generated Viper text for function_assignment:
 method pkg$$global$function_assignment(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
@@ -74,10 +71,10 @@ method pkg$$global$function_assignment(local$f: Ref)
   label label$ret
 }
 
-/loop_invariants.kt:(262,293): info: Generated Viper text for conditional_function_assignment:
 method pkg$$global$returns_boolean() returns (ret: Bool)
 
 
+/loop_invariants.kt:(262,293): info: Generated Viper text for conditional_function_assignment:
 method pkg$$global$conditional_function_assignment(local$b: Bool, local$f: Ref,
   local$h: Ref)
   returns (ret: dom$Unit)
@@ -123,3 +120,6 @@ method pkg$$global$conditional_function_assignment(local$b: Bool, local$f: Ref,
   label label$break$1
   label label$ret
 }
+
+method pkg$$global$returns_boolean() returns (ret: Bool)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -16,9 +16,6 @@ method pkg$$class_Foo$member_member_fun(this: Ref) returns (ret: Int)
 /member_functions.kt:(84,99): info: Generated Viper text for call_member_fun:
 field pkg$$class_Foo$member_x: Int
 
-method pkg$$class_Foo$member_member_fun(this: Ref) returns (ret: Int)
-
-
 method pkg$$class_Foo$member_call_member_fun(this: Ref)
   returns (ret: dom$Unit)
 {
@@ -28,11 +25,11 @@ method pkg$$class_Foo$member_call_member_fun(this: Ref)
   label label$ret
 }
 
-/member_functions.kt:(140,152): info: Generated Viper text for sibling_call:
-field pkg$$class_Foo$member_x: Int
-
 method pkg$$class_Foo$member_member_fun(this: Ref) returns (ret: Int)
 
+
+/member_functions.kt:(140,152): info: Generated Viper text for sibling_call:
+field pkg$$class_Foo$member_x: Int
 
 method pkg$$class_Foo$member_sibling_call(this: Ref, local$other: Ref)
   returns (ret: dom$Unit)
@@ -44,15 +41,11 @@ method pkg$$class_Foo$member_sibling_call(this: Ref, local$other: Ref)
   label label$ret
 }
 
-/member_functions.kt:(207,228): info: Generated Viper text for outer_member_fun_call:
-field pkg$$class_Foo$member_x: Int
-
-method pkg$$class_Foo$member_Foo(local$x: Int) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
 method pkg$$class_Foo$member_member_fun(this: Ref) returns (ret: Int)
 
+
+/member_functions.kt:(207,228): info: Generated Viper text for outer_member_fun_call:
+field pkg$$class_Foo$member_x: Int
 
 method pkg$$global$outer_member_fun_call() returns (ret: dom$Unit)
 {
@@ -64,3 +57,10 @@ method pkg$$global$outer_member_fun_call() returns (ret: dom$Unit)
   anonymous$2 := pkg$$class_Foo$member_member_fun(local$f)
   label label$ret
 }
+
+method pkg$$class_Foo$member_Foo(local$x: Int) returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+
+
+method pkg$$class_Foo$member_member_fun(this: Ref) returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -14,11 +14,6 @@ method pkg$$global$use_nullable_twice(local$x: dom$Nullable[Int])
 }
 
 /nullable.kt:(88,111): info: Generated Viper text for pass_nullable_parameter:
-method pkg$$global$use_nullable_twice(local$x: dom$Nullable[Int])
-  returns (ret: dom$Nullable[Int])
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
-
-
 method pkg$$global$pass_nullable_parameter(local$x: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
@@ -30,6 +25,11 @@ method pkg$$global$pass_nullable_parameter(local$x: dom$Nullable[Int])
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$use_nullable_twice(local$x: dom$Nullable[Int])
+  returns (ret: dom$Nullable[Int])
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
+
 
 /nullable.kt:(175,203): info: Generated Viper text for nullable_nullable_comparison:
 method pkg$$global$nullable_nullable_comparison(local$x: dom$Nullable[Int],

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.fir.diag.txt
@@ -1,0 +1,9 @@
+/recursion.kt:(4,13): info: Generated Viper text for recursive:
+method pkg$$global$recursive() returns (ret: dom$Unit)
+{
+  var anonymous$1: dom$Unit
+  anonymous$1 := pkg$$global$recursive()
+  ret := anonymous$1
+  goto label$ret
+  label label$ret
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.fir.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.fir.txt
@@ -1,0 +1,4 @@
+FILE: recursion.kt
+    public final fun recursive(): R|kotlin/Unit| {
+        ^recursive R|/recursive|()
+    }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.kt
@@ -1,0 +1,1 @@
+fun <!VIPER_TEXT!>recursive<!>(): Unit = recursive()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.diag.txt
@@ -47,13 +47,13 @@ method pkg$$global$nullable_parameter(local$b: dom$Nullable[Bool])
 }
 
 /subtyping.kt:(272,300): info: Generated Viper text for function_parameter_subtyping:
-method pkg$$global$nullable_parameter(local$b: dom$Nullable[Bool])
-  returns (ret: dom$Unit)
-
-
 method pkg$$global$function_parameter_subtyping() returns (ret: dom$Unit)
 {
   var anonymous$1: dom$Unit
   anonymous$1 := pkg$$global$nullable_parameter((dom$Casting$cast(false, dom$Type$special$Nullable(dom$Type$Boolean())): dom$Nullable[Bool]))
   label label$ret
 }
+
+method pkg$$global$nullable_parameter(local$b: dom$Nullable[Bool])
+  returns (ret: dom$Unit)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -83,9 +83,6 @@ method pkg$$global$when_with_subject_var(local$x: Int) returns (ret: Int)
 }
 
 /when.kt:(716,738): info: Generated Viper text for when_with_subject_call:
-method pkg$$global$when_with_subject_var(local$x: Int) returns (ret: Int)
-
-
 method pkg$$global$when_with_subject_call(local$x: Int) returns (ret: Int)
 {
   var anonymous$1: Int
@@ -105,6 +102,9 @@ method pkg$$global$when_with_subject_call(local$x: Int) returns (ret: Int)
   goto label$ret
   label label$ret
 }
+
+method pkg$$global$when_with_subject_var(local$x: Int) returns (ret: Int)
+
 
 /when.kt:(861,871): info: Generated Viper text for empty_when:
 method pkg$$global$empty_when() returns (ret: Int)

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -222,6 +222,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("recursion.kt")
+        public void testRecursion() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/recursion.kt");
+        }
+
+        @Test
         @TestMetadata("return_break_continue.kt")
         public void testReturn_break_continue() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/return_break_continue.kt");


### PR DESCRIPTION
This simplifies getting the order of what happens in `ProgramConverter` right now and should make it easier to have a single interface for generating function calls from different places in the code.
