### PR TITLE
Change try-catch implementation to match Kotlin's CFG

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -53,7 +53,16 @@ interface StmtConversionContext<out RTC : ResultTrackingContext> : MethodConvers
     fun <R> withFreshWhile(action: StmtConversionContext<RTC>.() -> R): R
     fun <R> withWhenSubject(subject: VariableEmbedding?, action: StmtConversionContext<RTC>.() -> R): R
     fun <R> withCheckedSafeCallSubject(subject: ExpEmbedding?, action: StmtConversionContext<RTC>.() -> R): R
-    fun withCatches(catches: List<FirCatch>, action: StmtConversionContext<RTC>.(exitLabel: Label) -> Unit): CatchBlockListData
+    fun withCatches(
+        catches: List<FirCatch>,
+        action: StmtConversionContext<RTC>.(catchBlockListData: CatchBlockListData) -> Unit,
+    ): CatchBlockListData
+}
+
+fun <RTC : ResultTrackingContext> StmtConversionContext<RTC>.nonDeterministically(action: StmtConversionContext<RTC>.() -> Unit) {
+    val branchVar = freshAnonVar(BooleanTypeEmbedding)
+    addDeclaration(branchVar.toLocalVarDecl())
+    addStatement(Stmt.If(branchVar.toViper(), withNewScopeToBlock(action), Stmt.Seqn()))
 }
 
 fun StmtConversionContext<ResultTrackingContext>.convertAndStore(exp: FirExpression): VariableEmbedding = store(convert(exp))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/LambdaExp.kt
@@ -21,7 +21,6 @@ class LambdaExp(
     private val parentCtx: MethodConversionContext,
 ) : CallableEmbedding, ExpEmbedding,
     FunctionSignature by signature {
-    override val canThrow: Boolean = false
     override val type: TypeEmbedding = FunctionTypeEmbedding(signature.asData)
 
     override fun toViper(): Exp = TODO("create new function object with counter, duplicable (requires toViper restructuring)")

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
@@ -7,10 +7,7 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.conversion.withResult
-import org.jetbrains.kotlin.formver.embeddings.BooleanTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.ExpEmbedding
-import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 /**
  * Kotlin entity that can be called.
@@ -18,32 +15,10 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
  * Should be used exclusively through `insertCall` below.
  */
 interface CallableEmbedding : CallableSignature {
-    /**
-     * Indicates whether the function *call* can throw.
-     *
-     * Note that this is generally false for everything inlined: the inlined body may throw,
-     * but the call itself typically can't.
-     */
-    val canThrow: Boolean
-
     fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding
 }
 
 fun CallableEmbedding.insertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
-    // If this method call can throw, then instead of obtaining a result, we can jump to any currently
-    // active catch label. From the point of view of Viper, the method call never happened.
-    // This is not entirely accurate, since this means that we did not relinquish any permissions to
-    // this method call; in our current implementation that does not matter, as we never pass permissions.
-    if (canThrow) {
-        for (label in ctx.activeCatchLabels) {
-            ctx.withResult(BooleanTypeEmbedding) {
-                val block = withNewScopeToBlock {
-                    addStatement(label.toGoto())
-                }
-                addStatement(Stmt.If(resultExp.toViper(), block, Stmt.Seqn()))
-            }
-        }
-    }
     return args.zip(formalArgTypes)
         .map { (arg, type) -> arg.withType(type) }
         .let { insertCallImpl(it, ctx) }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
@@ -16,8 +16,6 @@ class InlineNamedFunction(
     val signature: FullNamedFunctionSignature,
     val symbol: FirFunctionSymbol<*>,
 ) : CallableEmbedding, FullNamedFunctionSignature by signature {
-    override val canThrow: Boolean = false
-
     @OptIn(SymbolInternals::class)
     override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
         val inlineBody = symbol.fir.body ?: throw Exception("Function symbol $symbol has a null body")

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.formver.embeddings.ExpEmbedding
 class NonInlineNamedFunction(
     val signature: FullNamedFunctionSignature,
 ) : CallableEmbedding, FullNamedFunctionSignature by signature {
-    override val canThrow: Boolean = true
     override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
         ctx.withResult(returnType) {
             addStatement(toMethodCall(args, resultCtx.resultVar))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -21,9 +21,6 @@ import org.jetbrains.kotlin.name.Name
  * offers more possibilities for reasoning about the code.
  */
 interface SpecialKotlinFunction : FunctionEmbedding {
-    override val canThrow: Boolean
-        get() = false
-
     val packageName: List<String>
     val className: String?
         get() = null

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -88,3 +88,79 @@ method global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(loca
 
 
 /calls_in_place.kt:(866,889): warning: Function incorrect_at_least_once may not satisfy its contract.
+
+/calls_in_place.kt:(1150,1183): info: Generated Viper text for incorrect_exactly_once_with_catch:
+method global$fun_incorrect_exactly_once_with_catch$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures local$f.special$function_object_call_counter ==
+    old(local$f.special$function_object_call_counter) + 1
+{
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
+  if (true) {
+    var anonymous$0: Bool
+    var anonymous$1: dom$Unit
+    var anonymous$2: Bool
+    if (anonymous$0) {
+      goto label$catch$0
+    }
+    special$invoke_function_object(local$f)
+    if (anonymous$2) {
+      goto label$catch$0
+    }
+    goto label$try_exit$0
+  }
+  if (true) {
+    label label$catch$0
+    goto label$try_exit$0
+  }
+  label label$try_exit$0
+  label label$ret$0
+}
+
+/calls_in_place.kt:(1150,1183): warning: Viper verification error: Postcondition of global$fun_incorrect_exactly_once_with_catch$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
+
+
+/calls_in_place.kt:(1150,1183): warning: Function incorrect_exactly_once_with_catch may not satisfy its contract.
+
+/calls_in_place.kt:(1478,1519): info: Generated Viper text for incorrect_exactly_once_with_call_in_catch:
+method global$fun_incorrect_exactly_once_with_call_in_catch$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+  ensures local$f.special$function_object_call_counter ==
+    old(local$f.special$function_object_call_counter) + 1
+{
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$f): dom$Type), dom$Type$Function())
+  if (true) {
+    var anonymous$0: Bool
+    var anonymous$1: dom$Unit
+    var anonymous$2: Bool
+    if (anonymous$0) {
+      goto label$catch$0
+    }
+    special$invoke_function_object(local$f)
+    if (anonymous$2) {
+      goto label$catch$0
+    }
+    goto label$try_exit$0
+  }
+  if (true) {
+    var anonymous$3: dom$Unit
+    label label$catch$0
+    special$invoke_function_object(local$f)
+    goto label$try_exit$0
+  }
+  label label$try_exit$0
+  label label$ret$0
+}
+
+/calls_in_place.kt:(1478,1519): warning: Viper verification error: Postcondition of global$fun_incorrect_exactly_once_with_call_in_catch$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold. (<no position>)
+
+
+/calls_in_place.kt:(1478,1519): warning: Function incorrect_exactly_once_with_call_in_catch may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.kt
@@ -39,3 +39,30 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>i
     }
     return unknown(f)
 }
+
+// Consistency check with current Kotlin contract verification mechanism.
+@Suppress("WRONG_INVOCATION_KIND")
+@OptIn(ExperimentalContracts::class)
+fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>incorrect_exactly_once_with_catch<!>(f : () -> Unit) : Unit {
+    contract {
+        callsInPlace(f, EXACTLY_ONCE)
+    }
+    try {
+        f()
+    } catch (e: Exception) {
+    }
+}
+
+// Consistency check with current Kotlin contract verification mechanism.
+@Suppress("WRONG_INVOCATION_KIND")
+@OptIn(ExperimentalContracts::class)
+fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT, VIPER_VERIFICATION_ERROR!>incorrect_exactly_once_with_call_in_catch<!>(f : () -> Unit) : Unit {
+    contract {
+        callsInPlace(f, EXACTLY_ONCE)
+    }
+    try {
+        f()
+    } catch (e: Exception) {
+        f()
+    }
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/try_catch.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/try_catch.fir.diag.txt
@@ -5,16 +5,16 @@ method global$fun_try_catch$fun_take$$return$T_Unit()
   if (true) {
     var anonymous$0: Bool
     var anonymous$1: dom$Unit
-    var anonymous$2: Bool
-    var anonymous$3: dom$Unit
+    var anonymous$2: dom$Unit
+    var anonymous$3: Bool
     if (anonymous$0) {
       goto label$catch$0
     }
     anonymous$1 := global$fun_call$fun_take$T_Int$return$T_Unit(0)
-    if (anonymous$2) {
+    anonymous$2 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
+    if (anonymous$3) {
       goto label$catch$0
     }
-    anonymous$3 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
     goto label$try_exit$0
   }
   if (true) {
@@ -38,34 +38,34 @@ method global$fun_nested_try_catch$fun_take$$return$T_Unit()
   if (true) {
     var anonymous$0: Bool
     var anonymous$1: dom$Unit
+    var anonymous$6: Bool
     if (anonymous$0) {
       goto label$catch$0
     }
     anonymous$1 := global$fun_call$fun_take$T_Int$return$T_Unit(0)
     if (true) {
       var anonymous$2: Bool
-      var anonymous$3: Bool
-      var anonymous$4: dom$Unit
+      var anonymous$3: dom$Unit
+      var anonymous$4: Bool
       if (anonymous$2) {
-        goto label$catch$0
-      }
-      if (anonymous$3) {
         goto label$catch$1
       }
-      anonymous$4 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
+      anonymous$3 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
+      if (anonymous$4) {
+        goto label$catch$1
+      }
       goto label$try_exit$1
     }
     if (true) {
-      var anonymous$5: Bool
-      var anonymous$6: dom$Unit
+      var anonymous$5: dom$Unit
       label label$catch$1
-      if (anonymous$5) {
-        goto label$catch$0
-      }
-      anonymous$6 := global$fun_call$fun_take$T_Int$return$T_Unit(2)
+      anonymous$5 := global$fun_call$fun_take$T_Int$return$T_Unit(2)
       goto label$try_exit$1
     }
     label label$try_exit$1
+    if (anonymous$6) {
+      goto label$catch$0
+    }
     goto label$try_exit$0
   }
   if (true) {
@@ -85,21 +85,21 @@ method global$fun_try_catch_with_inline$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
   if (true) {
-    var anonymous$0: dom$Unit
+    var anonymous$0: Bool
+    var anonymous$1: dom$Unit
+    var anonymous$4: Bool
+    if (anonymous$0) {
+      goto label$catch$0
+    }
     if (true) {
-      var anonymous$1: Bool
       var anonymous$2: dom$Unit
-      var anonymous$3: Bool
-      var anonymous$4: dom$Unit
-      if (anonymous$1) {
-        goto label$catch$0
-      }
+      var anonymous$3: dom$Unit
       anonymous$2 := global$fun_call$fun_take$T_Int$return$T_Unit(0)
-      if (anonymous$3) {
-        goto label$catch$0
-      }
-      anonymous$4 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
+      anonymous$3 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
       label label$ret$1
+    }
+    if (anonymous$4) {
+      goto label$catch$0
     }
     goto label$try_exit$0
   }
@@ -124,8 +124,16 @@ method global$fun_try_catch_shadowing$fun_take$$return$T_Unit()
   var local0$x: Int
   local0$x := 0
   if (true) {
+    var anonymous$0: Bool
     var local1$x: Int
+    var anonymous$1: Bool
+    if (anonymous$0) {
+      goto label$catch$0
+    }
     local1$x := 1
+    if (anonymous$1) {
+      goto label$catch$0
+    }
     goto label$try_exit$0
   }
   if (true) {
@@ -146,9 +154,9 @@ method global$fun_multiple_catches$fun_take$$return$T_Unit()
     var anonymous$0: Bool
     var anonymous$1: Bool
     var anonymous$2: dom$Unit
-    var anonymous$3: Bool
+    var anonymous$3: dom$Unit
     var anonymous$4: Bool
-    var anonymous$5: dom$Unit
+    var anonymous$5: Bool
     if (anonymous$0) {
       goto label$catch$0
     }
@@ -156,13 +164,13 @@ method global$fun_multiple_catches$fun_take$$return$T_Unit()
       goto label$catch$1
     }
     anonymous$2 := global$fun_call$fun_take$T_Int$return$T_Unit(0)
-    if (anonymous$3) {
+    anonymous$3 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
+    if (anonymous$4) {
       goto label$catch$0
     }
-    if (anonymous$4) {
+    if (anonymous$5) {
       goto label$catch$1
     }
-    anonymous$5 := global$fun_call$fun_take$T_Int$return$T_Unit(1)
     goto label$try_exit$0
   }
   if (true) {


### PR DESCRIPTION
In Kotlin, the semantics of the CFG are that a try block may go to the catch block at the beginning or the end of the block (nondeterministically).  This gives slightly different verification results than what we got in our implementation.  From discussions with the Language Evolution team, the default behaviour is the desired one, so I'm switching the implementation to this simpler one so that we get verification failures in the same situations as they do.

More details to be found here: https://kotlinlang.org/spec/control--and-data-flow-analysis.html#other-expressions