### PR TITLE
Restructure naming system.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -153,7 +153,7 @@ class ContractDescriptionConversionVisitor(
         data: Unit,
     ): Exp {
         val argVar = isInstancePredicate.arg.embeddedVar()
-        return TypeDomain.isSubtype(TypeOfDomain.typeOf(argVar.toViper()), ctx.embedType(isInstancePredicate.type).kotlinType)
+        return TypeDomain.isSubtype(TypeOfDomain.typeOf(argVar.toViper()), ctx.embedType(isInstancePredicate.type).runtimeType)
     }
 
     private fun KtValueParameterReference<ConeKotlinType, ConeDiagnostic>.embeddedVar(): VariableEmbedding =

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshNames.kt
@@ -7,8 +7,7 @@ package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.formver.viper.MangledName
 
-/**
- * This file contains mangled names for constructs introduced during the conversion to Viper.
+/* This file contains mangled names for constructs introduced during the conversion to Viper.
  *
  * See the NameEmbeddings file for guidelines on good name choices.
  */

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/NameMangler.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/NameMangler.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.conversion
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.formver.embeddings.embedName
+import org.jetbrains.kotlin.formver.embeddings.embedPropertyName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.Name
 
@@ -17,7 +18,7 @@ class NameMangler(
     returnLabelIndex: Int? = null
 ) {
     fun mangleParameterName(parameter: FirValueParameterSymbol) = substitutionParams[parameter.name]?.name ?: parameter.embedName()
-    fun mangleLocalPropertyName(property: FirPropertySymbol, scopeDepth: Int) = property.callableId.embedName(scopeDepth)
+    fun mangleLocalPropertyName(property: FirPropertySymbol, scopeDepth: Int) = property.callableId.embedPropertyName(scopeDepth)
 
     val mangledReturnLabelName: MangledName = ReturnLabelName(returnLabelIndex)
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -23,6 +23,7 @@ interface ProgramConversionContext {
 
     fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding
     fun embedType(type: ConeKotlinType): TypeEmbedding
+    fun embedType(symbol: FirFunctionSymbol<*>): TypeEmbedding
     fun embedType(exp: FirExpression): TypeEmbedding = embedType(exp.resolvedType)
     fun getField(field: FirPropertySymbol): FieldEmbedding?
     fun newAnonName(): AnonymousName

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/CastingDomain.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/CastingDomain.kt
@@ -45,7 +45,7 @@ object CastingDomain : BuiltinDomain("Casting") {
     // Prefer this cast method if you have access to a `TypeEmbedding`.
     // An example of where this is not the case is when defining generic domain axioms.
     fun cast(exp: Exp, newType: TypeEmbedding) =
-        cast(exp, newType.kotlinType, newType.viperType)
+        cast(exp, newType.runtimeType, newType.viperType)
 
     override val functions: List<DomainFunc> = listOf(castFunc)
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/TypingDomain.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/TypingDomain.kt
@@ -144,7 +144,7 @@ class TypeDomain(classes: List<ClassTypeEmbedding>) : BuiltinDomain(TYPE_DOMAIN_
         val isSubtype = createDomainFunc("isSubtype", listOf(Var("a", Type).decl(), Var("b", Type).decl()), Bool)
     }
 
-    val classTypes = classes.map { classTypeFunc(it.name) }
+    val classTypes = classes.map { classTypeFunc(it.className) }
 
     val nonNullableTypes = listOf(intType, booleanType, unitType, nothingType, anyType, functionType) + classTypes
     val types = nonNullableTypes + nullableTypeFunc
@@ -279,7 +279,7 @@ class TypeDomain(classes: List<ClassTypeEmbedding>) : BuiltinDomain(TYPE_DOMAIN_
         classes.flatMap { cls ->
             cls.superTypes.map { superType ->
                 createAnonymousDomainAxiom(
-                    isSubtype(cls.kotlinType, superType.kotlinType)
+                    isSubtype(cls.runtimeType, superType.runtimeType)
                 )
             }
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ExpEmbedding.kt
@@ -183,7 +183,7 @@ data class Is(val exp: ExpEmbedding, val comparisonType: TypeEmbedding) : ExpEmb
     override val type = BooleanTypeEmbedding
 
     override fun toViper() =
-        TypeDomain.isSubtype(TypeOfDomain.typeOf(exp.toViper()), comparisonType.kotlinType)
+        TypeDomain.isSubtype(TypeOfDomain.typeOf(exp.toViper()), comparisonType.runtimeType)
 }
 
 data class Cast(val exp: ExpEmbedding, override val type: TypeEmbedding) : ExpEmbedding {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/KotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/KotlinName.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Name corresponding to an entity in the original Kotlin code.
+ *
+ * This is a little more general than the `Name` type in Kotlin: we also use this
+ * to represent getters and setters, for example.
+ */
+sealed interface KotlinName : MangledName
+
+data class SimpleKotlinName(val name: Name) : KotlinName {
+    override val mangled: String = name.asStringStripSpecialMarkers()
+}
+
+abstract class PrefixedKotlinName(prefix: String, name: Name) : KotlinName {
+    override val mangled: String = "${prefix}_${name.asStringStripSpecialMarkers()}"
+}
+
+data class FunctionKotlinName(val name: Name) : PrefixedKotlinName("fun", name)
+data class MemberKotlinName(val name: Name) : PrefixedKotlinName("member", name)
+data class GetterKotlinName(val name: Name) : PrefixedKotlinName("getter", name)
+data class SetterKotlinName(val name: Name) : PrefixedKotlinName("setter", name)
+
+data class ClassKotlinName(val name: Name) : KotlinName {
+    override val mangled: String = "class_${name.asStringStripSpecialMarkers()}"
+}
+
+data object ConstructorKotlinName : KotlinName {
+    override val mangled: String = "constructor"
+}
+

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
@@ -9,151 +9,51 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertyAccessorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
-import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.isNullable
+import org.jetbrains.kotlin.formver.conversion.ProgramConversionContext
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 
-/**
- * This file contains classes to mangle names present in the Kotlin source.
+/* This file contains classes to mangle names present in the Kotlin source.
  *
  * Name components should be separated by dollar signs.
  * If there is a risk of collision, add a prefix.
  */
 
-interface FqMangledName : MangledName {
-    val packageName: FqName
-    val postfix: String
 
-    // We need to replace the dots in the package name as Viper doesn't allow dots in names
-    override val mangled: String
-        get() = "pkg\$${packageName.asString().replace('.', '$')}\$$postfix"
-}
-
-/**
- * Representation for Kotlin local variable names.
- */
-data class LocalName(val name: Name, val scopeDepth: Int) : MangledName {
-    override val mangled: String
-        get() = if (scopeDepth == 0) {
-            "local\$${name.asStringStripSpecialMarkers()}"
-        } else {
-            "local\$$scopeDepth\$${name.asStringStripSpecialMarkers()}"
-        }
-}
-
-data class ClassName(override val packageName: FqName, val className: Name) : FqMangledName {
-    override val postfix: String = "class_${className.asStringStripSpecialMarkers()}"
-}
-
-data class ClassConstructorName(val className: ClassName, val paramsTypeSignature: String) : MangledName {
-    override val mangled: String
-        get() = "${className.mangled}\$constructor\$${paramsTypeSignature}"
-}
-
-data class ClassFunctionName(val className: ClassName, val functionName: Name, val paramsTypeSignature: String) : MangledName {
-    override val mangled: String
-        get() = "${className.mangled}\$fun_${functionName.asStringStripSpecialMarkers()}\$${paramsTypeSignature}"
-}
-
-data class ClassMemberName(val className: ClassName, val name: Name) : MangledName {
-    override val mangled: String
-        get() = "${className.mangled}\$member_${name.asStringStripSpecialMarkers()}"
-}
-
-data class ClassMemberGetter(val className: ClassName, val name: Name) : MangledName {
-    override val mangled: String
-        get() = "${className.mangled}\$getter_${name.asStringStripSpecialMarkers()}"
-}
-
-data class ClassMemberSetter(val className: ClassName, val name: Name) : MangledName {
-    override val mangled: String
-        get() = "${className.mangled}\$setter_${name.asStringStripSpecialMarkers()}"
-}
-
-/**
- * Global name not associated with a class.
- */
-data class GlobalName(override val packageName: FqName, val name: Name) : FqMangledName {
-    override val postfix: String = "global$${name.asStringStripSpecialMarkers()}"
-}
-
-data class GlobalFunctionName(override val packageName: FqName, val name: Name, val typeSignature: String) : FqMangledName {
-    override val postfix: String = "global$${name.asStringStripSpecialMarkers()}$${typeSignature}"
-}
-
-/**
- * Mangle a type's name into an identifier supported by Viper.
- * When the type is Nullable, its name will be prefixed by `NT` (Nullable Type).
- * Otherwise, the prefix will be `T` (Type).
- */
-val ConeKotlinType.mangledName: String
-    get() {
-        val prefix = when (this.isNullable) {
-            true -> "NT" // Nullable Type
-            false -> "T" // Type
-        }
-        // Check if there are any type argument in type's name
-        val mangled = toString()
-            .replace("/", "_")
-            .replace(Regex("[? ]"), "")
-            .replace(Regex("[<>]"), "__")
-            .replace(",", "$")
-        return prefix + mangled
+fun CallableId.embedScopeName(): NameScope =
+    when (val id = this.classId) {
+        null -> GlobalScope(packageName)
+        else -> ClassScope(packageName, id.embedName())
     }
 
-/**
- * Create a `String` embedding the type names, joined together by a separator character (`$`).
- * This function is useful to handle cases with function overloading.
- */
-fun FirFunctionSymbol<*>.embedTypeSignature(): String = valueParameterSymbols.joinToString("$") { param ->
-    param.resolvedReturnType.mangledName
+fun CallableId.embedScoped(f: CallableId.() -> KotlinName) = ScopedKotlinName(embedScopeName(), f())
+fun CallableId.embedScopedWithType(type: TypeEmbedding, f: CallableId.() -> KotlinName) = ScopedKotlinName(embedScopeName(), f(), type)
+
+fun ClassId.embedName(): ScopedKotlinName = ScopedKotlinName(GlobalScope(packageFqName), ClassKotlinName(shortClassName))
+fun CallableId.embedGetterName(): ScopedKotlinName = embedScoped { GetterKotlinName(callableName) }
+fun CallableId.embedSetterName(): ScopedKotlinName = embedScoped { SetterKotlinName(callableName) }
+fun CallableId.embedMemberPropertyName(): MangledName = embedScoped { MemberKotlinName(callableName) }
+
+fun CallableId.embedPropertyName(scope: Int): MangledName = when {
+    isLocal -> ScopedKotlinName(LocalScope(scope), SimpleKotlinName(callableName))
+    className != null -> embedMemberPropertyName()
+    else -> throw IllegalStateException("Name is neither local nor bound to a class; we do not know how to handle this.")
 }
 
-// Parameters always have scope depth equal to zero
-fun FirValueParameterSymbol.embedName(): LocalName = LocalName(name, 0)
-
-fun FirPropertyAccessorSymbol.embedName(): MangledName {
-    val className = propertySymbol.callableId.classId!!.embedName()
-    val propertyName = propertySymbol.callableId.callableName
-    return when {
-        isGetter -> ClassMemberGetter(className, propertyName)
-        isSetter -> ClassMemberSetter(className, propertyName)
-        else -> throw IllegalStateException("A property accessor must be a setter or a getter!")
-    }
+fun FirValueParameterSymbol.embedName(): ScopedKotlinName = ScopedKotlinName(ParameterScope, SimpleKotlinName(name))
+fun FirPropertyAccessorSymbol.embedName(): MangledName = when {
+    isGetter -> callableId.embedGetterName()
+    isSetter -> callableId.embedSetterName()
+    else -> throw IllegalStateException("A property accessor must be a setter or a getter!")
 }
 
-fun FirFunctionSymbol<*>.embedName(): MangledName = when (this) {
+fun FirConstructorSymbol.embedName(ctx: ProgramConversionContext): MangledName =
+    callableId.embedScopedWithType(ctx.embedType(this)) { ConstructorKotlinName }
+
+fun FirFunctionSymbol<*>.embedName(ctx: ProgramConversionContext): MangledName = when (this) {
     is FirPropertyAccessorSymbol -> embedName()
-    is FirConstructorSymbol -> ClassConstructorName(callableId.classId!!.embedName(), embedTypeSignature())
-    else -> {
-        // When mangling the function name we have to take into account function overloading.
-        // To distinguish functions with the same name we use function's type signature.
-        // Both local/classes functions must be covered.
-        when {
-            callableId.className != null -> ClassFunctionName(
-                callableId.classId!!.embedName(),
-                callableId.callableName,
-                embedTypeSignature()
-            )
-            else -> GlobalFunctionName(callableId.packageName, callableId.callableName, embedTypeSignature())
-        }
-    }
+    is FirConstructorSymbol -> embedName(ctx)
+    else -> callableId.embedScopedWithType(ctx.embedType(this)) { FunctionKotlinName(callableId.callableName) }
 }
 
-fun CallableId.embedName(scope: Int): MangledName = when {
-    isLocal -> LocalName(callableName, scope)
-    className != null -> embedClassMemberName()
-    else -> GlobalName(packageName, callableName)
-}
-
-fun CallableId.embedClassMemberName(): MangledName {
-    // The !! is necessary since className is a property from a different package.
-    val name = ClassName(packageName, className!!.shortName())
-    return ClassMemberName(name, callableName)
-}
-
-fun ClassId.embedName() = ClassName(packageFqName, shortClassName)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameScope.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameScope.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.name.FqName
+
+sealed interface NameScope : MangledName
+
+interface PackagePrefixScope : NameScope {
+    val packageName: FqName
+    val suffix: String
+    override val mangled: String
+        get() = if (packageName.isRoot) {
+            suffix
+        } else {
+            "pkg\$${packageName.asViperString()}\$$suffix"
+        }
+}
+
+data class GlobalScope(override val packageName: FqName) : PackagePrefixScope {
+    override val suffix = "global"
+}
+
+// We use the embedded class name here.  It's not clear whether className.scope can be anything
+// but GlobalScope(packageName) here, but this approach makes the embedName implementation make
+// more sense.
+data class ClassScope(override val packageName: FqName, val className: ScopedKotlinName) : PackagePrefixScope {
+    override val suffix = "class_scope_${className.mangled}"
+}
+
+data object ParameterScope : NameScope {
+    override val mangled = "local"
+}
+
+data class LocalScope(val level: Int) : NameScope {
+    override val mangled = "local$level"
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ScopedKotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ScopedKotlinName.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.name.FqName
+
+/**
+ * Name of a Kotlin entity in the original program in a specified scope and optionally distinguished by type.
+ */
+data class ScopedKotlinName(val scope: NameScope, val name: KotlinName, val type: TypeEmbedding? = null) : MangledName {
+    override val mangled: String
+        get() = listOfNotNull(scope.mangled, name.mangled, type?.name?.mangled).joinToString("$")
+}
+
+fun FqName.asViperString() = asString().replace('.', '$')

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableSignature.kt
@@ -8,15 +8,32 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 
 /**
- * This embedding represents a signature of a callable object.
- * In case the method has a receiver it becomes the first argument of the function.
- * Example: Foo.bar(x: Int) --> Foo$bar(this: Foo, x: Int)
+ * This embedding represents a signature of a callable object without name information.
  */
+
 interface CallableSignature {
     val receiverType: TypeEmbedding?
     val paramTypes: List<TypeEmbedding>
     val returnType: TypeEmbedding
 
+    /**
+     * The flattened structure of the callable parameters: in case the callable has a receiver
+     * it becomes the first argument of the function.
+     *
+     * `Foo.(Int) -> Int --> (Foo, Int) -> Int`
+     */
     val formalArgTypes: List<TypeEmbedding>
         get() = listOfNotNull(receiverType) + paramTypes
 }
+
+/**
+ * An instance of `CallableSignature` that is guaranteed to be `data`.
+ */
+data class CallableSignatureData(
+    override val receiverType: TypeEmbedding?,
+    override val paramTypes: List<TypeEmbedding>,
+    override val returnType: TypeEmbedding,
+) : CallableSignature
+
+val CallableSignature.asData: CallableSignatureData
+    get() = CallableSignatureData(receiverType, paramTypes, returnType)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FunctionSignature.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.callables
+
+import org.jetbrains.kotlin.formver.conversion.ReturnVariableName
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+
+interface FunctionSignature : CallableSignature {
+    val receiver: VariableEmbedding?
+    val params: List<VariableEmbedding>
+
+    val returnVar
+        get() = VariableEmbedding(ReturnVariableName, returnType)
+    val formalArgs: List<VariableEmbedding>
+        get() = listOfNotNull(receiver) + params
+
+    override val receiverType: TypeEmbedding?
+        get() = receiver?.type
+    override val paramTypes: List<TypeEmbedding>
+        get() = params.map { it.type }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NamedFunctionSignature.kt
@@ -16,20 +16,8 @@ import org.jetbrains.kotlin.formver.viper.ast.Position
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 import org.jetbrains.kotlin.formver.viper.ast.Trafos
 
-interface NamedFunctionSignature : CallableSignature {
+interface NamedFunctionSignature : FunctionSignature {
     val name: MangledName
-    val receiver: VariableEmbedding?
-    val params: List<VariableEmbedding>
-
-    val returnVar
-        get() = VariableEmbedding(ReturnVariableName, returnType)
-    val formalArgs: List<VariableEmbedding>
-        get() = listOfNotNull(receiver) + params
-
-    override val receiverType: TypeEmbedding?
-        get() = receiver?.type
-    override val paramTypes: List<TypeEmbedding>
-        get() = params.map { it.type }
 }
 
 fun NamedFunctionSignature.toMethodCall(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialFunctions.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialFunctions.kt
@@ -7,14 +7,14 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.AnonymousName
 import org.jetbrains.kotlin.formver.conversion.SpecialName
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.LegacyUnspecifiedFunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.BuiltinFunction
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
 object DuplicableFunction : BuiltinFunction(SpecialName("duplicable")) {
-    private val thisArg = VariableEmbedding(AnonymousName(0), FunctionTypeEmbedding)
+    private val thisArg = VariableEmbedding(AnonymousName(0), LegacyUnspecifiedFunctionTypeEmbedding)
 
     override val formalArgs: List<Declaration.LocalVarDecl> = listOf(thisArg.toLocalVarDecl())
     override val retType: Type = Type.Bool

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialMethods.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialMethods.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 import org.jetbrains.kotlin.formver.conversion.AnonymousName
 import org.jetbrains.kotlin.formver.conversion.SpecialFields
 import org.jetbrains.kotlin.formver.conversion.SpecialName
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.LegacyUnspecifiedFunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.BuiltInMethod
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.*
 
 object InvokeFunctionObjectMethod : BuiltInMethod(SpecialName("invoke_function_object")) {
-    private val thisArg = VariableEmbedding(AnonymousName(0), FunctionTypeEmbedding)
+    private val thisArg = VariableEmbedding(AnonymousName(0), LegacyUnspecifiedFunctionTypeEmbedding)
     private val calls = EqCmp(
         Add(Old(thisArg.toFieldAccess(SpecialFields.FunctionObjectCallCounterField)), IntLit(1)),
         thisArg.toFieldAccess(SpecialFields.FunctionObjectCallCounterField)

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -1,5 +1,5 @@
 /calls_in_place.kt:(450,472): info: Generated Viper text for incorrect_at_most_once:
-method pkg$$global$incorrect_at_most_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_incorrect_at_most_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -11,14 +11,14 @@ method pkg$$global$incorrect_at_most_once$Tkotlin_Function1__kotlin_Int$kotlin_I
   var anonymous$1: Int
   var anonymous$2: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
-  anonymous$1 := pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f)
+  anonymous$1 := global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f)
   special$invoke_function_object(local$f)
   ret := anonymous$2
   goto label$ret
   label label$ret
 }
 
-method pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -27,13 +27,13 @@ method pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: R
   ensures true
 
 
-/calls_in_place.kt:(450,472): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_most_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__ might not hold. Assertion local$f.special$function_object_call_counter <= old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
+/calls_in_place.kt:(450,472): warning: Viper verification error: Postcondition of global$fun_incorrect_at_most_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$f.special$function_object_call_counter <= old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
 
 /calls_in_place.kt:(450,472): warning: Function incorrect_at_most_once may not satisfy its contract.
 
 /calls_in_place.kt:(661,683): info: Generated Viper text for incorrect_exactly_once:
-method pkg$$global$incorrect_exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_incorrect_exactly_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -52,13 +52,13 @@ method pkg$$global$incorrect_exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_I
   label label$ret
 }
 
-/calls_in_place.kt:(661,683): warning: Viper verification error: Postcondition of pkg$$global$incorrect_exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__ might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
+/calls_in_place.kt:(661,683): warning: Viper verification error: Postcondition of global$fun_incorrect_exactly_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
 
 /calls_in_place.kt:(661,683): warning: Function incorrect_exactly_once may not satisfy its contract.
 
 /calls_in_place.kt:(866,889): info: Generated Viper text for incorrect_at_least_once:
-method pkg$$global$incorrect_at_least_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_incorrect_at_least_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -69,13 +69,13 @@ method pkg$$global$incorrect_at_least_once$Tkotlin_Function1__kotlin_Int$kotlin_
 {
   var anonymous$1: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
-  anonymous$1 := pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f)
+  anonymous$1 := global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
-method pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -84,7 +84,7 @@ method pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: R
   ensures true
 
 
-/calls_in_place.kt:(866,889): warning: Viper verification error: Postcondition of pkg$$global$incorrect_at_least_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__ might not hold. Assertion local$f.special$function_object_call_counter > old(local$f.special$function_object_call_counter) might not hold. (<no position>)
+/calls_in_place.kt:(866,889): warning: Viper verification error: Postcondition of global$fun_incorrect_at_least_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$f.special$function_object_call_counter > old(local$f.special$function_object_call_counter) might not hold. (<no position>)
 
 
 /calls_in_place.kt:(866,889): warning: Function incorrect_at_least_once may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
@@ -1,5 +1,5 @@
 /calls_in_place_leak.kt:(364,386): info: Generated Viper text for invalid_calls_in_place:
-method pkg$$global$invalid_calls_in_place$Tkotlin_Function0__kotlin_Unit__(local$f: Ref)
+method global$fun_invalid_calls_in_place$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -9,11 +9,11 @@ method pkg$$global$invalid_calls_in_place$Tkotlin_Function0__kotlin_Unit__(local
 {
   var anonymous$1: dom$Unit
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
-  anonymous$1 := pkg$$global$escape$Tkotlin_Function0__kotlin_Unit__(local$f)
+  anonymous$1 := global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f)
   label label$ret
 }
 
-method pkg$$global$escape$Tkotlin_Function0__kotlin_Unit__(local$f: Ref)
+method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   requires special$duplicable(local$f)
@@ -22,7 +22,7 @@ method pkg$$global$escape$Tkotlin_Function0__kotlin_Unit__(local$f: Ref)
     local$f.special$function_object_call_counter
 
 
-/calls_in_place_leak.kt:(364,386): warning: Viper verification error: The precondition of method pkg$$global$escape$Tkotlin_Function0__kotlin_Unit__ might not hold. Assertion special$duplicable(local$f) might not hold. (<no position>)
+/calls_in_place_leak.kt:(364,386): warning: Viper verification error: The precondition of method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion special$duplicable(local$f) might not hold. (<no position>)
 
 
 /calls_in_place_leak.kt:(364,386): warning: Function invalid_calls_in_place may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/do_not_verify.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/do_not_verify.fir.diag.txt
@@ -1,5 +1,6 @@
 /do_not_verify.kt:(245,256): info: Generated Viper text for bad_returns:
-method pkg$$global$bad_returns$() returns (ret: Bool)
+method global$fun_bad_returns$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
   ensures ret == true
 {
   ret := false

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.fir.diag.txt
@@ -1,5 +1,5 @@
 /inlining_captured.kt:(354,365): info: Generated Viper text for nested_call:
-method pkg$$global$nested_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   ensures acc(local$g.special$function_object_call_counter, write)
@@ -30,13 +30,13 @@ method pkg$$global$nested_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$
   label label$ret
 }
 
-/inlining_captured.kt:(354,365): warning: Viper verification error: Postcondition of pkg$$global$nested_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__ might not hold. Assertion local$g.special$function_object_call_counter == old(local$g.special$function_object_call_counter) + 1 might not hold. (<no position>)
+/inlining_captured.kt:(354,365): warning: Viper verification error: Postcondition of global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$g.special$function_object_call_counter == old(local$g.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
 
 /inlining_captured.kt:(354,365): warning: Function nested_call may not satisfy its contract.
 
 /inlining_captured.kt:(585,596): info: Generated Viper text for double_call:
-method pkg$$global$double_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_double_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   ensures acc(local$g.special$function_object_call_counter, write)
@@ -67,7 +67,7 @@ method pkg$$global$double_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$
   label label$ret
 }
 
-/inlining_captured.kt:(585,596): warning: Viper verification error: Postcondition of pkg$$global$double_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__ might not hold. Assertion local$g.special$function_object_call_counter <= old(local$g.special$function_object_call_counter) + 1 might not hold. (<no position>)
+/inlining_captured.kt:(585,596): warning: Viper verification error: Postcondition of global$fun_double_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$g.special$function_object_call_counter <= old(local$g.special$function_object_call_counter) + 1 might not hold. (<no position>)
 
 
 /inlining_captured.kt:(585,596): warning: Function double_call may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -1,24 +1,24 @@
 /is_type_contract.kt:(121,142): info: Generated Viper text for unverifiableTypeCheck:
-field pkg$kotlin$class_String$member_length: Int
+field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
-method pkg$$global$unverifiableTypeCheck$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int])
   returns (ret: Bool)
   ensures true ==>
     dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Unit())
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
-  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$kotlin$class_String())
+  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$kotlin$global$class_String())
   goto label$ret
   label label$ret
 }
 
-/is_type_contract.kt:(121,142): warning: Viper verification error: Postcondition of pkg$$global$unverifiableTypeCheck$NTkotlin_Int might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Unit()) might not hold. (<no position>)
+/is_type_contract.kt:(121,142): warning: Viper verification error: Postcondition of global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Unit()) might not hold. (<no position>)
 
 
 /is_type_contract.kt:(121,142): warning: Function unverifiableTypeCheck may not satisfy its contract.
 
 /is_type_contract.kt:(289,311): info: Generated Viper text for nullableNotNonNullable:
-method pkg$$global$nullableNotNonNullable$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_nullableNotNonNullable$fun_take$NT_Int$return$T_Unit(local$x: dom$Nullable[Int])
   returns (ret: dom$Unit)
   ensures true ==>
     dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Int())
@@ -27,7 +27,7 @@ method pkg$$global$nullableNotNonNullable$NTkotlin_Int(local$x: dom$Nullable[Int
   label label$ret
 }
 
-/is_type_contract.kt:(289,311): warning: Viper verification error: Postcondition of pkg$$global$nullableNotNonNullable$NTkotlin_Int might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Int()) might not hold. (<no position>)
+/is_type_contract.kt:(289,311): warning: Viper verification error: Postcondition of global$fun_nullableNotNonNullable$fun_take$NT_Int$return$T_Unit might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Int()) might not hold. (<no position>)
 
 
 /is_type_contract.kt:(289,311): warning: Function nullableNotNonNullable may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_booleans.fir.diag.txt
@@ -1,5 +1,6 @@
 /returns_booleans.kt:(121,146): info: Generated Viper text for incorrectly_returns_false:
-method pkg$$global$incorrectly_returns_false$() returns (ret: Bool)
+method global$fun_incorrectly_returns_false$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
   ensures ret == true
 {
   ret := false
@@ -7,7 +8,7 @@ method pkg$$global$incorrectly_returns_false$() returns (ret: Bool)
   label label$ret
 }
 
-/returns_booleans.kt:(121,146): warning: Viper verification error: Postcondition of pkg$$global$incorrectly_returns_false$ might not hold. Assertion ret == true might not hold. (<no position>)
+/returns_booleans.kt:(121,146): warning: Viper verification error: Postcondition of global$fun_incorrectly_returns_false$fun_take$$return$T_Boolean might not hold. Assertion ret == true might not hold. (<no position>)
 
 
 /returns_booleans.kt:(121,146): warning: Function incorrectly_returns_false may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_null.kt:(121,146): info: Generated Viper text for returns_null_unverifiable:
-method pkg$$global$returns_null_unverifiable$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_returns_null_unverifiable$fun_take$NT_Int$return$NT_Int(local$x: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
   ensures true ==> false
@@ -10,13 +10,13 @@ method pkg$$global$returns_null_unverifiable$NTkotlin_Int(local$x: dom$Nullable[
   label label$ret
 }
 
-/returns_null.kt:(121,146): warning: Viper verification error: Postcondition of pkg$$global$returns_null_unverifiable$NTkotlin_Int might not hold. Assertion true ==> false might not hold. (<no position>)
+/returns_null.kt:(121,146): warning: Viper verification error: Postcondition of global$fun_returns_null_unverifiable$fun_take$NT_Int$return$NT_Int might not hold. Assertion true ==> false might not hold. (<no position>)
 
 
 /returns_null.kt:(121,146): warning: Function returns_null_unverifiable may not satisfy its contract.
 
 /returns_null.kt:(277,302): info: Generated Viper text for non_nullable_returns_null:
-method pkg$$global$non_nullable_returns_null$Tkotlin_Int(local$x: Int)
+method global$fun_non_nullable_returns_null$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
   ensures false
 {
@@ -25,7 +25,7 @@ method pkg$$global$non_nullable_returns_null$Tkotlin_Int(local$x: Int)
   label label$ret
 }
 
-/returns_null.kt:(277,302): warning: Viper verification error: Postcondition of pkg$$global$non_nullable_returns_null$Tkotlin_Int might not hold. Assertion false might not hold. (<no position>)
+/returns_null.kt:(277,302): warning: Viper verification error: Postcondition of global$fun_non_nullable_returns_null$fun_take$T_Int$return$T_Int might not hold. Assertion false might not hold. (<no position>)
 
 
 /returns_null.kt:(277,302): warning: Function non_nullable_returns_null may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/calls_in_place.fir.diag.txt
@@ -1,5 +1,5 @@
 /calls_in_place.kt:(162,169): info: Generated Viper text for unknown:
-method pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -16,7 +16,7 @@ method pkg$$global$unknown$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: R
 }
 
 /calls_in_place.kt:(309,321): info: Generated Viper text for at_most_once:
-method pkg$$global$at_most_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_at_most_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -34,7 +34,7 @@ method pkg$$global$at_most_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local
 }
 
 /calls_in_place.kt:(466,478): info: Generated Viper text for exactly_once:
-method pkg$$global$exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_exactly_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -52,7 +52,7 @@ method pkg$$global$exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local
 }
 
 /calls_in_place.kt:(623,636): info: Generated Viper text for at_least_once:
-method pkg$$global$at_least_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_at_least_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -63,13 +63,13 @@ method pkg$$global$at_least_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(loca
 {
   var anonymous$1: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
-  anonymous$1 := pkg$$global$exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f)
+  anonymous$1 := global$fun_exactly_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
-method pkg$$global$exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_exactly_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -80,7 +80,7 @@ method pkg$$global$exactly_once$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local
 
 
 /calls_in_place.kt:(800,809): info: Generated Viper text for loopWhile:
-method pkg$$global$loopWhile$Tkotlin_Function0__kotlin_Boolean__(local$lambda: Ref)
+method global$fun_loopWhile$fun_take$fun_take$$return$T_Boolean$return$T_Unit(local$lambda: Ref)
   returns (ret: dom$Unit)
   requires acc(local$lambda.special$function_object_call_counter, write)
   ensures acc(local$lambda.special$function_object_call_counter, write)
@@ -111,7 +111,7 @@ method pkg$$global$loopWhile$Tkotlin_Function0__kotlin_Boolean__(local$lambda: R
 }
 
 /calls_in_place.kt:(990,999): info: Generated Viper text for loopUntil:
-method pkg$$global$loopUntil$Tkotlin_Function0__kotlin_Boolean__(local$lambda: Ref)
+method global$fun_loopUntil$fun_take$fun_take$$return$T_Boolean$return$T_Unit(local$lambda: Ref)
   returns (ret: dom$Unit)
   requires acc(local$lambda.special$function_object_call_counter, write)
   ensures acc(local$lambda.special$function_object_call_counter, write)
@@ -142,7 +142,7 @@ method pkg$$global$loopUntil$Tkotlin_Function0__kotlin_Boolean__(local$lambda: R
 }
 
 /calls_in_place.kt:(1178,1181): info: Generated Viper text for run:
-method pkg$$global$run$Tkotlin_Function0__R__(local$block: Ref)
+method global$fun_run$fun_take$fun_take$$return$NT_Any$return$NT_Any(local$block: Ref)
   returns (ret: dom$Nullable[dom$Any])
   requires acc(local$block.special$function_object_call_counter, write)
   ensures acc(local$block.special$function_object_call_counter, write)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/inlining.fir.diag.txt
@@ -1,5 +1,5 @@
 /inlining.kt:(481,492): info: Generated Viper text for call_invoke:
-method pkg$$global$call_invoke$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_call_invoke$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   ensures acc(local$g.special$function_object_call_counter, write)
@@ -8,28 +8,28 @@ method pkg$$global$call_invoke$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$
   ensures local$g.special$function_object_call_counter >
     old(local$g.special$function_object_call_counter)
 {
-  var local$1$z: Int
+  var local1$z: Int
   var anonymous$1: Int
   var anonymous$4: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$g): dom$Type), dom$Type$Function())
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
     var anonymous$3: Int
     special$invoke_function_object(local$g)
-    local$2$x := anonymous$2
+    local2$x := anonymous$2
     special$invoke_function_object(local$g)
     anonymous$1 := anonymous$3
     goto inline_label$1$ret
     label inline_label$1$ret
   }
-  local$1$z := anonymous$1
+  local1$z := anonymous$1
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$5: Int
     var anonymous$6: Int
     special$invoke_function_object(local$g)
-    local$2$x := anonymous$5
+    local2$x := anonymous$5
     special$invoke_function_object(local$g)
     anonymous$4 := anonymous$6
     goto inline_label$1$ret
@@ -41,7 +41,7 @@ method pkg$$global$call_invoke$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$
 }
 
 /inlining.kt:(725,745): info: Generated Viper text for call_invoke_with_int:
-method pkg$$global$call_invoke_with_int$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_call_invoke_with_int$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   ensures acc(local$g.special$function_object_call_counter, write)
@@ -50,28 +50,28 @@ method pkg$$global$call_invoke_with_int$Tkotlin_Function1__kotlin_Int$kotlin_Int
   ensures local$g.special$function_object_call_counter >
     old(local$g.special$function_object_call_counter)
 {
-  var local$1$z: Int
+  var local1$z: Int
   var anonymous$1: Int
   var anonymous$4: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$g): dom$Type), dom$Type$Function())
   if (true) {
     var anonymous$2: Int
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$3: Int
     anonymous$2 := 1
-    local$2$x := anonymous$2 + anonymous$2
+    local2$x := anonymous$2 + anonymous$2
     special$invoke_function_object(local$g)
     anonymous$1 := anonymous$3
     goto inline_label$1$ret
     label inline_label$1$ret
   }
-  local$1$z := anonymous$1
+  local1$z := anonymous$1
   if (true) {
     var anonymous$5: Int
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$6: Int
     special$invoke_function_object(local$g)
-    local$2$x := anonymous$5 + anonymous$5
+    local2$x := anonymous$5 + anonymous$5
     special$invoke_function_object(local$g)
     anonymous$4 := anonymous$6
     goto inline_label$1$ret
@@ -83,7 +83,7 @@ method pkg$$global$call_invoke_with_int$Tkotlin_Function1__kotlin_Int$kotlin_Int
 }
 
 /inlining.kt:(1005,1017): info: Generated Viper text for name_clashes:
-method pkg$$global$name_clashes$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_name_clashes$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -92,26 +92,26 @@ method pkg$$global$name_clashes$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local
   ensures local$f.special$function_object_call_counter >
     old(local$f.special$function_object_call_counter)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: Int
   var anonymous$4: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
     var anonymous$3: Int
     special$invoke_function_object(local$f)
-    local$2$x := anonymous$2
+    local2$x := anonymous$2
     special$invoke_function_object(local$f)
     anonymous$1 := anonymous$3
     goto inline_label$1$ret
     label inline_label$1$ret
   }
-  local$1$x := anonymous$1
+  local1$x := anonymous$1
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$5: Int
-    local$2$x := local$1$x + local$1$x
+    local2$x := local1$x + local1$x
     special$invoke_function_object(local$f)
     anonymous$4 := anonymous$5
     goto inline_label$1$ret
@@ -123,7 +123,7 @@ method pkg$$global$name_clashes$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local
 }
 
 /inlining.kt:(1262,1283): info: Generated Viper text for different_return_type:
-method pkg$$global$different_return_type$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_different_return_type$fun_take$fun_take$T_Int$return$T_Int$return$T_Boolean(local$f: Ref)
   returns (ret: Bool)
   requires acc(local$f.special$function_object_call_counter, write)
   ensures acc(local$f.special$function_object_call_counter, write)
@@ -132,34 +132,34 @@ method pkg$$global$different_return_type$Tkotlin_Function1__kotlin_Int$kotlin_In
   ensures local$f.special$function_object_call_counter >
     old(local$f.special$function_object_call_counter)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: Int
   var anonymous$4: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
     var anonymous$3: Int
     special$invoke_function_object(local$f)
-    local$2$x := anonymous$2
+    local2$x := anonymous$2
     special$invoke_function_object(local$f)
     anonymous$1 := anonymous$3
     goto inline_label$1$ret
     label inline_label$1$ret
   }
-  local$1$x := anonymous$1
+  local1$x := anonymous$1
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$5: Int
     var anonymous$6: Int
     special$invoke_function_object(local$f)
-    local$2$x := anonymous$5
+    local2$x := anonymous$5
     special$invoke_function_object(local$f)
     anonymous$4 := anonymous$6
     goto inline_label$1$ret
     label inline_label$1$ret
   }
-  ret := local$1$x == anonymous$4
+  ret := local1$x == anonymous$4
   goto label$ret
   label label$ret
 }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/inlining_captured.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/inlining_captured.fir.diag.txt
@@ -1,5 +1,5 @@
 /inlining_captured.kt:(354,365): info: Generated Viper text for single_call:
-method pkg$$global$single_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_single_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   ensures acc(local$g.special$function_object_call_counter, write)
@@ -29,7 +29,7 @@ method pkg$$global$single_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$
 }
 
 /inlining_captured.kt:(582,593): info: Generated Viper text for double_call:
-method pkg$$global$double_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref,
+method global$fun_double_call$fun_take$fun_take$T_Int$return$T_Int$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref,
   local$g: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
@@ -69,7 +69,7 @@ method pkg$$global$double_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__$Tkotli
 }
 
 /inlining_captured.kt:(872,883): info: Generated Viper text for nested_call:
-method pkg$$global$nested_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref,
+method global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref,
   local$g: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,32 +1,33 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
-field pkg$kotlin$class_String$member_length: Int
+field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
-method pkg$$global$isString$NTkotlin_Any(local$x: dom$Nullable[dom$Any])
+method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullable[dom$Any])
   returns (ret: Bool)
   ensures ret == true ==>
-    dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$kotlin$class_String())
+    dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$kotlin$global$class_String())
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$kotlin$class_String())
+  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$kotlin$global$class_String())
   goto label$ret
   label label$ret
 }
 
 /is_type_contract.kt:(322,330): info: Generated Viper text for isString:
-field pkg$kotlin$class_String$member_length: Int
+field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
-method pkg$$global$isString$(this: dom$Any) returns (ret: Bool)
+method global$fun_isString$fun_take$T_Any$return$T_Boolean(this: dom$Any)
+  returns (ret: Bool)
   ensures ret == true ==>
-    dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$kotlin$class_String())
+    dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$kotlin$global$class_String())
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$Any())
-  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$kotlin$class_String())
+  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$kotlin$global$class_String())
   goto label$ret
   label label$ret
 }
 
 /is_type_contract.kt:(491,508): info: Generated Viper text for subtypeTransitive:
-method pkg$$global$subtypeTransitive$Tkotlin_Unit(local$x: dom$Unit)
+method global$fun_subtypeTransitive$fun_take$T_Unit$return$T_Unit(local$x: dom$Unit)
   returns (ret: dom$Unit)
   ensures true ==>
     dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
@@ -35,47 +36,50 @@ method pkg$$global$subtypeTransitive$Tkotlin_Unit(local$x: dom$Unit)
 }
 
 /is_type_contract.kt:(686,707): info: Generated Viper text for constructorReturnType:
-field pkg$$class_Foo$member_bar: Ref
+field class_scope_global$class_Foo$member_bar: Ref
 
-method pkg$$global$constructorReturnType$() returns (ret: Bool)
+method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
   ensures ret == true
 {
   var anonymous$1: Ref
-  anonymous$1 := pkg$$class_Foo$constructor$()
-  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$pkg$$class_Foo())
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  ret := dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$global$class_Foo())
   goto label$ret
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
 /is_type_contract.kt:(832,848): info: Generated Viper text for subtypeSuperType:
-field pkg$$class_Foo$member_bar: Ref
+field class_scope_global$class_Foo$member_bar: Ref
 
-method pkg$$global$subtypeSuperType$TBar(local$bar: Ref)
+method global$fun_subtypeSuperType$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
   ensures true ==>
-    dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Foo())
+    dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Foo())
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
   label label$ret
 }
 
 /is_type_contract.kt:(965,976): info: Generated Viper text for typeOfField:
-field pkg$$class_Foo$member_bar: Ref
+field class_scope_global$class_Foo$member_bar: Ref
 
-method pkg$$global$typeOfField$TFoo(local$foo: Ref) returns (ret: Bool)
+method global$fun_typeOfField$fun_take$T_class_global$class_Foo$return$T_Boolean(local$foo: Ref)
+  returns (ret: Bool)
   ensures ret == true
 {
   var anonymous$1: Ref
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$foo): dom$Type), dom$Type$pkg$$class_Foo())
-  inhale acc(local$foo.pkg$$class_Foo$member_bar, write)
-  anonymous$1 := local$foo.pkg$$class_Foo$member_bar
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$pkg$$class_Bar())
-  exhale acc(local$foo.pkg$$class_Foo$member_bar, write)
-  if (dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$pkg$$class_Bar())) {
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$foo): dom$Type), dom$Type$global$class_Foo())
+  inhale acc(local$foo.class_scope_global$class_Foo$member_bar, write)
+  anonymous$1 := local$foo.class_scope_global$class_Foo$member_bar
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$global$class_Bar())
+  exhale acc(local$foo.class_scope_global$class_Foo$member_bar, write)
+  if (dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$global$class_Bar())) {
     ret := true
     goto label$ret
   } else {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -1,5 +1,6 @@
 /returns_booleans.kt:(121,133): info: Generated Viper text for returns_true:
-method pkg$$global$returns_true$() returns (ret: Bool)
+method global$fun_returns_true$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
   ensures true
   ensures ret == true
 {
@@ -9,7 +10,8 @@ method pkg$$global$returns_true$() returns (ret: Bool)
 }
 
 /returns_booleans.kt:(268,281): info: Generated Viper text for returns_false:
-method pkg$$global$returns_false$() returns (ret: Bool)
+method global$fun_returns_false$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
   ensures true
   ensures ret == false
 {
@@ -19,7 +21,7 @@ method pkg$$global$returns_false$() returns (ret: Bool)
 }
 
 /returns_booleans.kt:(418,435): info: Generated Viper text for conditional_basic:
-method pkg$$global$conditional_basic$Tkotlin_Boolean(local$b: Bool)
+method global$fun_conditional_basic$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
   returns (ret: Bool)
   ensures ret == true ==> true
   ensures ret == false ==> local$b
@@ -30,7 +32,7 @@ method pkg$$global$conditional_basic$Tkotlin_Boolean(local$b: Bool)
 }
 
 /returns_booleans.kt:(612,636): info: Generated Viper text for binary_logic_expressions:
-method pkg$$global$binary_logic_expressions$Tkotlin_Boolean$Tkotlin_Boolean(local$a: Bool,
+method global$fun_binary_logic_expressions$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$a: Bool,
   local$b: Bool)
   returns (ret: Bool)
   ensures ret == false ==> local$b && false
@@ -42,7 +44,7 @@ method pkg$$global$binary_logic_expressions$Tkotlin_Boolean$Tkotlin_Boolean(loca
 }
 
 /returns_booleans.kt:(855,866): info: Generated Viper text for logical_not:
-method pkg$$global$logical_not$Tkotlin_Boolean(local$b: Bool)
+method global$fun_logical_not$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
   returns (ret: Bool)
   ensures ret == true ==> !local$b && local$b
   ensures ret == false ==> local$b || !local$b
@@ -53,21 +55,21 @@ method pkg$$global$logical_not$Tkotlin_Boolean(local$b: Bool)
 }
 
 /returns_booleans.kt:(1052,1075): info: Generated Viper text for call_fun_with_contracts:
-method pkg$$global$call_fun_with_contracts$Tkotlin_Boolean(local$b: Bool)
+method global$fun_call_fun_with_contracts$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
   returns (ret: Bool)
   ensures ret == true
 {
-  var local$1$a: Bool
+  var local1$a: Bool
   var anonymous$1: Bool
-  anonymous$1 := pkg$$global$binary_logic_expressions$Tkotlin_Boolean$Tkotlin_Boolean(local$b,
+  anonymous$1 := global$fun_binary_logic_expressions$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$b,
     local$b)
-  local$1$a := anonymous$1
-  ret := local$1$a
+  local1$a := anonymous$1
+  ret := local1$a
   goto label$ret
   label label$ret
 }
 
-method pkg$$global$binary_logic_expressions$Tkotlin_Boolean$Tkotlin_Boolean(local$a: Bool,
+method global$fun_binary_logic_expressions$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$a: Bool,
   local$b: Bool)
   returns (ret: Bool)
   ensures ret == false ==> local$b && false
@@ -75,25 +77,25 @@ method pkg$$global$binary_logic_expressions$Tkotlin_Boolean$Tkotlin_Boolean(loca
 
 
 /returns_booleans.kt:(1268,1281): info: Generated Viper text for isNullOrEmpty:
-method pkg$$global$isNullOrEmpty$(this: dom$Nullable[Ref])
+method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: dom$Nullable[Ref])
   returns (ret: Bool)
   ensures ret == false ==> this != (dom$Nullable$null(): dom$Nullable[Ref])
 {
   var anonymous$1: Bool
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$special$Nullable(dom$Type$pkg$kotlin$collections$class_Collection()))
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$special$Nullable(dom$Type$pkg$kotlin$collections$global$class_Collection()))
   if (this == (dom$Nullable$null(): dom$Nullable[Ref]) &&
   (dom$Nullable$null(): dom$Nullable[dom$Unit]) ==
   (dom$Nullable$null(): dom$Nullable[dom$Unit]) ||
   this != (dom$Nullable$null(): dom$Nullable[Ref]) &&
   (dom$Nullable$null(): dom$Nullable[dom$Unit]) !=
   (dom$Nullable$null(): dom$Nullable[dom$Unit]) &&
-  (dom$Casting$cast(this, dom$Type$pkg$kotlin$collections$class_Collection()): Ref) ==
-  (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]), dom$Type$pkg$kotlin$collections$class_Collection()): Ref)) {
+  (dom$Casting$cast(this, dom$Type$pkg$kotlin$collections$global$class_Collection()): Ref) ==
+  (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]), dom$Type$pkg$kotlin$collections$global$class_Collection()): Ref)) {
     anonymous$1 := true
   } else {
     var anonymous$2: Bool
-    anonymous$2 := pkg$kotlin$collections$class_Collection$fun_isEmpty$((dom$Casting$cast(this,
-      dom$Type$pkg$kotlin$collections$class_Collection()): Ref))
+    anonymous$2 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean((dom$Casting$cast(this,
+      dom$Type$pkg$kotlin$collections$global$class_Collection()): Ref))
     anonymous$1 := anonymous$2
   }
   ret := anonymous$1
@@ -101,6 +103,5 @@ method pkg$$global$isNullOrEmpty$(this: dom$Nullable[Ref])
   label label$ret
 }
 
-method pkg$kotlin$collections$class_Collection$fun_isEmpty$(this: Ref)
+method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: Ref)
   returns (ret: Bool)
-

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_null.kt:(121,140): info: Generated Viper text for simple_returns_null:
-method pkg$$global$simple_returns_null$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_simple_returns_null$fun_take$NT_Int$return$NT_Int(local$x: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
   ensures ret == (dom$Nullable$null(): dom$Nullable[Int])
@@ -12,7 +12,7 @@ method pkg$$global$simple_returns_null$NTkotlin_Int(local$x: dom$Nullable[Int])
 }
 
 /returns_null.kt:(300,320): info: Generated Viper text for returns_null_implies:
-method pkg$$global$returns_null_implies$NTkotlin_Boolean(local$x: dom$Nullable[Bool])
+method global$fun_returns_null_implies$fun_take$NT_Boolean$return$NT_Boolean(local$x: dom$Nullable[Bool])
   returns (ret: dom$Nullable[Bool])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Boolean()))
   ensures ret == (dom$Nullable$null(): dom$Nullable[Bool]) ==>
@@ -27,7 +27,7 @@ method pkg$$global$returns_null_implies$NTkotlin_Boolean(local$x: dom$Nullable[B
 }
 
 /returns_null.kt:(511,531): info: Generated Viper text for returns_null_with_if:
-method pkg$$global$returns_null_with_if$NTkotlin_Int$NTkotlin_Int$NTkotlin_Int(local$x: dom$Nullable[Int],
+method global$fun_returns_null_with_if$fun_take$NT_Int$NT_Int$NT_Int$return$NT_Int(local$x: dom$Nullable[Int],
   local$y: dom$Nullable[Int], local$z: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
@@ -60,7 +60,7 @@ method pkg$$global$returns_null_with_if$NTkotlin_Int$NTkotlin_Int$NTkotlin_Int(l
 }
 
 /returns_null.kt:(833,862): info: Generated Viper text for non_nullable_returns_not_null:
-method pkg$$global$non_nullable_returns_not_null$Tkotlin_Int(local$x: Int)
+method global$fun_non_nullable_returns_not_null$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
   ensures true
 {
@@ -70,7 +70,7 @@ method pkg$$global$non_nullable_returns_not_null$Tkotlin_Int(local$x: Int)
 }
 
 /returns_null.kt:(981,1010): info: Generated Viper text for non_nullable_compared_to_null:
-method pkg$$global$non_nullable_compared_to_null$Tkotlin_Int$Tkotlin_Int(local$x: Int,
+method global$fun_non_nullable_compared_to_null$fun_take$T_Int$T_Int$return$T_Int(local$x: Int,
   local$y: Int)
   returns (ret: Int)
   ensures true ==> false || true

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/simple.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/simple.fir.diag.txt
@@ -1,11 +1,13 @@
 /simple.kt:(84,100): info: Generated Viper text for without_contract:
-method pkg$$global$without_contract$() returns (ret: dom$Unit)
+method global$fun_without_contract$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   label label$ret
 }
 
 /simple.kt:(148,161): info: Generated Viper text for with_contract:
-method pkg$$global$with_contract$() returns (ret: dom$Unit)
+method global$fun_with_contract$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
   ensures true
 {
   label label$ret

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/any.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/any.fir.diag.txt
@@ -1,5 +1,5 @@
 /any.kt:(4,23): info: Generated Viper text for any_argument_return:
-method pkg$$global$any_argument_return$Tkotlin_Any(local$x: dom$Any)
+method global$fun_any_argument_return$fun_take$T_Any$return$T_Any(local$x: dom$Any)
   returns (ret: dom$Any)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$Any())
 {
@@ -10,7 +10,7 @@ method pkg$$global$any_argument_return$Tkotlin_Any(local$x: dom$Any)
 }
 
 /any.kt:(59,67): info: Generated Viper text for any_cast:
-method pkg$$global$any_cast$Tkotlin_Int(local$x: Int)
+method global$fun_any_cast$fun_take$T_Int$return$T_Any(local$x: Int)
   returns (ret: dom$Any)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$Any())
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/arithmetic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/arithmetic.fir.diag.txt
@@ -1,36 +1,36 @@
 /arithmetic.kt:(4,12): info: Generated Viper text for addition:
-method pkg$$global$addition$Tkotlin_Int(local$x: Int)
+method global$fun_addition$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
-  var local$1$y: Int
-  local$1$y := local$x + local$x
+  var local1$y: Int
+  local1$y := local$x + local$x
   label label$ret
 }
 
 /arithmetic.kt:(47,58): info: Generated Viper text for subtraction:
-method pkg$$global$subtraction$Tkotlin_Int(local$x: Int)
+method global$fun_subtraction$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
-  var local$1$y: Int
-  local$1$y := local$x - local$x
+  var local1$y: Int
+  local1$y := local$x - local$x
   label label$ret
 }
 
 /arithmetic.kt:(93,107): info: Generated Viper text for multiplication:
-method pkg$$global$multiplication$Tkotlin_Int(local$x: Int)
+method global$fun_multiplication$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
-  var local$1$y: Int
-  local$1$y := local$x * local$x
+  var local1$y: Int
+  local1$y := local$x * local$x
   label label$ret
 }
 
 /arithmetic.kt:(142,150): info: Generated Viper text for division:
-method pkg$$global$division$Tkotlin_Int(local$x: Int)
+method global$fun_division$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
-  var local$1$y: Int
+  var local1$y: Int
   inhale local$x != 0
-  local$1$y := local$x / local$x
+  local1$y := local$x / local$x
   label label$ret
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/basic.fir.diag.txt
@@ -1,11 +1,12 @@
 /basic.kt:(4,15): info: Generated Viper text for return_unit:
-method pkg$$global$return_unit$() returns (ret: dom$Unit)
+method global$fun_return_unit$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   label label$ret
 }
 
 /basic.kt:(25,35): info: Generated Viper text for return_int:
-method pkg$$global$return_int$() returns (ret: Int)
+method global$fun_return_int$fun_take$$return$T_Int() returns (ret: Int)
 {
   ret := 0
   goto label$ret
@@ -13,14 +14,14 @@ method pkg$$global$return_int$() returns (ret: Int)
 }
 
 /basic.kt:(60,80): info: Generated Viper text for take_int_return_unit:
-method pkg$$global$take_int_return_unit$Tkotlin_Int(local$x: Int)
+method global$fun_take_int_return_unit$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
   label label$ret
 }
 
 /basic.kt:(126,145): info: Generated Viper text for take_int_return_int:
-method pkg$$global$take_int_return_int$Tkotlin_Int(local$x: Int)
+method global$fun_take_int_return_int$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   ret := local$x
@@ -29,7 +30,7 @@ method pkg$$global$take_int_return_int$Tkotlin_Int(local$x: Int)
 }
 
 /basic.kt:(176,200): info: Generated Viper text for take_int_return_int_expr:
-method pkg$$global$take_int_return_int_expr$Tkotlin_Int(local$x: Int)
+method global$fun_take_int_return_int_expr$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   ret := local$x
@@ -38,20 +39,22 @@ method pkg$$global$take_int_return_int_expr$Tkotlin_Int(local$x: Int)
 }
 
 /basic.kt:(222,242): info: Generated Viper text for with_int_declaration:
-method pkg$$global$with_int_declaration$() returns (ret: Int)
+method global$fun_with_int_declaration$fun_take$$return$T_Int()
+  returns (ret: Int)
 {
-  var local$1$x: Int
-  local$1$x := 0
-  ret := local$1$x
+  var local1$x: Int
+  local1$x := 0
+  ret := local1$x
   goto label$ret
   label label$ret
 }
 
 /basic.kt:(285,299): info: Generated Viper text for int_assignment:
-method pkg$$global$int_assignment$() returns (ret: dom$Unit)
+method global$fun_int_assignment$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$x: Int
-  local$1$x := 0
-  local$1$x := 1
+  var local1$x: Int
+  local1$x := 0
+  local1$x := 1
   label label$ret
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/boolean_logic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/boolean_logic.fir.diag.txt
@@ -1,5 +1,5 @@
 /boolean_logic.kt:(4,12): info: Generated Viper text for negation:
-method pkg$$global$negation$Tkotlin_Boolean(local$x: Bool)
+method global$fun_negation$fun_take$T_Boolean$return$T_Boolean(local$x: Bool)
   returns (ret: Bool)
 {
   ret := !local$x
@@ -8,7 +8,7 @@ method pkg$$global$negation$Tkotlin_Boolean(local$x: Bool)
 }
 
 /boolean_logic.kt:(56,67): info: Generated Viper text for conjunction:
-method pkg$$global$conjunction$Tkotlin_Boolean$Tkotlin_Boolean(local$x: Bool,
+method global$fun_conjunction$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$x: Bool,
   local$y: Bool)
   returns (ret: Bool)
 {
@@ -23,16 +23,16 @@ method pkg$$global$conjunction$Tkotlin_Boolean$Tkotlin_Boolean(local$x: Bool,
 }
 
 /boolean_logic.kt:(127,151): info: Generated Viper text for conjunction_side_effects:
-method pkg$$global$conjunction_side_effects$Tkotlin_Boolean$Tkotlin_Boolean(local$x: Bool,
+method global$fun_conjunction_side_effects$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$x: Bool,
   local$y: Bool)
   returns (ret: Bool)
 {
   var anonymous$1: Bool
   var anonymous$2: Bool
-  anonymous$1 := pkg$$global$negation$Tkotlin_Boolean(local$x)
+  anonymous$1 := global$fun_negation$fun_take$T_Boolean$return$T_Boolean(local$x)
   if (anonymous$1) {
     var anonymous$3: Bool
-    anonymous$3 := pkg$$global$negation$Tkotlin_Boolean(local$y)
+    anonymous$3 := global$fun_negation$fun_take$T_Boolean$return$T_Boolean(local$y)
     anonymous$2 := anonymous$3
   } else {
     anonymous$2 := false}
@@ -41,12 +41,12 @@ method pkg$$global$conjunction_side_effects$Tkotlin_Boolean$Tkotlin_Boolean(loca
   label label$ret
 }
 
-method pkg$$global$negation$Tkotlin_Boolean(local$x: Bool)
+method global$fun_negation$fun_take$T_Boolean$return$T_Boolean(local$x: Bool)
   returns (ret: Bool)
 
 
 /boolean_logic.kt:(324,335): info: Generated Viper text for disjunction:
-method pkg$$global$disjunction$Tkotlin_Boolean$Tkotlin_Boolean(local$x: Bool,
+method global$fun_disjunction$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$x: Bool,
   local$y: Bool)
   returns (ret: Bool)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
@@ -1,90 +1,93 @@
 /class_constructors.kt:(389,411): info: Generated Viper text for onlySecondConstructors:
-field pkg$$class_Foo$member_a: Int
+field class_scope_global$class_Foo$member_a: Int
 
-method pkg$$global$onlySecondConstructors$() returns (ret: dom$Unit)
+method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$f1: Ref
+  var local1$f1: Ref
   var anonymous$1: Ref
-  var local$1$shouldBeOne: Int
+  var local1$shouldBeOne: Int
   var anonymous$2: Int
-  var local$1$f2: Ref
+  var local1$f2: Ref
   var anonymous$3: Ref
-  var local$1$shouldBeAnswer: Int
+  var local1$shouldBeAnswer: Int
   var anonymous$4: Int
-  var local$1$f3: Ref
+  var local1$f3: Ref
   var anonymous$5: Ref
-  var local$1$test: Int
+  var local1$test: Int
   var anonymous$6: Int
-  anonymous$1 := pkg$$class_Foo$constructor$Tkotlin_Boolean(true)
-  local$1$f1 := anonymous$1
-  inhale acc(local$1$f1.pkg$$class_Foo$member_a, write)
-  anonymous$2 := local$1$f1.pkg$$class_Foo$member_a
-  exhale acc(local$1$f1.pkg$$class_Foo$member_a, write)
-  local$1$shouldBeOne := anonymous$2
-  anonymous$3 := pkg$$class_Foo$constructor$Tkotlin_Int(42)
-  local$1$f2 := anonymous$3
-  inhale acc(local$1$f2.pkg$$class_Foo$member_a, write)
-  anonymous$4 := local$1$f2.pkg$$class_Foo$member_a
-  exhale acc(local$1$f2.pkg$$class_Foo$member_a, write)
-  local$1$shouldBeAnswer := anonymous$4
-  anonymous$5 := pkg$$class_Foo$constructor$Tkotlin_Int$Tkotlin_Int(10, 32)
-  local$1$f3 := anonymous$5
-  inhale acc(local$1$f3.pkg$$class_Foo$member_a, write)
-  anonymous$6 := local$1$f3.pkg$$class_Foo$member_a
-  exhale acc(local$1$f3.pkg$$class_Foo$member_a, write)
-  local$1$test := anonymous$6
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(true)
+  local1$f1 := anonymous$1
+  inhale acc(local1$f1.class_scope_global$class_Foo$member_a, write)
+  anonymous$2 := local1$f1.class_scope_global$class_Foo$member_a
+  exhale acc(local1$f1.class_scope_global$class_Foo$member_a, write)
+  local1$shouldBeOne := anonymous$2
+  anonymous$3 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
+  local1$f2 := anonymous$3
+  inhale acc(local1$f2.class_scope_global$class_Foo$member_a, write)
+  anonymous$4 := local1$f2.class_scope_global$class_Foo$member_a
+  exhale acc(local1$f2.class_scope_global$class_Foo$member_a, write)
+  local1$shouldBeAnswer := anonymous$4
+  anonymous$5 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
+    32)
+  local1$f3 := anonymous$5
+  inhale acc(local1$f3.class_scope_global$class_Foo$member_a, write)
+  anonymous$6 := local1$f3.class_scope_global$class_Foo$member_a
+  exhale acc(local1$f3.class_scope_global$class_Foo$member_a, write)
+  local1$test := anonymous$6
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$Tkotlin_Boolean(local$b: Bool)
+method class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Bool)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$class_Foo$constructor$Tkotlin_Int(local$n: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$class_Foo$constructor$Tkotlin_Int$Tkotlin_Int(local$x1: Int, local$x2: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Int,
+  local$x2: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
 /class_constructors.kt:(590,617): info: Generated Viper text for primaryAndSecondConstructor:
-field pkg$$class_Bar$member_a: Int
+field class_scope_global$class_Bar$member_a: Int
 
-method pkg$$global$primaryAndSecondConstructor$() returns (ret: dom$Unit)
+method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$b1: Ref
+  var local1$b1: Ref
   var anonymous$1: Ref
-  var local$1$shouldBeZero: Int
+  var local1$shouldBeZero: Int
   var anonymous$2: Int
-  var local$1$b2: Ref
+  var local1$b2: Ref
   var anonymous$3: Ref
-  var local$1$shouldBeAnswer: Int
+  var local1$shouldBeAnswer: Int
   var anonymous$4: Int
-  anonymous$1 := pkg$$class_Bar$constructor$Tkotlin_Boolean(false)
-  local$1$b1 := anonymous$1
-  inhale acc(local$1$b1.pkg$$class_Bar$member_a, write)
-  anonymous$2 := local$1$b1.pkg$$class_Bar$member_a
-  exhale acc(local$1$b1.pkg$$class_Bar$member_a, write)
-  local$1$shouldBeZero := anonymous$2
-  anonymous$3 := pkg$$class_Bar$constructor$Tkotlin_Int(42)
-  local$1$b2 := anonymous$3
-  inhale acc(local$1$b2.pkg$$class_Bar$member_a, write)
-  anonymous$4 := local$1$b2.pkg$$class_Bar$member_a
-  exhale acc(local$1$b2.pkg$$class_Bar$member_a, write)
-  local$1$shouldBeAnswer := anonymous$4
+  anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(false)
+  local1$b1 := anonymous$1
+  inhale acc(local1$b1.class_scope_global$class_Bar$member_a, write)
+  anonymous$2 := local1$b1.class_scope_global$class_Bar$member_a
+  exhale acc(local1$b1.class_scope_global$class_Bar$member_a, write)
+  local1$shouldBeZero := anonymous$2
+  anonymous$3 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(42)
+  local1$b2 := anonymous$3
+  inhale acc(local1$b2.class_scope_global$class_Bar$member_a, write)
+  anonymous$4 := local1$b2.class_scope_global$class_Bar$member_a
+  exhale acc(local1$b2.class_scope_global$class_Bar$member_a, write)
+  local1$shouldBeAnswer := anonymous$4
   label label$ret
 }
 
-method pkg$$class_Bar$constructor$Tkotlin_Boolean(local$b: Bool)
+method class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Bool)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
-method pkg$$class_Bar$constructor$Tkotlin_Int(local$a: Int)
+method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -1,48 +1,51 @@
 /classes.kt:(39,48): info: Generated Viper text for createFoo:
-field pkg$$class_Foo$member_a: Int
+field class_scope_global$class_Foo$member_a: Int
 
-field pkg$$class_Foo$member_b: Int
+field class_scope_global$class_Foo$member_b: Int
 
-method pkg$$global$createFoo$() returns (ret: dom$Unit)
+method global$fun_createFoo$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$f: Ref
+  var local1$f: Ref
   var anonymous$1: Ref
-  var local$1$fa: Int
+  var local1$fa: Int
   var anonymous$2: Int
-  var local$1$fb: Int
+  var local1$fb: Int
   var anonymous$3: Int
-  anonymous$1 := pkg$$class_Foo$constructor$Tkotlin_Int$Tkotlin_Int(10, 20)
-  local$1$f := anonymous$1
-  inhale acc(local$1$f.pkg$$class_Foo$member_a, write)
-  anonymous$2 := local$1$f.pkg$$class_Foo$member_a
-  exhale acc(local$1$f.pkg$$class_Foo$member_a, write)
-  local$1$fa := anonymous$2
-  inhale acc(local$1$f.pkg$$class_Foo$member_b, write)
-  anonymous$3 := local$1$f.pkg$$class_Foo$member_b
-  exhale acc(local$1$f.pkg$$class_Foo$member_b, write)
-  local$1$fb := anonymous$3
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
+    20)
+  local1$f := anonymous$1
+  inhale acc(local1$f.class_scope_global$class_Foo$member_a, write)
+  anonymous$2 := local1$f.class_scope_global$class_Foo$member_a
+  exhale acc(local1$f.class_scope_global$class_Foo$member_a, write)
+  local1$fa := anonymous$2
+  inhale acc(local1$f.class_scope_global$class_Foo$member_b, write)
+  anonymous$3 := local1$f.class_scope_global$class_Foo$member_b
+  exhale acc(local1$f.class_scope_global$class_Foo$member_b, write)
+  local1$fb := anonymous$3
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$Tkotlin_Int$Tkotlin_Int(local$a: Int, local$b: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
+  local$b: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
 /classes.kt:(147,156): info: Generated Viper text for createBar:
-field pkg$$class_Bar$member_a: dom$Nullable[Ref]
+field class_scope_global$class_Bar$member_a: dom$Nullable[Ref]
 
-method pkg$$global$createBar$() returns (ret: dom$Unit)
+method global$fun_createBar$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$b: Ref
+  var local1$b: Ref
   var anonymous$1: Ref
-  anonymous$1 := pkg$$class_Bar$constructor$NTBar((dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]),
-    dom$Type$special$Nullable(dom$Type$pkg$$class_Bar())): dom$Nullable[Ref]))
-  local$1$b := anonymous$1
+  anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar((dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]),
+    dom$Type$special$Nullable(dom$Type$global$class_Bar())): dom$Nullable[Ref]))
+  local1$b := anonymous$1
   label label$ret
 }
 
-method pkg$$class_Bar$constructor$NTBar(local$a: dom$Nullable[Ref])
+method class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: dom$Nullable[Ref])
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -1,112 +1,117 @@
 /classes_getters.kt:(195,205): info: Generated Viper text for testGetter:
-field pkg$$class_IntWrapper$member_n: Int
+field class_scope_global$class_IntWrapper$member_n: Int
 
-method pkg$$global$testGetter$() returns (ret: dom$Unit)
+method global$fun_testGetter$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$wrapper: Ref
+  var local1$wrapper: Ref
   var anonymous$1: Ref
-  var local$1$succ: Int
+  var local1$succ: Int
   var anonymous$2: Int
-  anonymous$1 := pkg$$class_IntWrapper$constructor$Tkotlin_Int(42)
-  local$1$wrapper := anonymous$1
-  anonymous$2 := pkg$$class_IntWrapper$getter_succ(local$1$wrapper)
-  local$1$succ := anonymous$2
+  anonymous$1 := class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
+  local1$wrapper := anonymous$1
+  anonymous$2 := pkg$special$global$getter_accessor(local1$wrapper)
+  local1$succ := anonymous$2
   label label$ret
 }
 
-method pkg$$class_IntWrapper$constructor$Tkotlin_Int(local$n: Int)
+method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
 
 
-method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
 
 
 /classes_getters.kt:(278,295): info: Generated Viper text for testCascadeGetter:
-field pkg$$class_Foo$member_a: Int
+field class_scope_global$class_Foo$member_a: Int
 
-field pkg$$class_Foo$member_b: Int
+field class_scope_global$class_Foo$member_b: Int
 
-field pkg$$class_Bar$member_f: Ref
+field class_scope_global$class_Bar$member_f: Ref
 
-method pkg$$global$testCascadeGetter$() returns (ret: dom$Unit)
+method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$foo: Ref
+  var local1$foo: Ref
   var anonymous$1: Ref
-  var local$1$bar: Ref
+  var local1$bar: Ref
   var anonymous$2: Ref
-  var local$1$bfa: Int
+  var local1$bfa: Int
   var anonymous$3: Ref
   var anonymous$4: Int
-  var local$1$bfb: Int
+  var local1$bfb: Int
   var anonymous$5: Ref
   var anonymous$6: Int
-  anonymous$1 := pkg$$class_Foo$constructor$Tkotlin_Int$Tkotlin_Int(10, 20)
-  local$1$foo := anonymous$1
-  anonymous$2 := pkg$$class_Bar$constructor$TFoo(local$1$foo)
-  local$1$bar := anonymous$2
-  inhale acc(local$1$bar.pkg$$class_Bar$member_f, write)
-  anonymous$3 := local$1$bar.pkg$$class_Bar$member_f
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$pkg$$class_Foo())
-  exhale acc(local$1$bar.pkg$$class_Bar$member_f, write)
-  inhale acc(anonymous$3.pkg$$class_Foo$member_a, write)
-  anonymous$4 := anonymous$3.pkg$$class_Foo$member_a
-  exhale acc(anonymous$3.pkg$$class_Foo$member_a, write)
-  local$1$bfa := anonymous$4
-  inhale acc(local$1$bar.pkg$$class_Bar$member_f, write)
-  anonymous$5 := local$1$bar.pkg$$class_Bar$member_f
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$5): dom$Type), dom$Type$pkg$$class_Foo())
-  exhale acc(local$1$bar.pkg$$class_Bar$member_f, write)
-  inhale acc(anonymous$5.pkg$$class_Foo$member_b, write)
-  anonymous$6 := anonymous$5.pkg$$class_Foo$member_b
-  exhale acc(anonymous$5.pkg$$class_Foo$member_b, write)
-  local$1$bfb := anonymous$6
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
+    20)
+  local1$foo := anonymous$1
+  anonymous$2 := class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local1$foo)
+  local1$bar := anonymous$2
+  inhale acc(local1$bar.class_scope_global$class_Bar$member_f, write)
+  anonymous$3 := local1$bar.class_scope_global$class_Bar$member_f
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$global$class_Foo())
+  exhale acc(local1$bar.class_scope_global$class_Bar$member_f, write)
+  inhale acc(anonymous$3.class_scope_global$class_Foo$member_a, write)
+  anonymous$4 := anonymous$3.class_scope_global$class_Foo$member_a
+  exhale acc(anonymous$3.class_scope_global$class_Foo$member_a, write)
+  local1$bfa := anonymous$4
+  inhale acc(local1$bar.class_scope_global$class_Bar$member_f, write)
+  anonymous$5 := local1$bar.class_scope_global$class_Bar$member_f
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$5): dom$Type), dom$Type$global$class_Foo())
+  exhale acc(local1$bar.class_scope_global$class_Bar$member_f, write)
+  inhale acc(anonymous$5.class_scope_global$class_Foo$member_b, write)
+  anonymous$6 := anonymous$5.class_scope_global$class_Foo$member_b
+  exhale acc(anonymous$5.class_scope_global$class_Foo$member_b, write)
+  local1$bfb := anonymous$6
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$Tkotlin_Int$Tkotlin_Int(local$a: Int, local$b: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
+  local$b: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$class_Bar$constructor$TFoo(local$f: Ref) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+method class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
 /classes_getters.kt:(401,425): info: Generated Viper text for testCascadeCustomGetters:
-field pkg$$class_IntWrapper$member_n: Int
+field class_scope_global$class_IntWrapper$member_n: Int
 
-field pkg$$class_IntWrapperContainer$member_i: Ref
+field class_scope_global$class_IntWrapperContainer$member_i: Ref
 
-method pkg$$global$testCascadeCustomGetters$() returns (ret: dom$Unit)
+method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$wrapper: Ref
+  var local1$wrapper: Ref
   var anonymous$1: Ref
   var anonymous$2: Ref
-  var local$1$succ: Int
+  var local1$succ: Int
   var anonymous$3: Ref
   var anonymous$4: Int
-  anonymous$1 := pkg$$class_IntWrapper$constructor$Tkotlin_Int(42)
-  anonymous$2 := pkg$$class_IntWrapperContainer$constructor$TIntWrapper(anonymous$1)
-  local$1$wrapper := anonymous$2
-  inhale acc(local$1$wrapper.pkg$$class_IntWrapperContainer$member_i, write)
-  anonymous$3 := local$1$wrapper.pkg$$class_IntWrapperContainer$member_i
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$pkg$$class_IntWrapper())
-  exhale acc(local$1$wrapper.pkg$$class_IntWrapperContainer$member_i, write)
-  anonymous$4 := pkg$$class_IntWrapper$getter_succ(anonymous$3)
-  local$1$succ := anonymous$4
+  anonymous$1 := class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
+  anonymous$2 := class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(anonymous$1)
+  local1$wrapper := anonymous$2
+  inhale acc(local1$wrapper.class_scope_global$class_IntWrapperContainer$member_i, write)
+  anonymous$3 := local1$wrapper.class_scope_global$class_IntWrapperContainer$member_i
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$global$class_IntWrapper())
+  exhale acc(local1$wrapper.class_scope_global$class_IntWrapperContainer$member_i, write)
+  anonymous$4 := pkg$special$global$getter_accessor(anonymous$3)
+  local1$succ := anonymous$4
   label label$ret
 }
 
-method pkg$$class_IntWrapperContainer$constructor$TIntWrapper(local$i: Ref)
+method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapperContainer())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
 
 
-method pkg$$class_IntWrapper$constructor$Tkotlin_Int(local$n: Int)
+method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_IntWrapper())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
 
 
-method pkg$$class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
-
+method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -1,133 +1,141 @@
 /classes_setters.kt:(408,424): info: Generated Viper text for testCustomSetter:
-field pkg$$class_AlwaysPlusOne$member_b: Int
+field class_scope_global$class_AlwaysPlusOne$member_b: Int
 
-field pkg$$class_AlwaysPlusOne$member_num: Int
+field class_scope_global$class_AlwaysPlusOne$member_num: Int
 
-method pkg$$global$testCustomSetter$() returns (ret: dom$Unit)
+method global$fun_testCustomSetter$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$f: Ref
+  var local1$f: Ref
   var anonymous$1: Ref
   var anonymous$2: dom$Unit
-  anonymous$1 := pkg$$class_AlwaysPlusOne$constructor$()
-  local$1$f := anonymous$1
-  inhale acc(local$1$f.pkg$$class_AlwaysPlusOne$member_b, write)
-  local$1$f.pkg$$class_AlwaysPlusOne$member_b := 1
-  exhale acc(local$1$f.pkg$$class_AlwaysPlusOne$member_b, write)
-  anonymous$2 := pkg$$class_AlwaysPlusOne$setter_num(local$1$f, 1)
+  anonymous$1 := class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
+  local1$f := anonymous$1
+  inhale acc(local1$f.class_scope_global$class_AlwaysPlusOne$member_b, write)
+  local1$f.class_scope_global$class_AlwaysPlusOne$member_b := 1
+  exhale acc(local1$f.class_scope_global$class_AlwaysPlusOne$member_b, write)
+  anonymous$2 := pkg$special$global$setter_accessor(local1$f, 1)
   label label$ret
 }
 
-method pkg$$class_AlwaysPlusOne$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_AlwaysPlusOne())
+method class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_AlwaysPlusOne())
 
 
-method pkg$$class_AlwaysPlusOne$getter_num(this: Ref) returns (ret: Int)
+method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
 
 
-method pkg$$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
+method pkg$special$global$setter_accessor(this: Ref, local$value: Int)
   returns (ret: dom$Unit)
 
 
 /classes_setters.kt:(490,500): info: Generated Viper text for testSetter:
-field pkg$$class_Person$member_age: Int
+field class_scope_global$class_Person$member_age: Int
 
-method pkg$$global$testSetter$() returns (ret: dom$Unit)
+method global$fun_testSetter$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$person: Ref
+  var local1$person: Ref
   var anonymous$1: Ref
   var anonymous$2: Int
-  anonymous$1 := pkg$$class_Person$constructor$Tkotlin_Int(19)
-  local$1$person := anonymous$1
-  inhale acc(local$1$person.pkg$$class_Person$member_age, write)
-  anonymous$2 := local$1$person.pkg$$class_Person$member_age
-  exhale acc(local$1$person.pkg$$class_Person$member_age, write)
-  inhale acc(local$1$person.pkg$$class_Person$member_age, write)
-  local$1$person.pkg$$class_Person$member_age := anonymous$2 + 1
-  exhale acc(local$1$person.pkg$$class_Person$member_age, write)
+  anonymous$1 := class_scope_global$class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(19)
+  local1$person := anonymous$1
+  inhale acc(local1$person.class_scope_global$class_Person$member_age, write)
+  anonymous$2 := local1$person.class_scope_global$class_Person$member_age
+  exhale acc(local1$person.class_scope_global$class_Person$member_age, write)
+  inhale acc(local1$person.class_scope_global$class_Person$member_age, write)
+  local1$person.class_scope_global$class_Person$member_age := anonymous$2 +
+    1
+  exhale acc(local1$person.class_scope_global$class_Person$member_age, write)
   label label$ret
 }
 
-method pkg$$class_Person$constructor$Tkotlin_Int(local$age: Int)
+method class_scope_global$class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(local$age: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Person())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Person())
 
 
 /classes_setters.kt:(572,589): info: Generated Viper text for testSetterCascade:
-field pkg$$class_Bar$member_a: Int
+field class_scope_global$class_Bar$member_a: Int
 
-field pkg$$class_Foo$member_b: Ref
+field class_scope_global$class_Foo$member_b: Ref
 
-method pkg$$global$testSetterCascade$() returns (ret: dom$Unit)
+method global$fun_testSetterCascade$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$f: Ref
+  var local1$f: Ref
   var anonymous$1: Ref
   var anonymous$2: Ref
   var anonymous$3: Ref
-  anonymous$1 := pkg$$class_Bar$constructor$Tkotlin_Int(10)
-  anonymous$2 := pkg$$class_Foo$constructor$TBar(anonymous$1)
-  local$1$f := anonymous$2
-  inhale acc(local$1$f.pkg$$class_Foo$member_b, write)
-  anonymous$3 := local$1$f.pkg$$class_Foo$member_b
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$pkg$$class_Bar())
-  exhale acc(local$1$f.pkg$$class_Foo$member_b, write)
-  inhale acc(anonymous$3.pkg$$class_Bar$member_a, write)
-  anonymous$3.pkg$$class_Bar$member_a := 42
-  exhale acc(anonymous$3.pkg$$class_Bar$member_a, write)
+  anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(10)
+  anonymous$2 := class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(anonymous$1)
+  local1$f := anonymous$2
+  inhale acc(local1$f.class_scope_global$class_Foo$member_b, write)
+  anonymous$3 := local1$f.class_scope_global$class_Foo$member_b
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$global$class_Bar())
+  exhale acc(local1$f.class_scope_global$class_Foo$member_b, write)
+  inhale acc(anonymous$3.class_scope_global$class_Bar$member_a, write)
+  anonymous$3.class_scope_global$class_Bar$member_a := 42
+  exhale acc(anonymous$3.class_scope_global$class_Bar$member_a, write)
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$TBar(local$b: Ref) returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
-
-
-method pkg$$class_Bar$constructor$Tkotlin_Int(local$a: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
+method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
 /classes_setters.kt:(641,665): info: Generated Viper text for testSetterNoBackingField:
-field pkg$$class_Baz$member__a: Int
+field class_scope_global$class_Baz$member__a: Int
 
-method pkg$$global$testSetterNoBackingField$() returns (ret: dom$Unit)
+method global$fun_testSetterNoBackingField$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$baz: Ref
+  var local1$baz: Ref
   var anonymous$1: Ref
   var anonymous$2: dom$Unit
-  anonymous$1 := pkg$$class_Baz$constructor$()
-  local$1$baz := anonymous$1
-  anonymous$2 := pkg$$class_Baz$setter_a(local$1$baz, 42)
+  anonymous$1 := class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
+  local1$baz := anonymous$1
+  anonymous$2 := pkg$special$global$setter_accessor(local1$baz, 42)
   label label$ret
 }
 
-method pkg$$class_Baz$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Baz())
+method class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Baz())
 
 
-method pkg$$class_Baz$getter_a(this: Ref) returns (ret: Int)
+method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
 
 
-method pkg$$class_Baz$setter_a(this: Ref, local$value: Int)
+method pkg$special$global$setter_accessor(this: Ref, local$value: Int)
   returns (ret: dom$Unit)
 
 
 /classes_setters.kt:(805,821): info: Generated Viper text for testSetterLambda:
-field pkg$$class_Bar$member_a: Int
+field class_scope_global$class_Bar$member_a: Int
 
-method pkg$$global$testSetterLambda$() returns (ret: dom$Unit)
+method global$fun_testSetterLambda$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: dom$Unit
   if (true) {
     var anonymous$2: Ref
-    anonymous$2 := pkg$$class_Bar$constructor$Tkotlin_Int(0)
-    inhale acc(anonymous$2.pkg$$class_Bar$member_a, write)
-    anonymous$2.pkg$$class_Bar$member_a := 42
-    exhale acc(anonymous$2.pkg$$class_Bar$member_a, write)
+    anonymous$2 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(0)
+    inhale acc(anonymous$2.class_scope_global$class_Bar$member_a, write)
+    anonymous$2.class_scope_global$class_Bar$member_a := 42
+    exhale acc(anonymous$2.class_scope_global$class_Bar$member_a, write)
     label inline_label$1$ret
   }
   label label$ret
 }
 
-method pkg$$class_Bar$constructor$Tkotlin_Int(local$a: Int)
+method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
-
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
@@ -1,23 +1,24 @@
 /exp_side_effects.kt:(27,34): info: Generated Viper text for get_foo:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-method pkg$$global$get_foo$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 {
   var anonymous$1: Ref
-  anonymous$1 := pkg$$class_Foo$constructor$Tkotlin_Int(0)
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(0)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$Tkotlin_Int(local$x: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
 /exp_side_effects.kt:(55,66): info: Generated Viper text for side_effect:
-method pkg$$global$side_effect$() returns (ret: Int)
+method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)
 {
   ret := 0
   goto label$ret
@@ -25,33 +26,33 @@ method pkg$$global$side_effect$() returns (ret: Int)
 }
 
 /exp_side_effects.kt:(83,87): info: Generated Viper text for test:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-method pkg$$global$test$() returns (ret: dom$Unit)
+method global$fun_test$fun_take$$return$T_Unit() returns (ret: dom$Unit)
 {
   var anonymous$1: Ref
   var anonymous$2: Int
-  var local$1$y: Int
+  var local1$y: Int
   var anonymous$3: Ref
   var anonymous$4: Int
   var anonymous$5: Int
-  anonymous$1 := pkg$$global$get_foo$()
-  anonymous$2 := pkg$$global$side_effect$()
-  inhale acc(anonymous$1.pkg$$class_Foo$member_x, write)
-  anonymous$1.pkg$$class_Foo$member_x := anonymous$2
-  exhale acc(anonymous$1.pkg$$class_Foo$member_x, write)
-  anonymous$3 := pkg$$global$get_foo$()
-  inhale acc(anonymous$3.pkg$$class_Foo$member_x, write)
-  anonymous$4 := anonymous$3.pkg$$class_Foo$member_x
-  exhale acc(anonymous$3.pkg$$class_Foo$member_x, write)
-  anonymous$5 := pkg$$global$side_effect$()
-  local$1$y := anonymous$4 + anonymous$5
+  anonymous$1 := global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
+  anonymous$2 := global$fun_side_effect$fun_take$$return$T_Int()
+  inhale acc(anonymous$1.class_scope_global$class_Foo$member_x, write)
+  anonymous$1.class_scope_global$class_Foo$member_x := anonymous$2
+  exhale acc(anonymous$1.class_scope_global$class_Foo$member_x, write)
+  anonymous$3 := global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
+  inhale acc(anonymous$3.class_scope_global$class_Foo$member_x, write)
+  anonymous$4 := anonymous$3.class_scope_global$class_Foo$member_x
+  exhale acc(anonymous$3.class_scope_global$class_Foo$member_x, write)
+  anonymous$5 := global$fun_side_effect$fun_take$$return$T_Int()
+  local1$y := anonymous$4 + anonymous$5
   label label$ret
 }
 
-method pkg$$global$get_foo$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$global$side_effect$() returns (ret: Int)
-
+method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
@@ -1,5 +1,6 @@
 /extension_function.kt:(8,11): info: Generated Viper text for inc:
-method pkg$$global$inc$(this: Int) returns (ret: Int)
+method global$fun_inc$fun_take$T_Int$return$T_Int(this: Int)
+  returns (ret: Int)
 {
   ret := this + 1
   goto label$ret
@@ -7,12 +8,13 @@ method pkg$$global$inc$(this: Int) returns (ret: Int)
 }
 
 /extension_function.kt:(35,56): info: Generated Viper text for extension_method_call:
-method pkg$$global$extension_method_call$() returns (ret: dom$Unit)
+method global$fun_extension_method_call$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: Int
-  anonymous$1 := pkg$kotlin$class_Int$fun_inc$(3)
+  anonymous$1 := pkg$kotlin$class_scope_pkg$kotlin$global$class_Int$fun_inc$fun_take$T_Int$return$T_Int(3)
   label label$ret
 }
 
-method pkg$kotlin$class_Int$fun_inc$(this: Int) returns (ret: Int)
-
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_Int$fun_inc$fun_take$T_Int$return$T_Int(this: Int)
+  returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -1,4 +1,4 @@
-/full_viper_dump.kt:(4,5): info: Generated Viper text for f:
+/full_viper_dump.kt:(54,55): info: Generated Viper text for f:
 domain dom$Unit  {
 
   function dom$Unit$element(): dom$Unit
@@ -90,6 +90,8 @@ domain dom$Type  {
 
   unique function dom$Type$Function(): dom$Type
 
+  unique function dom$Type$global$class_Foo(): dom$Type
+
   function dom$Type$special$Nullable(t: dom$Type): dom$Type
 
   function dom$Type$isSubtype(a: dom$Type, b: dom$Type): Bool
@@ -133,6 +135,12 @@ domain dom$Type  {
   }
 
   axiom {
+    (forall t: dom$Type ::
+      { dom$Type$special$Nullable(t) }
+      dom$Type$special$Nullable(t) != dom$Type$global$class_Foo())
+  }
+
+  axiom {
     !dom$Type$is_nullable_type(dom$Type$Int())
   }
 
@@ -154,6 +162,10 @@ domain dom$Type  {
 
   axiom {
     !dom$Type$is_nullable_type(dom$Type$Function())
+  }
+
+  axiom {
+    !dom$Type$is_nullable_type(dom$Type$global$class_Foo())
   }
 
   axiom {
@@ -184,6 +196,10 @@ domain dom$Type  {
 
   axiom {
     dom$Type$isSubtype(dom$Type$Function(), dom$Type$Any())
+  }
+
+  axiom {
+    dom$Type$isSubtype(dom$Type$global$class_Foo(), dom$Type$Any())
   }
 
   axiom {
@@ -232,6 +248,10 @@ domain dom$Type  {
       { dom$Type$isSubtype(dom$Type$Nothing(), t) }
       dom$Type$isSubtype(dom$Type$Nothing(), t))
   }
+
+  axiom {
+    dom$Type$isSubtype(dom$Type$global$class_Foo(), dom$Type$Any())
+  }
 }
 
 domain dom$Any  {
@@ -240,6 +260,8 @@ domain dom$Any  {
 }
 
 field special$function_object_call_counter: Int
+
+field class_scope_global$class_Foo$member_x: Int
 
 function special$duplicable(anonymous$0: Ref): Bool
 
@@ -251,7 +273,15 @@ method special$invoke_function_object(anonymous$0: Ref)
     anonymous$0.special$function_object_call_counter
 
 
-method pkg$$global$f$() returns (ret: dom$Unit)
+method global$fun_f$fun_take$$return$T_Unit() returns (ret: dom$Unit)
 {
+  var local1$foo: Ref
+  var anonymous$1: Ref
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(0)
+  local1$foo := anonymous$1
   label label$ret
 }
+
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.kt
@@ -1,1 +1,6 @@
-fun <!VIPER_TEXT!>f<!>() {}
+// Check class generation.
+class Foo(val x: Int)
+
+fun <!VIPER_TEXT!>f<!>() {
+    val foo = Foo(0)
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
@@ -1,27 +1,30 @@
 /function_call.kt:(99,112): info: Generated Viper text for function_call:
-method pkg$$global$function_call$() returns (ret: dom$Unit)
+method global$fun_function_call$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: Int
   var anonymous$2: Int
-  anonymous$1 := pkg$$global$f$Tkotlin_Int(0)
-  anonymous$2 := pkg$$global$f$Tkotlin_Int(0)
+  anonymous$1 := global$fun_f$fun_take$T_Int$return$T_Int(0)
+  anonymous$2 := global$fun_f$fun_take$T_Int$return$T_Int(0)
   label label$ret
 }
 
-method pkg$$global$f$Tkotlin_Int(local$x: Int) returns (ret: Int)
+method global$fun_f$fun_take$T_Int$return$T_Int(local$x: Int)
+  returns (ret: Int)
 
 
 /function_call.kt:(142,162): info: Generated Viper text for function_call_nested:
-method pkg$$global$function_call_nested$() returns (ret: dom$Unit)
+method global$fun_function_call_nested$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: Int
   var anonymous$2: Int
   var anonymous$3: Int
-  anonymous$1 := pkg$$global$f$Tkotlin_Int(0)
-  anonymous$2 := pkg$$global$f$Tkotlin_Int(anonymous$1)
-  anonymous$3 := pkg$$global$f$Tkotlin_Int(anonymous$2)
+  anonymous$1 := global$fun_f$fun_take$T_Int$return$T_Int(0)
+  anonymous$2 := global$fun_f$fun_take$T_Int$return$T_Int(anonymous$1)
+  anonymous$3 := global$fun_f$fun_take$T_Int$return$T_Int(anonymous$2)
   label label$ret
 }
 
-method pkg$$global$f$Tkotlin_Int(local$x: Int) returns (ret: Int)
-
+method global$fun_f$fun_take$T_Int$return$T_Int(local$x: Int)
+  returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
@@ -1,5 +1,5 @@
 /function_object.kt:(4,17): info: Generated Viper text for unit_function:
-method pkg$$global$unit_function$Tkotlin_Function0__kotlin_Unit__(local$f: Ref)
+method global$fun_unit_function$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   requires special$duplicable(local$f)
@@ -12,7 +12,7 @@ method pkg$$global$unit_function$Tkotlin_Function0__kotlin_Unit__(local$f: Ref)
 }
 
 /function_object.kt:(72,92): info: Generated Viper text for function_object_call:
-method pkg$$global$function_object_call$Tkotlin_Function2__kotlin_Boolean$kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_function_object_call$fun_take$fun_take$T_Boolean$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   requires special$duplicable(local$g)
@@ -29,7 +29,7 @@ method pkg$$global$function_object_call$Tkotlin_Function2__kotlin_Boolean$kotlin
 }
 
 /function_object.kt:(155,182): info: Generated Viper text for function_object_nested_call:
-method pkg$$global$function_object_nested_call$Tkotlin_Function1__kotlin_Int$kotlin_Int__$Tkotlin_Function1__kotlin_Boolean$kotlin_Int__(local$f: Ref,
+method global$fun_function_object_nested_call$fun_take$fun_take$T_Int$return$T_Int$fun_take$T_Boolean$return$T_Int$return$T_Int(local$f: Ref,
   local$g: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -1,51 +1,56 @@
 /function_overloading.kt:(30,33): info: Generated Viper text for baz:
-method pkg$$class_Bar$fun_baz$TFoo(this: Ref, local$f: Ref)
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
+  local$f: Ref)
   returns (ret: dom$Unit)
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Bar())
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$pkg$$class_Foo())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Bar())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$global$class_Foo())
   label label$ret
 }
 
 /function_overloading.kt:(55,58): info: Generated Viper text for baz:
-method pkg$$class_Bar$fun_baz$TBar(this: Ref, local$b: Ref)
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
+  local$b: Ref)
   returns (ret: dom$Unit)
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Bar())
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$b): dom$Type), dom$Type$pkg$$class_Bar())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Bar())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$b): dom$Type), dom$Type$global$class_Bar())
   label label$ret
 }
 
 /function_overloading.kt:(79,88): info: Generated Viper text for fakePrint:
-method pkg$$global$fakePrint$TBar(local$b: Ref) returns (ret: dom$Unit)
+method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
+  returns (ret: dom$Unit)
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$b): dom$Type), dom$Type$pkg$$class_Bar())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$b): dom$Type), dom$Type$global$class_Bar())
   label label$ret
 }
 
 /function_overloading.kt:(106,115): info: Generated Viper text for fakePrint:
-method pkg$$global$fakePrint$TFoo(local$f: Ref) returns (ret: dom$Unit)
+method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
+  returns (ret: dom$Unit)
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$pkg$$class_Foo())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$global$class_Foo())
   label label$ret
 }
 
 /function_overloading.kt:(133,142): info: Generated Viper text for fakePrint:
-method pkg$$global$fakePrint$Tkotlin_Int(local$value: Int)
+method global$fun_fakePrint$fun_take$T_Int$return$T_Unit(local$value: Int)
   returns (ret: dom$Unit)
 {
   label label$ret
 }
 
 /function_overloading.kt:(164,173): info: Generated Viper text for fakePrint:
-method pkg$$global$fakePrint$Tkotlin_Boolean(local$truth: Bool)
+method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
   returns (ret: dom$Unit)
 {
   label label$ret
 }
 
 /function_overloading.kt:(200,226): info: Generated Viper text for testGlobalScopeOverloading:
-method pkg$$global$testGlobalScopeOverloading$() returns (ret: dom$Unit)
+method global$fun_testGlobalScopeOverloading$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: dom$Unit
   var anonymous$2: dom$Unit
@@ -53,67 +58,77 @@ method pkg$$global$testGlobalScopeOverloading$() returns (ret: dom$Unit)
   var anonymous$4: dom$Unit
   var anonymous$5: Ref
   var anonymous$6: dom$Unit
-  anonymous$1 := pkg$$global$fakePrint$Tkotlin_Int(42)
-  anonymous$2 := pkg$$global$fakePrint$Tkotlin_Boolean(true)
-  anonymous$3 := pkg$$class_Foo$constructor$()
-  anonymous$4 := pkg$$global$fakePrint$TFoo(anonymous$3)
-  anonymous$5 := pkg$$class_Bar$constructor$()
-  anonymous$6 := pkg$$global$fakePrint$TBar(anonymous$5)
+  anonymous$1 := global$fun_fakePrint$fun_take$T_Int$return$T_Unit(42)
+  anonymous$2 := global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(true)
+  anonymous$3 := class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  anonymous$4 := global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(anonymous$3)
+  anonymous$5 := class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  anonymous$6 := global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(anonymous$5)
   label label$ret
 }
 
-method pkg$$global$fakePrint$Tkotlin_Int(local$value: Int)
+method global$fun_fakePrint$fun_take$T_Int$return$T_Unit(local$value: Int)
   returns (ret: dom$Unit)
 
 
-method pkg$$global$fakePrint$Tkotlin_Boolean(local$truth: Bool)
+method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
   returns (ret: dom$Unit)
 
 
-method pkg$$global$fakePrint$TFoo(local$f: Ref) returns (ret: dom$Unit)
+method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
+  returns (ret: dom$Unit)
 
 
-method pkg$$class_Foo$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$global$fakePrint$TBar(local$b: Ref) returns (ret: dom$Unit)
+method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
+  returns (ret: dom$Unit)
 
 
-method pkg$$class_Bar$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
 /function_overloading.kt:(318,346): info: Generated Viper text for testClassFunctionOverloading:
-method pkg$$global$testClassFunctionOverloading$() returns (ret: dom$Unit)
+method global$fun_testClassFunctionOverloading$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$b: Ref
+  var local1$b: Ref
   var anonymous$1: Ref
   var anonymous$2: Ref
   var anonymous$3: dom$Unit
   var anonymous$4: Ref
   var anonymous$5: dom$Unit
-  anonymous$1 := pkg$$class_Bar$constructor$()
-  local$1$b := anonymous$1
-  anonymous$2 := pkg$$class_Foo$constructor$()
-  anonymous$3 := pkg$$class_Bar$fun_baz$TFoo(local$1$b, anonymous$2)
-  anonymous$4 := pkg$$class_Bar$constructor$()
-  anonymous$5 := pkg$$class_Bar$fun_baz$TBar(local$1$b, anonymous$4)
+  anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  local1$b := anonymous$1
+  anonymous$2 := class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  anonymous$3 := class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(local1$b,
+    anonymous$2)
+  anonymous$4 := class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  anonymous$5 := class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(local1$b,
+    anonymous$4)
   label label$ret
 }
 
-method pkg$$class_Bar$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Bar())
+method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
-method pkg$$class_Bar$fun_baz$TFoo(this: Ref, local$f: Ref)
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
+  local$f: Ref)
   returns (ret: dom$Unit)
 
 
-method pkg$$class_Foo$constructor$() returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$class_Bar$fun_baz$TBar(this: Ref, local$b: Ref)
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
+  local$b: Ref)
   returns (ret: dom$Unit)
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
@@ -1,11 +1,12 @@
 /generics.kt:(33,46): info: Generated Viper text for genericMethod:
-field pkg$$class_Box$member_t: dom$Nullable[dom$Any]
+field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
 
-method pkg$$class_Box$fun_genericMethod$TT(this: Ref, local$x: dom$Nullable[dom$Any])
+method class_scope_global$class_Box$fun_genericMethod$fun_take$T_class_global$class_Box$NT_Any$return$NT_Any(this: Ref,
+  local$x: dom$Nullable[dom$Any])
   returns (ret: dom$Nullable[dom$Any])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Box())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Box())
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
   ret := local$x
   goto label$ret
@@ -13,62 +14,66 @@ method pkg$$class_Box$fun_genericMethod$TT(this: Ref, local$x: dom$Nullable[dom$
 }
 
 /generics.kt:(88,97): info: Generated Viper text for createBox:
-field pkg$$class_Box$member_t: dom$Nullable[dom$Any]
+field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
 
-method pkg$$global$createBox$() returns (ret: Int)
+method global$fun_createBox$fun_take$$return$T_Int() returns (ret: Int)
 {
-  var local$1$boolBox: Ref
+  var local1$boolBox: Ref
   var anonymous$1: Ref
-  var local$1$b: Bool
+  var local1$b: Bool
   var anonymous$2: dom$Nullable[dom$Any]
-  var local$1$intBox: Ref
+  var local1$intBox: Ref
   var anonymous$3: Ref
   var anonymous$4: dom$Nullable[dom$Any]
-  anonymous$1 := pkg$$class_Box$constructor$TT((dom$Casting$cast(true, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
-  local$1$boolBox := anonymous$1
-  inhale acc(local$1$boolBox.pkg$$class_Box$member_t, write)
-  anonymous$2 := local$1$boolBox.pkg$$class_Box$member_t
+  anonymous$1 := class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(true,
+    dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
+  local1$boolBox := anonymous$1
+  inhale acc(local1$boolBox.class_scope_global$class_Box$member_t, write)
+  anonymous$2 := local1$boolBox.class_scope_global$class_Box$member_t
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-  exhale acc(local$1$boolBox.pkg$$class_Box$member_t, write)
-  local$1$b := (dom$Casting$cast(anonymous$2, dom$Type$Boolean()): Bool)
-  anonymous$3 := pkg$$class_Box$constructor$TT((dom$Casting$cast(2, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
-  local$1$intBox := anonymous$3
-  inhale acc(local$1$intBox.pkg$$class_Box$member_t, write)
-  anonymous$4 := local$1$intBox.pkg$$class_Box$member_t
+  exhale acc(local1$boolBox.class_scope_global$class_Box$member_t, write)
+  local1$b := (dom$Casting$cast(anonymous$2, dom$Type$Boolean()): Bool)
+  anonymous$3 := class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(2,
+    dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
+  local1$intBox := anonymous$3
+  inhale acc(local1$intBox.class_scope_global$class_Box$member_t, write)
+  anonymous$4 := local1$intBox.class_scope_global$class_Box$member_t
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$4): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-  exhale acc(local$1$intBox.pkg$$class_Box$member_t, write)
+  exhale acc(local1$intBox.class_scope_global$class_Box$member_t, write)
   ret := (dom$Casting$cast(anonymous$4, dom$Type$Int()): Int)
   goto label$ret
   label label$ret
 }
 
-method pkg$$class_Box$constructor$TT(local$t: dom$Nullable[dom$Any])
+method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Box())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
 
 
 /generics.kt:(208,223): info: Generated Viper text for setGenericField:
-field pkg$$class_Box$member_t: dom$Nullable[dom$Any]
+field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
 
-method pkg$$global$setGenericField$() returns (ret: dom$Unit)
+method global$fun_setGenericField$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$box: Ref
+  var local1$box: Ref
   var anonymous$1: Ref
-  anonymous$1 := pkg$$class_Box$constructor$TT((dom$Casting$cast(3, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
-  local$1$box := anonymous$1
-  inhale acc(local$1$box.pkg$$class_Box$member_t, write)
-  local$1$box.pkg$$class_Box$member_t := (dom$Casting$cast(5, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any])
-  exhale acc(local$1$box.pkg$$class_Box$member_t, write)
+  anonymous$1 := class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(3,
+    dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
+  local1$box := anonymous$1
+  inhale acc(local1$box.class_scope_global$class_Box$member_t, write)
+  local1$box.class_scope_global$class_Box$member_t := (dom$Casting$cast(5, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any])
+  exhale acc(local1$box.class_scope_global$class_Box$member_t, write)
   label label$ret
 }
 
-method pkg$$class_Box$constructor$TT(local$t: dom$Nullable[dom$Any])
+method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Box())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
 
 
 /generics.kt:(274,284): info: Generated Viper text for genericFun:
-method pkg$$global$genericFun$TT(local$t: dom$Nullable[dom$Any])
+method global$fun_genericFun$fun_take$NT_Any$return$NT_Any(local$t: dom$Nullable[dom$Any])
   returns (ret: dom$Nullable[dom$Any])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
 {
@@ -79,16 +84,17 @@ method pkg$$global$genericFun$TT(local$t: dom$Nullable[dom$Any])
 }
 
 /generics.kt:(303,318): info: Generated Viper text for callGenericFunc:
-method pkg$$global$callGenericFunc$() returns (ret: dom$Unit)
+method global$fun_callGenericFunc$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: dom$Nullable[dom$Any]
-  anonymous$1 := pkg$$global$genericFun$TT((dom$Casting$cast(3, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
-  local$1$x := (dom$Casting$cast(anonymous$1, dom$Type$Int()): Int)
+  anonymous$1 := global$fun_genericFun$fun_take$NT_Any$return$NT_Any((dom$Casting$cast(3,
+    dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
+  local1$x := (dom$Casting$cast(anonymous$1, dom$Type$Int()): Int)
   label label$ret
 }
 
-method pkg$$global$genericFun$TT(local$t: dom$Nullable[dom$Any])
+method global$fun_genericFun$fun_take$NT_Any$return$NT_Any(local$t: dom$Nullable[dom$Any])
   returns (ret: dom$Nullable[dom$Any])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
@@ -1,5 +1,5 @@
 /if.kt:(4,13): info: Generated Viper text for simple_if:
-method pkg$$global$simple_if$() returns (ret: Int)
+method global$fun_simple_if$fun_take$$return$T_Int() returns (ret: Int)
 {
   if (true) {
     ret := 0
@@ -12,7 +12,7 @@ method pkg$$global$simple_if$() returns (ret: Int)
 }
 
 /if.kt:(98,113): info: Generated Viper text for if_on_parameter:
-method pkg$$global$if_on_parameter$Tkotlin_Boolean(local$b: Bool)
+method global$fun_if_on_parameter$fun_take$T_Boolean$return$T_Int(local$b: Bool)
   returns (ret: Int)
 {
   if (local$b) {
@@ -26,18 +26,19 @@ method pkg$$global$if_on_parameter$Tkotlin_Boolean(local$b: Bool)
 }
 
 /if.kt:(205,221): info: Generated Viper text for if_as_expression:
-method pkg$$global$if_as_expression$() returns (ret: Bool)
+method global$fun_if_as_expression$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
 {
-  var local$1$b: Bool
+  var local1$b: Bool
   var anonymous$1: Bool
-  local$1$b := false
-  if (local$1$b) {
+  local1$b := false
+  if (local1$b) {
     var anonymous$2: Int
-    anonymous$2 := pkg$$global$simple_if$()
+    anonymous$2 := global$fun_simple_if$fun_take$$return$T_Int()
     anonymous$1 := false
   } else {
     var anonymous$3: Int
-    anonymous$3 := pkg$$global$if_on_parameter$Tkotlin_Boolean(local$1$b)
+    anonymous$3 := global$fun_if_on_parameter$fun_take$T_Boolean$return$T_Int(local1$b)
     anonymous$1 := true
   }
   ret := anonymous$1
@@ -45,9 +46,8 @@ method pkg$$global$if_as_expression$() returns (ret: Bool)
   label label$ret
 }
 
-method pkg$$global$simple_if$() returns (ret: Int)
+method global$fun_simple_if$fun_take$$return$T_Int() returns (ret: Int)
 
 
-method pkg$$global$if_on_parameter$Tkotlin_Boolean(local$b: Bool)
+method global$fun_if_on_parameter$fun_take$T_Boolean$return$T_Int(local$b: Bool)
   returns (ret: Int)
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -1,170 +1,178 @@
 /inheritance.kt:(74,78): info: Generated Viper text for getY:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-method pkg$$class_Foo$fun_getY$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Foo())
-  inhale acc(this.pkg$$class_Foo$member_y, write)
-  anonymous$1 := this.pkg$$class_Foo$member_y
-  exhale acc(this.pkg$$class_Foo$member_y, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
+  inhale acc(this.class_scope_global$class_Foo$member_y, write)
+  anonymous$1 := this.class_scope_global$class_Foo$member_y
+  exhale acc(this.class_scope_global$class_Foo$member_y, write)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
 /inheritance.kt:(171,174): info: Generated Viper text for sum:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$class_Bar$fun_sum$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
+  returns (ret: Int)
 {
   var anonymous$1: Int
   var anonymous$2: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Bar())
-  inhale acc(this.pkg$$class_Foo$member_x, write)
-  anonymous$1 := this.pkg$$class_Foo$member_x
-  exhale acc(this.pkg$$class_Foo$member_x, write)
-  inhale acc(this.pkg$$class_Bar$member_z, write)
-  anonymous$2 := this.pkg$$class_Bar$member_z
-  exhale acc(this.pkg$$class_Bar$member_z, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Bar())
+  inhale acc(this.class_scope_global$class_Foo$member_x, write)
+  anonymous$1 := this.class_scope_global$class_Foo$member_x
+  exhale acc(this.class_scope_global$class_Foo$member_x, write)
+  inhale acc(this.class_scope_global$class_Bar$member_z, write)
+  anonymous$2 := this.class_scope_global$class_Bar$member_z
+  exhale acc(this.class_scope_global$class_Bar$member_z, write)
   ret := anonymous$1 + anonymous$2
   goto label$ret
   label label$ret
 }
 
 /inheritance.kt:(217,232): info: Generated Viper text for callSuperMethod:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$global$callSuperMethod$TBar(local$bar: Ref) returns (ret: Int)
+method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
+  returns (ret: Int)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
-  anonymous$1 := pkg$$class_Foo$fun_getY$((dom$Casting$cast(local$bar, dom$Type$pkg$$class_Foo()): Ref))
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
+  anonymous$1 := class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int((dom$Casting$cast(local$bar,
+    dom$Type$global$class_Foo()): Ref))
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
-method pkg$$class_Foo$fun_getY$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
 
 
 /inheritance.kt:(279,295): info: Generated Viper text for accessSuperField:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$global$accessSuperField$TBar(local$bar: Ref)
+method global$fun_accessSuperField$fun_take$T_class_global$class_Bar$return$T_Boolean(local$bar: Ref)
   returns (ret: Bool)
 {
   var anonymous$1: Bool
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
-  inhale acc(local$bar.pkg$$class_Foo$member_b, write)
-  anonymous$1 := local$bar.pkg$$class_Foo$member_b
-  exhale acc(local$bar.pkg$$class_Foo$member_b, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
+  inhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
+  anonymous$1 := local$bar.class_scope_global$class_Foo$member_b
+  exhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
 /inheritance.kt:(341,355): info: Generated Viper text for accessNewField:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$global$accessNewField$TBar(local$bar: Ref) returns (ret: Int)
+method global$fun_accessNewField$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
+  returns (ret: Int)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
-  inhale acc(local$bar.pkg$$class_Bar$member_z, write)
-  anonymous$1 := local$bar.pkg$$class_Bar$member_z
-  exhale acc(local$bar.pkg$$class_Bar$member_z, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
+  inhale acc(local$bar.class_scope_global$class_Bar$member_z, write)
+  anonymous$1 := local$bar.class_scope_global$class_Bar$member_z
+  exhale acc(local$bar.class_scope_global$class_Bar$member_z, write)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
 /inheritance.kt:(397,410): info: Generated Viper text for callNewMethod:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$global$callNewMethod$TBar(local$bar: Ref) returns (ret: Int)
+method global$fun_callNewMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
+  returns (ret: Int)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
-  anonymous$1 := pkg$$class_Bar$fun_sum$(local$bar)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
+  anonymous$1 := class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(local$bar)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
-method pkg$$class_Bar$fun_sum$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
+  returns (ret: Int)
 
 
 /inheritance.kt:(456,469): info: Generated Viper text for setSuperField:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$global$setSuperField$TBar(local$bar: Ref)
+method global$fun_setSuperField$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
 {
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$pkg$$class_Bar())
-  inhale acc(local$bar.pkg$$class_Foo$member_b, write)
-  local$bar.pkg$$class_Foo$member_b := true
-  exhale acc(local$bar.pkg$$class_Foo$member_b, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
+  inhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
+  local$bar.class_scope_global$class_Foo$member_b := true
+  exhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
   label label$ret
 }
 
 /inheritance.kt:(506,527): info: Generated Viper text for accessSuperSuperField:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-field pkg$$class_Foo$member_y: Int
+field class_scope_global$class_Foo$member_y: Int
 
-field pkg$$class_Foo$member_b: Bool
+field class_scope_global$class_Foo$member_b: Bool
 
-field pkg$$class_Bar$member_z: Int
+field class_scope_global$class_Bar$member_z: Int
 
-method pkg$$global$accessSuperSuperField$TBaz(local$baz: Ref)
+method global$fun_accessSuperSuperField$fun_take$T_class_global$class_Baz$return$T_Int(local$baz: Ref)
   returns (ret: Int)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$baz): dom$Type), dom$Type$pkg$$class_Baz())
-  inhale acc(local$baz.pkg$$class_Foo$member_x, write)
-  anonymous$1 := local$baz.pkg$$class_Foo$member_x
-  exhale acc(local$baz.pkg$$class_Foo$member_x, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$baz): dom$Type), dom$Type$global$class_Baz())
+  inhale acc(local$baz.class_scope_global$class_Foo$member_x, write)
+  anonymous$1 := local$baz.class_scope_global$class_Foo$member_x
+  exhale acc(local$baz.class_scope_global$class_Foo$member_x, write)
   ret := anonymous$1
   goto label$ret
   label label$ret

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inline.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inline.fir.diag.txt
@@ -1,19 +1,20 @@
 /inline.kt:(211,220): info: Generated Viper text for quadruple:
-method pkg$$global$quadruple$Tkotlin_Int(local$x: Int) returns (ret: Int)
+method global$fun_quadruple$fun_take$T_Int$return$T_Int(local$x: Int)
+  returns (ret: Int)
 {
   var anonymous$1: Int
   var anonymous$2: Int
   if (true) {
-    var local$2$y: Int
-    local$2$y := local$x + local$x
-    anonymous$1 := local$2$y
+    var local2$y: Int
+    local2$y := local$x + local$x
+    anonymous$1 := local2$y
     goto inline_label$1$ret
     label inline_label$1$ret
   }
   if (true) {
-    var local$2$y: Int
-    local$2$y := local$x + local$x
-    anonymous$2 := local$2$y
+    var local2$y: Int
+    local2$y := local$x + local$x
+    anonymous$2 := local2$y
     goto inline_label$1$ret
     label inline_label$1$ret
   }
@@ -23,7 +24,7 @@ method pkg$$global$quadruple$Tkotlin_Int(local$x: Int) returns (ret: Int)
 }
 
 /inline.kt:(450,463): info: Generated Viper text for use_branching:
-method pkg$$global$use_branching$() returns (ret: Int)
+method global$fun_use_branching$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
   var anonymous$3: Int

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_captured.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_captured.fir.diag.txt
@@ -1,5 +1,5 @@
 /inlining_captured.kt:(136,147): info: Generated Viper text for capture_arg:
-method pkg$$global$capture_arg$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$g: Ref)
+method global$fun_capture_arg$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$g: Ref)
   returns (ret: Int)
   requires acc(local$g.special$function_object_call_counter, write)
   requires special$duplicable(local$g)
@@ -28,17 +28,17 @@ method pkg$$global$capture_arg$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$
 }
 
 /inlining_captured.kt:(207,218): info: Generated Viper text for capture_var:
-method pkg$$global$capture_var$() returns (ret: Int)
+method global$fun_capture_var$fun_take$$return$T_Int() returns (ret: Int)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: Int
-  local$1$x := 1
+  local1$x := 1
   if (true) {
     var anonymous$2: Int
     var anonymous$3: Int
     anonymous$3 := 0
     if (true) {
-      anonymous$2 := anonymous$3 + local$1$x
+      anonymous$2 := anonymous$3 + local1$x
     }
     anonymous$1 := anonymous$2
     goto inline_label$1$ret
@@ -50,7 +50,7 @@ method pkg$$global$capture_var$() returns (ret: Int)
 }
 
 /inlining_captured.kt:(278,296): info: Generated Viper text for capture_and_shadow:
-method pkg$$global$capture_and_shadow$Tkotlin_Int(local$x: Int)
+method global$fun_capture_and_shadow$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
@@ -59,11 +59,11 @@ method pkg$$global$capture_and_shadow$Tkotlin_Int(local$x: Int)
     var anonymous$3: Int
     anonymous$3 := 0
     if (true) {
-      var local$3$y: Int
-      var local$3$x: Int
-      local$3$y := local$x
-      local$3$x := 1
-      anonymous$2 := anonymous$3 + local$3$x + local$3$y
+      var local3$y: Int
+      var local3$x: Int
+      local3$y := local$x
+      local3$x := 1
+      anonymous$2 := anonymous$3 + local3$x + local3$y
     }
     anonymous$1 := anonymous$2
     goto inline_label$1$ret
@@ -75,20 +75,20 @@ method pkg$$global$capture_and_shadow$Tkotlin_Int(local$x: Int)
 }
 
 /inlining_captured.kt:(499,516): info: Generated Viper text for capture_var_clash:
-method pkg$$global$capture_var_clash$Tkotlin_Int(local$x: Int)
+method global$fun_capture_var_clash$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
     var anonymous$3: Int
-    local$2$x := 1
+    local2$x := 1
     anonymous$3 := 0
     if (true) {
       anonymous$2 := anonymous$3 * local$x
     }
-    anonymous$1 := anonymous$2 + local$2$x
+    anonymous$1 := anonymous$2 + local2$x
     goto inline_label$1$ret
     label inline_label$1$ret
   }
@@ -98,24 +98,24 @@ method pkg$$global$capture_var_clash$Tkotlin_Int(local$x: Int)
 }
 
 /inlining_captured.kt:(574,598): info: Generated Viper text for capture_and_shadow_clash:
-method pkg$$global$capture_and_shadow_clash$Tkotlin_Int(local$x: Int)
+method global$fun_capture_and_shadow_clash$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
     var anonymous$3: Int
-    local$2$x := 1
+    local2$x := 1
     anonymous$3 := 0
     if (true) {
-      var local$3$y: Int
-      var local$3$x: Int
-      local$3$y := local$x
-      local$3$x := 2
-      anonymous$2 := local$3$x + local$3$y + anonymous$3
+      var local3$y: Int
+      var local3$x: Int
+      local3$y := local$x
+      local3$x := 2
+      anonymous$2 := local3$x + local3$y + anonymous$3
     }
-    anonymous$1 := anonymous$2 + local$2$x
+    anonymous$1 := anonymous$2 + local2$x
     goto inline_label$1$ret
     label inline_label$1$ret
   }
@@ -125,40 +125,40 @@ method pkg$$global$capture_and_shadow_clash$Tkotlin_Int(local$x: Int)
 }
 
 /inlining_captured.kt:(708,731): info: Generated Viper text for nested_lambda_shadowing:
-method pkg$$global$nested_lambda_shadowing$Tkotlin_Int(local$x: Int)
+method global$fun_nested_lambda_shadowing$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
     var anonymous$3: Int
-    local$2$x := 1
+    local2$x := 1
     anonymous$3 := 0
     if (true) {
       var anonymous$4: Int
-      var local$3$y: Int
-      var local$3$x: Int
+      var local3$y: Int
+      var local3$x: Int
       if (true) {
-        var local$4$x: Int
+        var local4$x: Int
         var anonymous$5: Int
         var anonymous$6: Int
-        local$4$x := 1
+        local4$x := 1
         anonymous$6 := 0
         if (true) {
-          var local$5$x: Int
-          local$5$x := 3
-          anonymous$5 := local$5$x + anonymous$6
+          var local5$x: Int
+          local5$x := 3
+          anonymous$5 := local5$x + anonymous$6
         }
-        anonymous$4 := anonymous$5 + local$4$x
+        anonymous$4 := anonymous$5 + local4$x
         goto inline_label$3$ret
         label inline_label$3$ret
       }
-      local$3$y := local$x
-      local$3$x := 4
-      anonymous$2 := local$3$x + local$3$y + anonymous$3
+      local3$y := local$x
+      local3$x := 4
+      anonymous$2 := local3$x + local3$y + anonymous$3
     }
-    anonymous$1 := anonymous$2 + local$2$x
+    anonymous$1 := anonymous$2 + local2$x
     goto inline_label$1$ret
     label inline_label$1$ret
   }
@@ -168,7 +168,7 @@ method pkg$$global$nested_lambda_shadowing$Tkotlin_Int(local$x: Int)
 }
 
 /inlining_captured.kt:(1006,1024): info: Generated Viper text for call_double_invoke:
-method pkg$$global$call_double_invoke$Tkotlin_Int(local$x: Int)
+method global$fun_call_double_invoke$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
@@ -179,15 +179,15 @@ method pkg$$global$call_double_invoke$Tkotlin_Int(local$x: Int)
     var anonymous$5: Int
     anonymous$3 := 0
     if (true) {
-      var local$3$x: Int
-      local$3$x := anonymous$3
-      anonymous$2 := local$3$x
+      var local3$x: Int
+      local3$x := anonymous$3
+      anonymous$2 := local3$x
     }
     anonymous$5 := 1
     if (true) {
-      var local$3$x: Int
-      local$3$x := anonymous$5
-      anonymous$4 := local$3$x
+      var local3$x: Int
+      local3$x := anonymous$5
+      anonymous$4 := local3$x
     }
     anonymous$1 := anonymous$4
     goto inline_label$1$ret

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.fir.diag.txt
@@ -1,5 +1,5 @@
 /inlining_lambdas.kt:(11,17): info: Generated Viper text for invoke:
-method pkg$$global$invoke$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Ref)
+method global$fun_invoke$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
   returns (ret: Int)
   requires acc(local$f.special$function_object_call_counter, write)
   requires special$duplicable(local$f)
@@ -16,7 +16,7 @@ method pkg$$global$invoke$Tkotlin_Function1__kotlin_Int$kotlin_Int__(local$f: Re
 }
 
 /inlining_lambdas.kt:(65,77): info: Generated Viper text for explicit_arg:
-method pkg$$global$explicit_arg$() returns (ret: Int)
+method global$fun_explicit_arg$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
   if (true) {
@@ -36,7 +36,7 @@ method pkg$$global$explicit_arg$() returns (ret: Int)
 }
 
 /inlining_lambdas.kt:(127,139): info: Generated Viper text for implicit_arg:
-method pkg$$global$implicit_arg$() returns (ret: Int)
+method global$fun_implicit_arg$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
   if (true) {
@@ -56,7 +56,7 @@ method pkg$$global$implicit_arg$() returns (ret: Int)
 }
 
 /inlining_lambdas.kt:(185,194): info: Generated Viper text for lambda_if:
-method pkg$$global$lambda_if$() returns (ret: Int)
+method global$fun_lambda_if$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
   if (true) {
@@ -81,7 +81,8 @@ method pkg$$global$lambda_if$() returns (ret: Int)
 }
 
 /inlining_lambdas.kt:(325,346): info: Generated Viper text for return_value_not_used:
-method pkg$$global$return_value_not_used$() returns (ret: dom$Unit)
+method global$fun_return_value_not_used$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: Int
   if (true) {
@@ -99,21 +100,21 @@ method pkg$$global$return_value_not_used$() returns (ret: dom$Unit)
 }
 
 /inlining_lambdas.kt:(382,391): info: Generated Viper text for shadowing:
-method pkg$$global$shadowing$() returns (ret: Int)
+method global$fun_shadowing$fun_take$$return$T_Int() returns (ret: Int)
 {
-  var local$1$x: Int
-  var local$1$y: Int
+  var local1$x: Int
+  var local1$y: Int
   var anonymous$1: Int
-  local$1$x := 1
-  local$1$y := 1
+  local1$x := 1
+  local1$y := 1
   if (true) {
     var anonymous$2: Int
     var anonymous$3: Int
     anonymous$3 := 0
     if (true) {
-      var local$3$y: Int
-      local$3$y := 0
-      anonymous$2 := anonymous$3 + local$3$y
+      var local3$y: Int
+      local3$y := 0
+      anonymous$2 := anonymous$3 + local3$y
     }
     anonymous$1 := anonymous$2
     goto inline_label$1$ret
@@ -125,11 +126,11 @@ method pkg$$global$shadowing$() returns (ret: Int)
 }
 
 /inlining_lambdas.kt:(537,540): info: Generated Viper text for foo:
-method pkg$$global$foo$() returns (ret: Int)
+method global$fun_foo$fun_take$$return$T_Int() returns (ret: Int)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: Int
-  local$1$x := 2
+  local1$x := 2
   if (true) {
     var anonymous$2: Int
     var anonymous$3: Int
@@ -147,15 +148,15 @@ method pkg$$global$foo$() returns (ret: Int)
 }
 
 /inlining_lambdas.kt:(604,610): info: Generated Viper text for nested:
-method pkg$$global$nested$() returns (ret: Int)
+method global$fun_nested$fun_take$$return$T_Int() returns (ret: Int)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: Int
-  local$1$x := 2
+  local1$x := 2
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$2: Int
-    local$2$x := 2
+    local2$x := 2
     if (true) {
       var anonymous$3: Int
       var anonymous$4: Int

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/is_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/is_operator.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_operator.kt:(4,19): info: Generated Viper text for is_non_nullable:
-method pkg$$global$is_non_nullable$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_is_non_nullable$fun_take$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int])
   returns (ret: Bool)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
@@ -9,7 +9,7 @@ method pkg$$global$is_non_nullable$NTkotlin_Int(local$x: dom$Nullable[Int])
 }
 
 /is_operator.kt:(67,82): info: Generated Viper text for not_is_nullable:
-method pkg$$global$not_is_nullable$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_not_is_nullable$fun_take$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int])
   returns (ret: Bool)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
@@ -19,7 +19,7 @@ method pkg$$global$not_is_nullable$NTkotlin_Int(local$x: dom$Nullable[Int])
 }
 
 /is_operator.kt:(135,145): info: Generated Viper text for smart_cast:
-method pkg$$global$smart_cast$NTkotlin_Any(local$x: dom$Nullable[dom$Any])
+method global$fun_smart_cast$fun_take$NT_Any$return$T_Int(local$x: dom$Nullable[dom$Any])
   returns (ret: Int)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop.fir.diag.txt
@@ -1,15 +1,15 @@
 /loop.kt:(4,14): info: Generated Viper text for while_loop:
-method pkg$$global$while_loop$Tkotlin_Boolean(local$b: Bool)
+method global$fun_while_loop$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
   returns (ret: Bool)
 {
   var anonymous$1: Bool
   label label$continue$1
   anonymous$1 := local$b
   while (anonymous$1) {
-    var local$2$a: Int
-    var local$2$c: Int
-    local$2$a := 1
-    local$2$c := 2
+    var local2$a: Int
+    var local2$c: Int
+    local2$a := 1
+    local2$c := 2
     anonymous$1 := local$b
   }
   label label$break$1
@@ -19,22 +19,22 @@ method pkg$$global$while_loop$Tkotlin_Boolean(local$b: Bool)
 }
 
 /loop.kt:(120,144): info: Generated Viper text for while_function_condition:
-method pkg$$global$while_function_condition$() returns (ret: dom$Unit)
+method global$fun_while_function_condition$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: Bool
   var anonymous$2: Bool
   label label$continue$1
-  anonymous$2 := pkg$$global$while_loop$Tkotlin_Boolean(true)
+  anonymous$2 := global$fun_while_loop$fun_take$T_Boolean$return$T_Boolean(true)
   anonymous$1 := anonymous$2
   while (anonymous$1) {
     var anonymous$3: Bool
-    anonymous$3 := pkg$$global$while_loop$Tkotlin_Boolean(true)
+    anonymous$3 := global$fun_while_loop$fun_take$T_Boolean$return$T_Boolean(true)
     anonymous$1 := anonymous$3
   }
   label label$break$1
   label label$ret
 }
 
-method pkg$$global$while_loop$Tkotlin_Boolean(local$b: Bool)
+method global$fun_while_loop$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
   returns (ret: Bool)
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/loop_invariants.fir.diag.txt
@@ -1,5 +1,5 @@
 /loop_invariants.kt:(128,152): info: Generated Viper text for dynamic_lambda_invariant:
-method pkg$$global$dynamic_lambda_invariant$Tkotlin_Function0__kotlin_Int__(local$f: Ref)
+method global$fun_dynamic_lambda_invariant$fun_take$fun_take$$return$T_Int$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   requires special$duplicable(local$f)
@@ -11,7 +11,7 @@ method pkg$$global$dynamic_lambda_invariant$Tkotlin_Function0__kotlin_Int__(loca
   var anonymous$2: Bool
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
   label label$continue$1
-  anonymous$2 := pkg$$global$returns_boolean$()
+  anonymous$2 := global$fun_returns_boolean$fun_take$$return$T_Boolean()
   anonymous$1 := anonymous$2
   while (anonymous$1)
     invariant acc(local$f.special$function_object_call_counter, write)
@@ -21,18 +21,19 @@ method pkg$$global$dynamic_lambda_invariant$Tkotlin_Function0__kotlin_Int__(loca
     var anonymous$3: Int
     var anonymous$4: Bool
     special$invoke_function_object(local$f)
-    anonymous$4 := pkg$$global$returns_boolean$()
+    anonymous$4 := global$fun_returns_boolean$fun_take$$return$T_Boolean()
     anonymous$1 := anonymous$4
   }
   label label$break$1
   label label$ret
 }
 
-method pkg$$global$returns_boolean$() returns (ret: Bool)
+method global$fun_returns_boolean$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
 
 
 /loop_invariants.kt:(226,245): info: Generated Viper text for function_assignment:
-method pkg$$global$function_assignment$Tkotlin_Function0__kotlin_Int__(local$f: Ref)
+method global$fun_function_assignment$fun_take$fun_take$$return$T_Int$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
   requires special$duplicable(local$f)
@@ -40,13 +41,13 @@ method pkg$$global$function_assignment$Tkotlin_Function0__kotlin_Int__(local$f: 
   ensures old(local$f.special$function_object_call_counter) <=
     local$f.special$function_object_call_counter
 {
-  var local$1$g: Ref
+  var local1$g: Ref
   var anonymous$1: Bool
   var anonymous$2: Bool
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
-  local$1$g := local$f
+  local1$g := local$f
   label label$continue$1
-  anonymous$2 := pkg$$global$returns_boolean$()
+  anonymous$2 := global$fun_returns_boolean$fun_take$$return$T_Boolean()
   anonymous$1 := anonymous$2
   while (anonymous$1)
     invariant acc(local$f.special$function_object_call_counter, write)
@@ -55,19 +56,20 @@ method pkg$$global$function_assignment$Tkotlin_Function0__kotlin_Int__(local$f: 
   {
     var anonymous$3: Int
     var anonymous$4: Bool
-    special$invoke_function_object(local$1$g)
-    anonymous$4 := pkg$$global$returns_boolean$()
+    special$invoke_function_object(local1$g)
+    anonymous$4 := global$fun_returns_boolean$fun_take$$return$T_Boolean()
     anonymous$1 := anonymous$4
   }
   label label$break$1
   label label$ret
 }
 
-method pkg$$global$returns_boolean$() returns (ret: Bool)
+method global$fun_returns_boolean$fun_take$$return$T_Boolean()
+  returns (ret: Bool)
 
 
 /loop_invariants.kt:(333,364): info: Generated Viper text for conditional_function_assignment:
-method pkg$$global$conditional_function_assignment$Tkotlin_Boolean$Tkotlin_Function0__kotlin_Int__$Tkotlin_Function0__kotlin_Int__(local$b: Bool,
+method global$fun_conditional_function_assignment$fun_take$T_Boolean$fun_take$$return$T_Int$fun_take$$return$T_Int$return$T_Unit(local$b: Bool,
   local$f: Ref, local$h: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
@@ -81,7 +83,7 @@ method pkg$$global$conditional_function_assignment$Tkotlin_Boolean$Tkotlin_Funct
   ensures old(local$h.special$function_object_call_counter) <=
     local$h.special$function_object_call_counter
 {
-  var local$1$g: Ref
+  var local1$g: Ref
   var anonymous$1: Ref
   var anonymous$2: Bool
   var anonymous$3: Bool
@@ -91,9 +93,9 @@ method pkg$$global$conditional_function_assignment$Tkotlin_Boolean$Tkotlin_Funct
     anonymous$1 := local$f
   } else {
     anonymous$1 := local$h}
-  local$1$g := anonymous$1
+  local1$g := anonymous$1
   label label$continue$1
-  anonymous$3 := pkg$$global$returns_boolean$()
+  anonymous$3 := global$fun_returns_boolean$fun_take$$return$T_Boolean()
   anonymous$2 := anonymous$3
   while (anonymous$2)
     invariant acc(local$f.special$function_object_call_counter, write)
@@ -105,13 +107,13 @@ method pkg$$global$conditional_function_assignment$Tkotlin_Boolean$Tkotlin_Funct
   {
     var anonymous$4: Int
     var anonymous$5: Bool
-    special$invoke_function_object(local$1$g)
-    anonymous$5 := pkg$$global$returns_boolean$()
+    special$invoke_function_object(local1$g)
+    anonymous$5 := global$fun_returns_boolean$fun_take$$return$T_Boolean()
     anonymous$2 := anonymous$5
   }
   label label$break$1
   label label$ret
 }
 
-method pkg$$global$returns_boolean$() returns (ret: Bool)
-
+method global$fun_returns_boolean$fun_take$$return$T_Boolean()
+  returns (ret: Bool)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -1,67 +1,72 @@
 /member_functions.kt:(32,42): info: Generated Viper text for member_fun:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-method pkg$$class_Foo$fun_member_fun$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Foo())
-  inhale acc(this.pkg$$class_Foo$member_x, write)
-  anonymous$1 := this.pkg$$class_Foo$member_x
-  exhale acc(this.pkg$$class_Foo$member_x, write)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
+  inhale acc(this.class_scope_global$class_Foo$member_x, write)
+  anonymous$1 := this.class_scope_global$class_Foo$member_x
+  exhale acc(this.class_scope_global$class_Foo$member_x, write)
   ret := anonymous$1
   goto label$ret
   label label$ret
 }
 
 /member_functions.kt:(84,99): info: Generated Viper text for call_member_fun:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-method pkg$$class_Foo$fun_call_member_fun$(this: Ref)
+method class_scope_global$class_Foo$fun_call_member_fun$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
   returns (ret: dom$Unit)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Foo())
-  anonymous$1 := pkg$$class_Foo$fun_member_fun$(this)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
+  anonymous$1 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this)
   label label$ret
 }
 
-method pkg$$class_Foo$fun_member_fun$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
 
 
 /member_functions.kt:(140,152): info: Generated Viper text for sibling_call:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-method pkg$$class_Foo$fun_sibling_call$TFoo(this: Ref, local$other: Ref)
+method class_scope_global$class_Foo$fun_sibling_call$fun_take$T_class_global$class_Foo$T_class_global$class_Foo$return$T_Unit(this: Ref,
+  local$other: Ref)
   returns (ret: dom$Unit)
 {
   var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$pkg$$class_Foo())
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$other): dom$Type), dom$Type$pkg$$class_Foo())
-  anonymous$1 := pkg$$class_Foo$fun_member_fun$(local$other)
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$other): dom$Type), dom$Type$global$class_Foo())
+  anonymous$1 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local$other)
   label label$ret
 }
 
-method pkg$$class_Foo$fun_member_fun$(this: Ref) returns (ret: Int)
+method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
 
 
 /member_functions.kt:(207,228): info: Generated Viper text for outer_member_fun_call:
-field pkg$$class_Foo$member_x: Int
+field class_scope_global$class_Foo$member_x: Int
 
-method pkg$$global$outer_member_fun_call$() returns (ret: dom$Unit)
+method global$fun_outer_member_fun_call$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$f: Ref
+  var local1$f: Ref
   var anonymous$1: Ref
   var anonymous$2: Int
-  anonymous$1 := pkg$$class_Foo$constructor$Tkotlin_Int(3)
-  local$1$f := anonymous$1
-  anonymous$2 := pkg$$class_Foo$fun_member_fun$(local$1$f)
+  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(3)
+  local1$f := anonymous$1
+  anonymous$2 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local1$f)
   label label$ret
 }
 
-method pkg$$class_Foo$constructor$Tkotlin_Int(local$x: Int)
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$$class_Foo())
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method pkg$$class_Foo$fun_member_fun$(this: Ref) returns (ret: Int)
-
+method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -1,38 +1,38 @@
 /nullable.kt:(4,22): info: Generated Viper text for use_nullable_twice:
-method pkg$$global$use_nullable_twice$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_use_nullable_twice$fun_take$NT_Int$return$NT_Int(local$x: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 {
-  var local$1$a: dom$Nullable[Int]
-  var local$1$b: dom$Nullable[Int]
+  var local1$a: dom$Nullable[Int]
+  var local1$b: dom$Nullable[Int]
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
-  local$1$a := local$x
-  local$1$b := local$x
-  ret := local$1$a
+  local1$a := local$x
+  local1$b := local$x
+  ret := local1$a
   goto label$ret
   label label$ret
 }
 
 /nullable.kt:(88,111): info: Generated Viper text for pass_nullable_parameter:
-method pkg$$global$pass_nullable_parameter$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_pass_nullable_parameter$fun_take$NT_Int$return$NT_Int(local$x: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 {
   var anonymous$1: dom$Nullable[Int]
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
-  anonymous$1 := pkg$$global$use_nullable_twice$NTkotlin_Int(local$x)
+  anonymous$1 := global$fun_use_nullable_twice$fun_take$NT_Int$return$NT_Int(local$x)
   ret := local$x
   goto label$ret
   label label$ret
 }
 
-method pkg$$global$use_nullable_twice$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_use_nullable_twice$fun_take$NT_Int$return$NT_Int(local$x: dom$Nullable[Int])
   returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 
 
 /nullable.kt:(175,203): info: Generated Viper text for nullable_nullable_comparison:
-method pkg$$global$nullable_nullable_comparison$NTkotlin_Int$NTkotlin_Int(local$x: dom$Nullable[Int],
+method global$fun_nullable_nullable_comparison$fun_take$NT_Int$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int],
   local$y: dom$Nullable[Int])
   returns (ret: Bool)
 {
@@ -49,7 +49,7 @@ method pkg$$global$nullable_nullable_comparison$NTkotlin_Int$NTkotlin_Int(local$
 }
 
 /nullable.kt:(258,290): info: Generated Viper text for nullable_non_nullable_comparison:
-method pkg$$global$nullable_non_nullable_comparison$NTkotlin_Int$NTkotlin_Int(local$x: dom$Nullable[Int],
+method global$fun_nullable_non_nullable_comparison$fun_take$NT_Int$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int],
   local$y: dom$Nullable[Int])
   returns (ret: Bool)
 {
@@ -62,7 +62,7 @@ method pkg$$global$nullable_non_nullable_comparison$NTkotlin_Int$NTkotlin_Int(lo
 }
 
 /nullable.kt:(345,360): info: Generated Viper text for null_comparison:
-method pkg$$global$null_comparison$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_null_comparison$fun_take$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int])
   returns (ret: Bool)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/recursion.fir.diag.txt
@@ -1,8 +1,9 @@
 /recursion.kt:(4,13): info: Generated Viper text for recursive:
-method pkg$$global$recursive$() returns (ret: dom$Unit)
+method global$fun_recursive$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: dom$Unit
-  anonymous$1 := pkg$$global$recursive$()
+  anonymous$1 := global$fun_recursive$fun_take$$return$T_Unit()
   ret := anonymous$1
   goto label$ret
   label label$ret

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/return_break_continue.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/return_break_continue.fir.diag.txt
@@ -1,5 +1,5 @@
 /return_break_continue.kt:(4,15): info: Generated Viper text for test_return:
-method pkg$$global$test_return$() returns (ret: Int)
+method global$fun_test_return$fun_take$$return$T_Int() returns (ret: Int)
 {
   ret := 0
   goto label$ret
@@ -9,7 +9,8 @@ method pkg$$global$test_return$() returns (ret: Int)
 }
 
 /return_break_continue.kt:(58,74): info: Generated Viper text for return_from_loop:
-method pkg$$global$return_from_loop$() returns (ret: Int)
+method global$fun_return_from_loop$fun_take$$return$T_Int()
+  returns (ret: Int)
 {
   var anonymous$1: Bool
   label label$continue$1
@@ -26,44 +27,45 @@ method pkg$$global$return_from_loop$() returns (ret: Int)
 }
 
 /return_break_continue.kt:(146,157): info: Generated Viper text for while_break:
-method pkg$$global$while_break$Tkotlin_Boolean(local$b: Bool)
+method global$fun_while_break$fun_take$T_Boolean$return$T_Int(local$b: Bool)
   returns (ret: Int)
 {
-  var local$1$i: Int
+  var local1$i: Int
   var anonymous$1: Bool
-  local$1$i := 0
+  local1$i := 0
   label label$continue$1
   anonymous$1 := local$b
   while (anonymous$1) {
-    local$1$i := 1
+    local1$i := 1
     goto label$break$1
     anonymous$1 := local$b
   }
   label label$break$1
-  ret := local$1$i
+  ret := local1$i
   goto label$ret
   label label$ret
 }
 
 /return_break_continue.kt:(261,275): info: Generated Viper text for while_continue:
-method pkg$$global$while_continue$() returns (ret: dom$Unit)
+method global$fun_while_continue$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$b: Bool
+  var local1$b: Bool
   var anonymous$1: Bool
-  local$1$b := true
+  local1$b := true
   label label$continue$1
-  anonymous$1 := local$1$b
+  anonymous$1 := local1$b
   while (anonymous$1) {
-    local$1$b := false
+    local1$b := false
     goto label$continue$1
-    anonymous$1 := local$1$b
+    anonymous$1 := local1$b
   }
   label label$break$1
   label label$ret
 }
 
 /return_break_continue.kt:(361,373): info: Generated Viper text for while_nested:
-method pkg$$global$while_nested$Tkotlin_Boolean(local$b: Bool)
+method global$fun_while_nested$fun_take$T_Boolean$return$T_Unit(local$b: Bool)
   returns (ret: dom$Unit)
 {
   var anonymous$1: Bool

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/shadowing.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/shadowing.fir.diag.txt
@@ -1,63 +1,64 @@
 /shadowing.kt:(4,16): info: Generated Viper text for shadow_local:
-method pkg$$global$shadow_local$() returns (ret: dom$Unit)
+method global$fun_shadow_local$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$foo: Int
-  var local$1$x: Int
-  local$1$x := 0
-  if (local$1$x == 0) {
-    var local$2$x: Int
-    local$1$foo := local$1$x
-    local$2$x := 1
-    local$1$foo := local$2$x
+  var local1$foo: Int
+  var local1$x: Int
+  local1$x := 0
+  if (local1$x == 0) {
+    var local2$x: Int
+    local1$foo := local1$x
+    local2$x := 1
+    local1$foo := local2$x
   } else {
-    var local$2$x: Int
-    local$1$foo := local$1$x
-    local$2$x := 2
-    local$1$foo := local$2$x
+    var local2$x: Int
+    local1$foo := local1$x
+    local2$x := 2
+    local1$foo := local2$x
   }
-  local$1$foo := local$1$x
+  local1$foo := local1$x
   label label$ret
 }
 
 /shadowing.kt:(214,226): info: Generated Viper text for shadow_param:
-method pkg$$global$shadow_param$Tkotlin_Int(local$x: Int)
+method global$fun_shadow_param$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
-  var local$1$foo: Int
-  var local$1$x: Int
-  local$1$foo := local$x
-  local$1$x := 0
-  local$1$foo := local$1$x
+  var local1$foo: Int
+  var local1$x: Int
+  local1$foo := local$x
+  local1$x := 0
+  local1$foo := local1$x
   label label$ret
 }
 
 /shadowing.kt:(305,318): info: Generated Viper text for shadow_nested:
-method pkg$$global$shadow_nested$Tkotlin_Int(local$x: Int)
+method global$fun_shadow_nested$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 {
-  var local$1$foo: Int
-  var local$1$x: Int
-  local$1$foo := local$x
-  local$1$x := 0
-  local$1$foo := local$1$x
+  var local1$foo: Int
+  var local1$x: Int
+  local1$foo := local$x
+  local1$x := 0
+  local1$foo := local1$x
   if (true) {
-    var local$2$x: Int
+    var local2$x: Int
     var anonymous$1: Bool
-    local$1$foo := local$1$x
-    local$2$x := 1
-    local$1$foo := local$2$x
+    local1$foo := local1$x
+    local2$x := 1
+    local1$foo := local2$x
     label label$continue$1
     anonymous$1 := true
     while (anonymous$1) {
-      var local$3$x: Int
-      local$1$foo := local$2$x
-      local$3$x := 2
-      local$1$foo := local$3$x
+      var local3$x: Int
+      local1$foo := local2$x
+      local3$x := 2
+      local1$foo := local3$x
       anonymous$1 := true
     }
     label label$break$1
-    local$1$foo := local$2$x
+    local1$foo := local2$x
   }
-  local$1$foo := local$1$x
+  local1$foo := local1$x
   label label$ret
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/subtyping.fir.diag.txt
@@ -1,5 +1,5 @@
 /subtyping.kt:(4,14): info: Generated Viper text for smart_cast:
-method pkg$$global$smart_cast$NTkotlin_Int(local$x: dom$Nullable[Int])
+method global$fun_smart_cast$fun_take$NT_Int$return$T_Int(local$x: dom$Nullable[Int])
   returns (ret: Int)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
@@ -21,7 +21,8 @@ method pkg$$global$smart_cast$NTkotlin_Int(local$x: dom$Nullable[Int])
 }
 
 /subtyping.kt:(112,128): info: Generated Viper text for return_subtyping:
-method pkg$$global$return_subtyping$() returns (ret: dom$Nullable[Int])
+method global$fun_return_subtyping$fun_take$$return$NT_Int()
+  returns (ret: dom$Nullable[Int])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 {
   ret := (dom$Casting$cast(0, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
@@ -30,16 +31,17 @@ method pkg$$global$return_subtyping$() returns (ret: dom$Nullable[Int])
 }
 
 /subtyping.kt:(159,179): info: Generated Viper text for assignment_subtyping:
-method pkg$$global$assignment_subtyping$() returns (ret: dom$Unit)
+method global$fun_assignment_subtyping$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
-  var local$1$x: dom$Nullable[Bool]
-  local$1$x := (dom$Casting$cast(false, dom$Type$special$Nullable(dom$Type$Boolean())): dom$Nullable[Bool])
-  local$1$x := (dom$Casting$cast(true, dom$Type$special$Nullable(dom$Type$Boolean())): dom$Nullable[Bool])
+  var local1$x: dom$Nullable[Bool]
+  local1$x := (dom$Casting$cast(false, dom$Type$special$Nullable(dom$Type$Boolean())): dom$Nullable[Bool])
+  local1$x := (dom$Casting$cast(true, dom$Type$special$Nullable(dom$Type$Boolean())): dom$Nullable[Bool])
   label label$ret
 }
 
 /subtyping.kt:(232,250): info: Generated Viper text for nullable_parameter:
-method pkg$$global$nullable_parameter$NTkotlin_Boolean(local$b: dom$Nullable[Bool])
+method global$fun_nullable_parameter$fun_take$NT_Boolean$return$T_Unit(local$b: dom$Nullable[Bool])
   returns (ret: dom$Unit)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$b): dom$Type), dom$Type$special$Nullable(dom$Type$Boolean()))
@@ -47,14 +49,14 @@ method pkg$$global$nullable_parameter$NTkotlin_Boolean(local$b: dom$Nullable[Boo
 }
 
 /subtyping.kt:(272,300): info: Generated Viper text for function_parameter_subtyping:
-method pkg$$global$function_parameter_subtyping$() returns (ret: dom$Unit)
+method global$fun_function_parameter_subtyping$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
 {
   var anonymous$1: dom$Unit
-  anonymous$1 := pkg$$global$nullable_parameter$NTkotlin_Boolean((dom$Casting$cast(false,
+  anonymous$1 := global$fun_nullable_parameter$fun_take$NT_Boolean$return$T_Unit((dom$Casting$cast(false,
     dom$Type$special$Nullable(dom$Type$Boolean())): dom$Nullable[Bool]))
   label label$ret
 }
 
-method pkg$$global$nullable_parameter$NTkotlin_Boolean(local$b: dom$Nullable[Bool])
+method global$fun_nullable_parameter$fun_take$NT_Boolean$return$T_Unit(local$b: dom$Nullable[Bool])
   returns (ret: dom$Unit)
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -1,5 +1,5 @@
 /when.kt:(4,15): info: Generated Viper text for return_when:
-method pkg$$global$return_when$Tkotlin_Boolean$Tkotlin_Boolean$Tkotlin_Boolean(local$a: Bool,
+method global$fun_return_when$fun_take$T_Boolean$T_Boolean$T_Boolean$return$T_Int(local$a: Bool,
   local$b: Bool, local$c: Bool)
   returns (ret: Int)
 {
@@ -18,7 +18,7 @@ method pkg$$global$return_when$Tkotlin_Boolean$Tkotlin_Boolean$Tkotlin_Boolean(l
 }
 
 /when.kt:(153,164): info: Generated Viper text for when_return:
-method pkg$$global$when_return$Tkotlin_Boolean$Tkotlin_Boolean$Tkotlin_Boolean(local$a: Bool,
+method global$fun_when_return$fun_take$T_Boolean$T_Boolean$T_Boolean$return$T_Int(local$a: Bool,
   local$b: Bool, local$c: Bool)
   returns (ret: Int)
 {
@@ -39,40 +39,40 @@ method pkg$$global$when_return$Tkotlin_Boolean$Tkotlin_Boolean$Tkotlin_Boolean(l
 }
 
 /when.kt:(323,341): info: Generated Viper text for single_branch_when:
-method pkg$$global$single_branch_when$Tkotlin_Boolean(local$a: Bool)
+method global$fun_single_branch_when$fun_take$T_Boolean$return$T_Int(local$a: Bool)
   returns (ret: Int)
 {
-  var local$1$x: Int
-  local$1$x := 1
+  var local1$x: Int
+  local1$x := 1
   if (local$a) {
-    local$1$x := 2
+    local1$x := 2
   }
-  ret := local$1$x
+  ret := local1$x
   goto label$ret
   label label$ret
 }
 
 /when.kt:(431,443): info: Generated Viper text for no_else_when:
-method pkg$$global$no_else_when$Tkotlin_Boolean$Tkotlin_Boolean$Tkotlin_Boolean(local$a: Bool,
+method global$fun_no_else_when$fun_take$T_Boolean$T_Boolean$T_Boolean$return$T_Int(local$a: Bool,
   local$b: Bool, local$c: Bool)
   returns (ret: Int)
 {
-  var local$1$y: Int
-  local$1$y := 0
+  var local1$y: Int
+  local1$y := 0
   if (local$a) {
-    local$1$y := 1
+    local1$y := 1
   } elseif (local$b) {
-    local$1$y := 2
+    local1$y := 2
   } elseif (local$c) {
-    local$1$y := 3
+    local1$y := 3
   }
-  ret := local$1$y
+  ret := local1$y
   goto label$ret
   label label$ret
 }
 
 /when.kt:(595,616): info: Generated Viper text for when_with_subject_var:
-method pkg$$global$when_with_subject_var$Tkotlin_Int(local$x: Int)
+method global$fun_when_with_subject_var$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
@@ -88,12 +88,12 @@ method pkg$$global$when_with_subject_var$Tkotlin_Int(local$x: Int)
 }
 
 /when.kt:(716,738): info: Generated Viper text for when_with_subject_call:
-method pkg$$global$when_with_subject_call$Tkotlin_Int(local$x: Int)
+method global$fun_when_with_subject_call$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 {
   var anonymous$1: Int
   var anonymous$2: Int
-  anonymous$1 := pkg$$global$when_with_subject_var$Tkotlin_Int(local$x)
+  anonymous$1 := global$fun_when_with_subject_var$fun_take$T_Int$return$T_Int(local$x)
   if (anonymous$1 == 1) {
     anonymous$2 := 2
   } elseif (anonymous$1 == 2) {
@@ -101,7 +101,7 @@ method pkg$$global$when_with_subject_call$Tkotlin_Int(local$x: Int)
   } else {
     var anonymous$3: Int
     var anonymous$4: Int
-    anonymous$3 := pkg$$global$when_with_subject_var$Tkotlin_Int(0)
+    anonymous$3 := global$fun_when_with_subject_var$fun_take$T_Int$return$T_Int(0)
     if (anonymous$3 == 3) {
       anonymous$4 := 4
     } elseif (anonymous$3 == 4) {
@@ -115,12 +115,12 @@ method pkg$$global$when_with_subject_call$Tkotlin_Int(local$x: Int)
   label label$ret
 }
 
-method pkg$$global$when_with_subject_var$Tkotlin_Int(local$x: Int)
+method global$fun_when_with_subject_var$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 
 
 /when.kt:(962,972): info: Generated Viper text for empty_when:
-method pkg$$global$empty_when$() returns (ret: Int)
+method global$fun_empty_when$fun_take$$return$T_Int() returns (ret: Int)
 {
   ret := 1
   goto label$ret
@@ -128,25 +128,26 @@ method pkg$$global$empty_when$() returns (ret: Int)
 }
 
 /when.kt:(1015,1028): info: Generated Viper text for unused_result:
-method pkg$$global$unused_result$() returns (ret: Int)
+method global$fun_unused_result$fun_take$$return$T_Int() returns (ret: Int)
 {
-  var local$1$x: Int
+  var local1$x: Int
   var anonymous$1: Int
   var anonymous$2: Int
   anonymous$2 := 5
   anonymous$1 := 0
-  local$1$x := anonymous$1
-  ret := local$1$x
+  local1$x := anonymous$1
+  ret := local1$x
   goto label$ret
   label label$ret
 }
 
 /when.kt:(1222,1229): info: Generated Viper text for when_is:
-method pkg$$global$when_is$TFoo(local$x: Ref) returns (ret: Bool)
+method global$fun_when_is$fun_take$T_class_global$class_Foo$return$T_Boolean(local$x: Ref)
+  returns (ret: Bool)
 {
   var anonymous$1: Bool
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$$class_Foo())
-  if (dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$pkg$$class_Bar())) {
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$global$class_Foo())
+  if (dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$global$class_Bar())) {
     anonymous$1 := true
   } else {
     anonymous$1 := false}


### PR DESCRIPTION
In particular, overloading now happens based on `TypeEmbedding` rather than the string representation of `ConeKotlinType`, which is more reliable and allows us to construct mangled names for objects that do not come from the compiled program.