### PR TITLE
Fix when expressions

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -87,7 +87,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
     override fun visitWhenExpression(whenExpression: FirWhenExpression, data: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
         val subj = whenExpression.subject?.let { data.convertAndStore(it) }
         val type = data.embedType(whenExpression)
-        val ctx = if (type != NothingTypeEmbedding) {
+        val ctx = if (type != NothingTypeEmbedding && type != UnitTypeEmbedding) {
             data.withResult(type)
         } else {
             data.withoutResult()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -12,9 +12,6 @@ import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.expressions.impl.FirElseIfTrueCondition
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
-import org.jetbrains.kotlin.fir.types.FirUserTypeRef
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.formver.UnsupportedFeatureBehaviour
@@ -89,10 +86,11 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
 
     override fun visitWhenExpression(whenExpression: FirWhenExpression, data: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
         val subj = whenExpression.subject?.let { data.convertAndStore(it) }
-        val ctx = if (whenExpression.usedAsExpression) {
-            data.withResult(data.embedType(whenExpression))
+        val type = data.embedType(whenExpression)
+        val ctx = if (type != NothingTypeEmbedding) {
+            data.withResult(type)
         } else {
-            data
+            data.withoutResult()
         }
         ctx.withWhenSubject(subj) { ctxWithSubj ->
             convertWhenBranches(whenExpression.branches.iterator(), ctxWithSubj)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inline.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inline.fir.diag.txt
@@ -56,11 +56,9 @@ method pkg$$global$use_branching() returns (ret: Int)
     if (anonymous$2) {
       anonymous$1 := 1
       goto inline$pkg$$global$branching$label$ret
-      anonymous$1 := (dom$Casting$cast(dom$Unit$element(), dom$Type$Int()): Int)
     } else {
       anonymous$1 := 0
       goto inline$pkg$$global$branching$label$ret
-      anonymous$1 := (dom$Casting$cast(dom$Unit$element(), dom$Type$Int()): Int)
     }
     label inline$pkg$$global$branching$label$ret
   }
@@ -70,11 +68,9 @@ method pkg$$global$use_branching() returns (ret: Int)
     if (anonymous$4) {
       anonymous$3 := 1
       goto inline$pkg$$global$branching$label$ret
-      anonymous$3 := (dom$Casting$cast(dom$Unit$element(), dom$Type$Int()): Int)
     } else {
       anonymous$3 := 0
       goto inline$pkg$$global$branching$label$ret
-      anonymous$3 := (dom$Casting$cast(dom$Unit$element(), dom$Type$Int()): Int)
     }
     label inline$pkg$$global$branching$label$ret
   }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.fir.diag.txt
@@ -57,12 +57,13 @@ method pkg$$global$lambda_if() returns (ret: Int)
   if (true) {
     var anonymous$2: Int
     var anonymous$3: Int
+    var anonymous$4: Int
     anonymous$3 := 0
     if (anonymous$3 == 0) {
-      anonymous$2 := anonymous$3 + 1
+      anonymous$4 := anonymous$3 + 1
     } else {
-      anonymous$2 := anonymous$3 + 2}
-    anonymous$2 := anonymous$2
+      anonymous$4 := anonymous$3 + 2}
+    anonymous$2 := anonymous$4
     anonymous$1 := anonymous$2
     goto inline$pkg$$global$invoke$label$ret
     label inline$pkg$$global$invoke$label$ret

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -40,9 +40,11 @@ method pkg$$global$when_return(local$a: Bool, local$b: Bool, local$c: Bool)
 method pkg$$global$single_branch_when(local$a: Bool) returns (ret: Int)
 {
   var local$x: Int
+  var anonymous$1: dom$Unit
   local$x := 1
   if (local$a) {
     local$x := 2
+    anonymous$1 := dom$Unit$element()
   }
   ret := local$x
   goto label$ret
@@ -54,13 +56,17 @@ method pkg$$global$no_else_when(local$a: Bool, local$b: Bool, local$c: Bool)
   returns (ret: Int)
 {
   var local$y: Int
+  var anonymous$1: dom$Unit
   local$y := 0
   if (local$a) {
     local$y := 1
+    anonymous$1 := dom$Unit$element()
   } elseif (local$b) {
     local$y := 2
+    anonymous$1 := dom$Unit$element()
   } elseif (local$c) {
     local$y := 3
+    anonymous$1 := dom$Unit$element()
   }
   ret := local$y
   goto label$ret
@@ -115,12 +121,27 @@ method pkg$$global$when_with_subject_var(local$x: Int) returns (ret: Int)
 /when.kt:(962,972): info: Generated Viper text for empty_when:
 method pkg$$global$empty_when() returns (ret: Int)
 {
+  var anonymous$1: dom$Unit
   ret := 1
   goto label$ret
   label label$ret
 }
 
-/when.kt:(1053,1060): info: Generated Viper text for when_is:
+/when.kt:(1015,1028): info: Generated Viper text for unused_result:
+method pkg$$global$unused_result() returns (ret: Int)
+{
+  var local$x: Int
+  var anonymous$1: Int
+  var anonymous$2: Int
+  anonymous$2 := 5
+  anonymous$1 := 0
+  local$x := anonymous$1
+  ret := local$x
+  goto label$ret
+  label label$ret
+}
+
+/when.kt:(1222,1229): info: Generated Viper text for when_is:
 method pkg$$global$when_is(local$x: Ref) returns (ret: Bool)
 {
   var anonymous$1: Bool

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -40,11 +40,9 @@ method pkg$$global$when_return(local$a: Bool, local$b: Bool, local$c: Bool)
 method pkg$$global$single_branch_when(local$a: Bool) returns (ret: Int)
 {
   var local$x: Int
-  var anonymous$1: dom$Unit
   local$x := 1
   if (local$a) {
     local$x := 2
-    anonymous$1 := dom$Unit$element()
   }
   ret := local$x
   goto label$ret
@@ -56,17 +54,13 @@ method pkg$$global$no_else_when(local$a: Bool, local$b: Bool, local$c: Bool)
   returns (ret: Int)
 {
   var local$y: Int
-  var anonymous$1: dom$Unit
   local$y := 0
   if (local$a) {
     local$y := 1
-    anonymous$1 := dom$Unit$element()
   } elseif (local$b) {
     local$y := 2
-    anonymous$1 := dom$Unit$element()
   } elseif (local$c) {
     local$y := 3
-    anonymous$1 := dom$Unit$element()
   }
   ret := local$y
   goto label$ret
@@ -121,7 +115,6 @@ method pkg$$global$when_with_subject_var(local$x: Int) returns (ret: Int)
 /when.kt:(962,972): info: Generated Viper text for empty_when:
 method pkg$$global$empty_when() returns (ret: Int)
 {
-  var anonymous$1: dom$Unit
   ret := 1
   goto label$ret
   label label$ret

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.kt
@@ -59,6 +59,18 @@ fun <!VIPER_TEXT!>empty_when<!>(): Int {
     return 1
 }
 
+fun <!VIPER_TEXT!>unused_result<!>(): Int {
+    val x = when {
+        else -> {
+            when {
+                else -> 5
+            }
+            0
+        }
+    }
+    return x
+}
+
 open class Foo()
 class Bar() : Foo()
 


### PR DESCRIPTION
Since `usedAsExpression` flag is just a syntax-based assumption, we cannot rely on it. This also fixes some bugs with the inlining