### PR TITLE
Represent lambdas as `ExpEmbedding`s

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/InlineMethodConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/InlineMethodConverter.kt
@@ -5,24 +5,19 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.fir.expressions.FirBlock
+import org.jetbrains.kotlin.formver.embeddings.LambdaExp
 import org.jetbrains.kotlin.formver.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.Name
 
 sealed interface SubstitutionItem {
-    val name: MangledName?
-    fun lambdaBody(): FirBlock? = null
-    fun lambdaArgs(): List<Name>? = null
+    val name: MangledName? get() = null
+    val lambda: LambdaExp? get() = null
 }
 
 data class SubstitutionName(override val name: MangledName) : SubstitutionItem
 
-data class SubstitutionLambda(val body: FirBlock, val args: List<Name>, val scopedNames: Map<Name, Int>) : SubstitutionItem {
-    override val name = null
-    override fun lambdaBody(): FirBlock = body
-    override fun lambdaArgs(): List<Name> = args
-}
+data class SubstitutionLambda(override val lambda: LambdaExp) : SubstitutionItem
 
 class InlineMethodConverter(
     private val programCtx: ProgramConversionContext,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -16,12 +16,14 @@ import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionEmbedding
+import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 
 interface ProgramConversionContext {
     val config: PluginConfiguration
     val errorCollector: ErrorCollector
 
     fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding
+    fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature
     fun embedType(type: ConeKotlinType): TypeEmbedding
     fun embedType(symbol: FirFunctionSymbol<*>): TypeEmbedding
     fun embedType(exp: FirExpression): TypeEmbedding = embedType(exp.resolvedType)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -122,7 +122,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     private var nextWhileIndex = 0
     override fun newWhileIndex() = ++nextWhileIndex
 
-    private fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature {
+    override fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature {
         val retType = symbol.resolvedReturnTypeRef.type
         val receiverType = symbol.receiverType
         return object : FunctionSignature {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/LambdaExp.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
+import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
+import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
+import org.jetbrains.kotlin.formver.conversion.getFunctionCallSubstitutionItems
+import org.jetbrains.kotlin.formver.embeddings.callables.CallableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
+import org.jetbrains.kotlin.formver.embeddings.callables.asData
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+import org.jetbrains.kotlin.name.Name
+
+class LambdaExp(
+    val signature: FunctionSignature, val function: FirAnonymousFunction,
+    val scopedNames: Map<Name, Int>,
+) : CallableEmbedding, ExpEmbedding,
+    FunctionSignature by signature {
+    override val type: TypeEmbedding = FunctionTypeEmbedding(signature.asData)
+
+    override fun toViper(): Exp = TODO("create new function object with counter, duplicable (requires toViper restructuring)")
+
+    override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
+        ctx.withResult(returnType) {
+            val paramNames = function.valueParameters.map { it.name }
+            paramNames.forEach { ctx.addScopedName(it) }
+            val callArgs = ctx.getFunctionCallSubstitutionItems(args)
+            val subs = paramNames.zip(callArgs).toMap()
+            val lambdaCtx = this.newBlock().withLambdaContext(this.signature, this.resultCtx.resultVar.name, subs, scopedNames)
+            lambdaCtx.convert(function.body!!)
+            // NOTE: It is necessary to drop the last stmt because is a wrong goto
+            val sqn = lambdaCtx.block.copy(stmts = lambdaCtx.block.stmts.dropLast(1))
+            // NOTE: Putting the block inside the then branch of an if-true statement is a little hack to make Viper respect the scoping
+            addStatement(Stmt.If(Exp.BoolLit(true), sqn, Stmt.Seqn(listOf(), listOf())))
+        }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
@@ -5,18 +5,12 @@
 
 package org.jetbrains.kotlin.formver.embeddings.callables
 
-import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.ExpEmbedding
 
 interface CallableEmbedding : CallableSignature {
     fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding
-
-    // Some callables can *only* be called via the FIR.
-    // TODO: Remove this method once everything implements `insertCallImpl` correctly.
-    fun insertFirCallImpl(firArgs: List<FirExpression>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
-        insertCall(firArgs.map { ctx.convert(it) }, ctx)
 }
 
 fun CallableEmbedding.insertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/inlining.fir.diag.txt
@@ -53,6 +53,7 @@ method global$fun_call_invoke_with_int$fun_take$fun_take$T_Int$return$T_Int$retu
   var local1$z: Int
   var anonymous$1: Int
   var anonymous$4: Int
+  var anonymous$5: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$g): dom$Type), dom$Type$Function())
   if (true) {
     var anonymous$2: Int
@@ -66,18 +67,17 @@ method global$fun_call_invoke_with_int$fun_take$fun_take$T_Int$return$T_Int$retu
     label inline_label$1$ret
   }
   local1$z := anonymous$1
+  special$invoke_function_object(local$g)
   if (true) {
-    var anonymous$5: Int
     var local2$x: Int
     var anonymous$6: Int
+    local2$x := anonymous$4 + anonymous$4
     special$invoke_function_object(local$g)
-    local2$x := anonymous$5 + anonymous$5
-    special$invoke_function_object(local$g)
-    anonymous$4 := anonymous$6
+    anonymous$5 := anonymous$6
     goto inline_label$1$ret
     label inline_label$1$ret
   }
-  ret := anonymous$4
+  ret := anonymous$5
   goto label$ret
   label label$ret
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -104,14 +104,15 @@ method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   label label$ret
 }
 
-method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
-
-
 method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
 
 
+method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
+
+
 method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -81,14 +81,14 @@ method global$fun_testSetterCascade$fun_take$$return$T_Unit()
   label label$ret
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
 method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
 /classes_setters.kt:(641,665): info: Generated Viper text for testSetterNoBackingField:
@@ -124,13 +124,13 @@ field class_scope_global$class_Bar$member_a: Int
 method global$fun_testSetterLambda$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
-  var anonymous$1: dom$Unit
+  var anonymous$1: Ref
+  var anonymous$2: dom$Unit
+  anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(0)
   if (true) {
-    var anonymous$2: Ref
-    anonymous$2 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(0)
-    inhale acc(anonymous$2.class_scope_global$class_Bar$member_a, write)
-    anonymous$2.class_scope_global$class_Bar$member_a := 42
-    exhale acc(anonymous$2.class_scope_global$class_Bar$member_a, write)
+    inhale acc(anonymous$1.class_scope_global$class_Bar$member_a, write)
+    anonymous$1.class_scope_global$class_Bar$member_a := 42
+    exhale acc(anonymous$1.class_scope_global$class_Bar$member_a, write)
     label inline_label$1$ret
   }
   label label$ret
@@ -139,3 +139,4 @@ method global$fun_testSetterLambda$fun_take$$return$T_Unit()
 method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -75,22 +75,22 @@ method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
   returns (ret: dom$Unit)
 
 
-method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
-  returns (ret: dom$Unit)
-
-
 method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
+method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
 
 
 method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
+  returns (ret: dom$Unit)
 
 
 /function_overloading.kt:(318,346): info: Generated Viper text for testClassFunctionOverloading:
@@ -119,16 +119,17 @@ method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
-  local$f: Ref)
-  returns (ret: dom$Unit)
-
-
 method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
+  local$f: Ref)
+  returns (ret: dom$Unit)
+
+
 method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
   local$b: Ref)
   returns (ret: dom$Unit)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.fir.diag.txt
@@ -1,21 +1,4 @@
-/inlining_lambdas.kt:(11,17): info: Generated Viper text for invoke:
-method global$fun_invoke$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f: Ref)
-  returns (ret: Int)
-  requires acc(local$f.special$function_object_call_counter, write)
-  requires special$duplicable(local$f)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
-{
-  var anonymous$1: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
-  special$invoke_function_object(local$f)
-  ret := anonymous$1
-  goto label$ret
-  label label$ret
-}
-
-/inlining_lambdas.kt:(65,77): info: Generated Viper text for explicit_arg:
+/inlining_lambdas.kt:(136,148): info: Generated Viper text for explicit_arg:
 method global$fun_explicit_arg$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
@@ -35,7 +18,7 @@ method global$fun_explicit_arg$fun_take$$return$T_Int() returns (ret: Int)
   label label$ret
 }
 
-/inlining_lambdas.kt:(127,139): info: Generated Viper text for implicit_arg:
+/inlining_lambdas.kt:(198,210): info: Generated Viper text for implicit_arg:
 method global$fun_implicit_arg$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
@@ -55,7 +38,7 @@ method global$fun_implicit_arg$fun_take$$return$T_Int() returns (ret: Int)
   label label$ret
 }
 
-/inlining_lambdas.kt:(185,194): info: Generated Viper text for lambda_if:
+/inlining_lambdas.kt:(256,265): info: Generated Viper text for lambda_if:
 method global$fun_lambda_if$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$1: Int
@@ -80,7 +63,7 @@ method global$fun_lambda_if$fun_take$$return$T_Int() returns (ret: Int)
   label label$ret
 }
 
-/inlining_lambdas.kt:(325,346): info: Generated Viper text for return_value_not_used:
+/inlining_lambdas.kt:(396,417): info: Generated Viper text for return_value_not_used:
 method global$fun_return_value_not_used$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -99,7 +82,7 @@ method global$fun_return_value_not_used$fun_take$$return$T_Unit()
   label label$ret
 }
 
-/inlining_lambdas.kt:(382,391): info: Generated Viper text for shadowing:
+/inlining_lambdas.kt:(453,462): info: Generated Viper text for shadowing:
 method global$fun_shadowing$fun_take$$return$T_Int() returns (ret: Int)
 {
   var local1$x: Int
@@ -125,7 +108,7 @@ method global$fun_shadowing$fun_take$$return$T_Int() returns (ret: Int)
   label label$ret
 }
 
-/inlining_lambdas.kt:(537,540): info: Generated Viper text for foo:
+/inlining_lambdas.kt:(608,611): info: Generated Viper text for foo:
 method global$fun_foo$fun_take$$return$T_Int() returns (ret: Int)
 {
   var local1$x: Int
@@ -147,7 +130,7 @@ method global$fun_foo$fun_take$$return$T_Int() returns (ret: Int)
   label label$ret
 }
 
-/inlining_lambdas.kt:(604,610): info: Generated Viper text for nested:
+/inlining_lambdas.kt:(675,681): info: Generated Viper text for nested:
 method global$fun_nested$fun_take$$return$T_Int() returns (ret: Int)
 {
   var local1$x: Int

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inlining_lambdas.kt
@@ -1,4 +1,7 @@
-inline fun <!VIPER_TEXT!>invoke<!>(f: (Int) -> Int): Int {
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+
+@NeverConvert
+inline fun invoke(f: (Int) -> Int): Int {
     return f(0)
 }
 


### PR DESCRIPTION
We don't yet support `toViper` since that would require a method call. However, we do have uniform function calls with this!  (i.e. no more `insertFirCallImpl` vs `insertCallImpl` distinction.)