### PR TITLE
Clear minor errors before running checker.

### DIFF
--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
@@ -20,6 +20,10 @@ class PluginConfiguration(
         }
     }
 
+    fun clearMinorErrors() {
+        minorErrors.clear()
+    }
+
     fun addMinorError(error: String) {
         minorErrors.add(error)
     }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -43,6 +43,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
     FirSimpleFunctionChecker() {
     override fun check(declaration: FirSimpleFunction, context: CheckerContext, reporter: DiagnosticReporter) {
         if (!config.conversionSelection.applicable(declaration)) return
+        config.clearMinorErrors()
         var program: Program? = null
         try {
             val programConversionContext = ProgramConverter(session, config)


### PR DESCRIPTION
A better solution here would be to put the minor errors somewhere other than in the config, but I'm not sure there's much to be won from that at this point.