### PR TITLE
Implement properties on interfaces

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.ErrorCollector
 import org.jetbrains.kotlin.formver.PluginConfiguration
-import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
+import org.jetbrains.kotlin.formver.embeddings.PropertyEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionEmbedding
@@ -33,7 +33,7 @@ interface ProgramConversionContext {
     fun embedType(type: ConeKotlinType): TypeEmbedding
     fun embedType(symbol: FirFunctionSymbol<*>): TypeEmbedding
     fun embedType(exp: FirExpression): TypeEmbedding = embedType(exp.resolvedType)
-    fun getField(field: FirPropertySymbol): FieldEmbedding?
+    fun embedProperty(symbol: FirPropertySymbol): PropertyEmbedding
 }
 
 fun ProgramConversionContext.freshAnonVar(type: TypeEmbedding): VariableEmbedding = VariableEmbedding(anonNameProducer.getFresh(), type)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -5,10 +5,7 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyGetter
-import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertySetter
 import org.jetbrains.kotlin.fir.expressions.*
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.formver.calleeSymbol
@@ -77,31 +74,18 @@ fun StmtConversionContext<ResultTrackingContext>.declareLocal(
 fun StmtConversionContext<ResultTrackingContext>.embedPropertyAccess(symbol: FirPropertyAccessExpression): PropertyAccessEmbedding =
     when (val calleeSymbol = symbol.calleeSymbol) {
         is FirValueParameterSymbol -> embedParameter(calleeSymbol).asPropertyAccess()
-        is FirPropertySymbol ->
-            when {
-                symbol.dispatchReceiver != null -> {
-                    ClassPropertyAccess(convert(symbol.dispatchReceiver!!), embedGetter(calleeSymbol), embedSetter(calleeSymbol))
-                }
-                symbol.extensionReceiver != null -> {
-                    ClassPropertyAccess(convert(symbol.extensionReceiver!!), embedGetter(calleeSymbol), embedSetter(calleeSymbol))
-                }
-                else -> embedLocalProperty(calleeSymbol)
+        is FirPropertySymbol -> when {
+            symbol.dispatchReceiver != null -> {
+                val property = embedProperty(calleeSymbol)
+                ClassPropertyAccess(convert(symbol.dispatchReceiver!!), property)
             }
+            symbol.extensionReceiver != null -> {
+                val property = embedProperty(calleeSymbol)
+                ClassPropertyAccess(convert(symbol.extensionReceiver!!), property)
+            }
+            else -> embedLocalProperty(calleeSymbol)
+        }
         else -> throw IllegalStateException("Property access symbol $calleeSymbol has unsupported type.")
-    }
-
-@OptIn(SymbolInternals::class)
-fun <RTC : ResultTrackingContext> StmtConversionContext<RTC>.embedGetter(symbol: FirPropertySymbol): GetterEmbedding? =
-    when (val getter = symbol.fir.getter) {
-        null, is FirDefaultPropertyGetter -> getField(symbol)?.let { BackingFieldGetter(it) }
-        else -> CustomGetter(embedFunction(getter.symbol))
-    }
-
-@OptIn(SymbolInternals::class)
-fun <RTC : ResultTrackingContext> StmtConversionContext<RTC>.embedSetter(symbol: FirPropertySymbol): SetterEmbedding? =
-    when (val setter = symbol.fir.setter) {
-        null, is FirDefaultPropertySetter -> getField(symbol)?.let { BackingFieldSetter(it) }
-        else -> CustomSetter(embedFunction(setter.symbol))
     }
 
 fun StmtConversionContext<ResultTrackingContext>.withResult(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
+import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
+import org.jetbrains.kotlin.formver.conversion.withResult
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+abstract class BackingFieldAccess(val field: FieldEmbedding) {
+    fun <RTC : ResultTrackingContext> access(
+        receiver: ExpEmbedding,
+        ctx: StmtConversionContext<RTC>,
+        action: StmtConversionContext<RTC>.(access: FieldAccess) -> Unit,
+    ) {
+        val fieldAccess = FieldAccess(receiver, field)
+        val accPred = fieldAccess.getAccessPredicate()
+        ctx.addStatement(Stmt.Inhale(accPred))
+        ctx.action(fieldAccess)
+        ctx.addStatement(Stmt.Exhale(accPred))
+    }
+}
+
+class BackingFieldGetter(field: FieldEmbedding) : BackingFieldAccess(field), GetterEmbedding {
+    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
+        ctx.withResult(field.type) {
+            access(receiver, this) {
+                addStatement(Stmt.assign(resultExp.toViper(), it.toViper()))
+                field.type.provenInvariants(resultExp.toViper()).forEach { inv ->
+                    addStatement(Stmt.Inhale(inv))
+                }
+            }
+        }
+}
+
+class BackingFieldSetter(field: FieldEmbedding) : BackingFieldAccess(field), SetterEmbedding {
+    override fun setValue(receiver: ExpEmbedding, value: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>) {
+        access(receiver, ctx) {
+            addStatement(Stmt.assign(it.toViper(), value.withType(field.type).toViper()))
+        }
+    }
+}
+

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassPropertyAccess.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassPropertyAccess.kt
@@ -7,63 +7,15 @@ package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.conversion.withResult
-import org.jetbrains.kotlin.formver.embeddings.callables.CallableEmbedding
-import org.jetbrains.kotlin.formver.embeddings.callables.insertCall
-import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 // We assume that thanks to the checks done by the Kotlin compiler, a property with a
 // missing getter or setter will never be accessed.
-class ClassPropertyAccess(val receiver: ExpEmbedding, val getter: GetterEmbedding?, val setter: SetterEmbedding?) :
+class ClassPropertyAccess(val receiver: ExpEmbedding, val property: PropertyEmbedding) :
     PropertyAccessEmbedding {
-    override fun getValue(ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding = getter!!.getValue(receiver, ctx)
+    override fun getValue(ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding = property.getter!!.getValue(receiver, ctx)
 
     override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>) {
-        setter!!.setValue(receiver, value, ctx)
+        property.setter!!.setValue(receiver, value, ctx)
     }
 }
 
-abstract class BackingFieldAccess(val field: FieldEmbedding) {
-    fun <RTC : ResultTrackingContext> access(
-        receiver: ExpEmbedding,
-        ctx: StmtConversionContext<RTC>,
-        action: StmtConversionContext<RTC>.(access: FieldAccess) -> Unit,
-    ) {
-        val fieldAccess = FieldAccess(receiver, field)
-        val accPred = fieldAccess.getAccessPredicate()
-        ctx.addStatement(Stmt.Inhale(accPred))
-        ctx.action(fieldAccess)
-        ctx.addStatement(Stmt.Exhale(accPred))
-    }
-}
-
-class BackingFieldGetter(field: FieldEmbedding) : BackingFieldAccess(field), GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
-        ctx.withResult(field.type) {
-            access(receiver, this) {
-                addStatement(Stmt.assign(resultExp.toViper(), it.toViper()))
-                field.type.provenInvariants(resultExp.toViper()).forEach { inv ->
-                    addStatement(Stmt.Inhale(inv))
-                }
-            }
-        }
-}
-
-class BackingFieldSetter(field: FieldEmbedding) : BackingFieldAccess(field), SetterEmbedding {
-    override fun setValue(receiver: ExpEmbedding, value: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>) {
-        access(receiver, ctx) {
-            addStatement(Stmt.assign(it.toViper(), value.withType(field.type).toViper()))
-        }
-    }
-}
-
-class CustomGetter(val getterMethod: CallableEmbedding) : GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
-        getterMethod.insertCall(listOf(receiver), ctx)
-}
-
-class CustomSetter(val setterMethod: CallableEmbedding) : SetterEmbedding {
-    override fun setValue(receiver: ExpEmbedding, value: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>) {
-        setterMethod.insertCall(listOf(receiver, value), ctx)
-    }
-}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/CustomAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/CustomAccessors.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
+import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
+import org.jetbrains.kotlin.formver.embeddings.callables.CallableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.callables.insertCall
+
+class CustomGetter(val getterMethod: CallableEmbedding) : GetterEmbedding {
+    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding =
+        getterMethod.insertCall(listOf(receiver), ctx)
+}
+
+class CustomSetter(val setterMethod: CallableEmbedding) : SetterEmbedding {
+    override fun setValue(receiver: ExpEmbedding, value: ExpEmbedding, ctx: StmtConversionContext<ResultTrackingContext>) {
+        setterMethod.insertCall(listOf(receiver, value), ctx)
+    }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
@@ -51,8 +51,8 @@ fun FirPropertyAccessorSymbol.embedName(ctx: ProgramConversionContext): ScopedKo
         else -> throw IllegalStateException("An extension property must be a setter or a getter!")
     }
     false -> when {
-        isGetter -> callableId.embedGetterName()
-        isSetter -> callableId.embedSetterName()
+        isGetter -> propertySymbol.callableId.embedGetterName()
+        isSetter -> propertySymbol.callableId.embedSetterName()
         else -> throw IllegalStateException("A property accessor must be a setter or a getter!")
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PropertyEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PropertyEmbedding.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+class PropertyEmbedding(val getter: GetterEmbedding?, val setter: SetterEmbedding?)

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -12,6 +12,10 @@ method global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean(local$x
   label label$ret$0
 }
 
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
+
 /is_type_contract.kt:(121,142): warning: Viper verification error: Postcondition of global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Unit()) might not hold. (<no position>)
 
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,6 +1,10 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
 field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
+
 method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullable[dom$Any])
   returns (ret: Bool)
   ensures ret == true ==>
@@ -14,6 +18,10 @@ method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullabl
 
 /is_type_contract.kt:(322,330): info: Generated Viper text for isString:
 field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
 
 method global$fun_isString$fun_take$T_Any$return$T_Boolean(this: dom$Any)
   returns (ret: Bool)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -77,6 +77,10 @@ method global$fun_binary_logic_expressions$fun_take$T_Boolean$T_Boolean$return$T
 
 
 /returns_booleans.kt:(1268,1281): info: Generated Viper text for isNullOrEmpty:
+method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$getter_size(this: Ref)
+  returns (ret: Int)
+
+
 method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: dom$Nullable[Ref])
   returns (ret: Bool)
   ensures ret == false ==> this != (dom$Nullable$null(): dom$Nullable[Ref])
@@ -105,3 +109,4 @@ method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$
 
 method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: Ref)
   returns (ret: Bool)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -10,17 +10,18 @@ method global$fun_testGetter$fun_take$$return$T_Unit()
   var local0$succ: Int
   anonymous$0 := class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
   local0$wrapper := anonymous$0
-  anonymous$1 := pkg$special$global$getter_accessor(local0$wrapper)
+  anonymous$1 := class_scope_global$class_IntWrapper$getter_succ(local0$wrapper)
   local0$succ := anonymous$1
   label label$ret$0
 }
 
+method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
+  returns (ret: Int)
+
+
 method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
-
-
-method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
 
 
 /classes_getters.kt:(278,295): info: Generated Viper text for testCascadeGetter:
@@ -99,10 +100,14 @@ method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   anonymous$2 := local0$wrapper.class_scope_global$class_IntWrapperContainer$member_i
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$global$class_IntWrapper())
   exhale acc(local0$wrapper.class_scope_global$class_IntWrapperContainer$member_i, write)
-  anonymous$3 := pkg$special$global$getter_accessor(anonymous$2)
+  anonymous$3 := class_scope_global$class_IntWrapper$getter_succ(anonymous$2)
   local0$succ := anonymous$3
   label label$ret$0
 }
+
+method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
+  returns (ret: Int)
+
 
 method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
   returns (ret: Ref)
@@ -113,5 +118,3 @@ method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_c
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
 
-
-method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -14,20 +14,22 @@ method global$fun_testCustomSetter$fun_take$$return$T_Unit()
   inhale acc(local0$f.class_scope_global$class_AlwaysPlusOne$member_b, write)
   local0$f.class_scope_global$class_AlwaysPlusOne$member_b := 1
   exhale acc(local0$f.class_scope_global$class_AlwaysPlusOne$member_b, write)
-  anonymous$1 := pkg$special$global$setter_accessor(local0$f, 1)
+  anonymous$1 := class_scope_global$class_AlwaysPlusOne$setter_num(local0$f,
+    1)
   label label$ret$0
 }
+
+method class_scope_global$class_AlwaysPlusOne$getter_num(this: Ref)
+  returns (ret: Int)
+
+
+method class_scope_global$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
 
 method class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_AlwaysPlusOne())
-
-
-method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
-
-
-method pkg$special$global$setter_accessor(this: Ref, local$value: Int)
-  returns (ret: dom$Unit)
 
 
 /classes_setters.kt:(490,500): info: Generated Viper text for testSetter:
@@ -102,20 +104,20 @@ method global$fun_testSetterNoBackingField$fun_take$$return$T_Unit()
   var anonymous$1: dom$Unit
   anonymous$0 := class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   local0$baz := anonymous$0
-  anonymous$1 := pkg$special$global$setter_accessor(local0$baz, 42)
+  anonymous$1 := class_scope_global$class_Baz$setter_a(local0$baz, 42)
   label label$ret$0
 }
+
+method class_scope_global$class_Baz$getter_a(this: Ref) returns (ret: Int)
+
+
+method class_scope_global$class_Baz$setter_a(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
 
 method class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Baz())
-
-
-method pkg$special$global$getter_accessor(this: Ref) returns (ret: Int)
-
-
-method pkg$special$global$setter_accessor(this: Ref, local$value: Int)
-  returns (ret: dom$Unit)
 
 
 /classes_setters.kt:(805,821): info: Generated Viper text for testSetterLambda:
@@ -139,3 +141,4 @@ method global$fun_testSetterLambda$fun_take$$return$T_Unit()
 method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
@@ -1,0 +1,27 @@
+/interface.kt:(65,80): info: Generated Viper text for test_properties:
+method class_scope_global$class_Foo$getter_varProp(this: Ref)
+  returns (ret: Int)
+
+
+method class_scope_global$class_Foo$setter_varProp(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
+
+method class_scope_global$class_Foo$getter_valProp(this: Ref)
+  returns (ret: Int)
+
+
+method global$fun_test_properties$fun_take$T_class_global$class_Foo$return$T_Unit(local$foo: Ref)
+  returns (ret: dom$Unit)
+{
+  var anonymous$0: dom$Unit
+  var anonymous$1: Int
+  var anonymous$2: Int
+  var local0$x: Int
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$foo): dom$Type), dom$Type$global$class_Foo())
+  anonymous$0 := class_scope_global$class_Foo$setter_varProp(local$foo, 0)
+  anonymous$1 := class_scope_global$class_Foo$getter_varProp(local$foo)
+  anonymous$2 := class_scope_global$class_Foo$getter_valProp(local$foo)
+  local0$x := anonymous$1 + anonymous$2
+  label label$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/interface.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/interface.kt
@@ -1,0 +1,9 @@
+interface Foo {
+    var varProp: Int
+    val valProp: Int
+}
+
+fun <!VIPER_TEXT!>test_properties<!>(foo: Foo) {
+    foo.varProp = 0
+    val x = foo.varProp + foo.valProp
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -144,6 +144,10 @@ method global$fun_evlis_operator_return$fun_take$NT_Int$return$T_Int(local$x: do
 /nullable.kt:(711,720): info: Generated Viper text for safe_call:
 field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
+
 method global$fun_safe_call$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
 {
@@ -166,6 +170,10 @@ method pkg$kotlin$class_scope_pkg$kotlin$global$class_Any$fun_hashCode$fun_take$
 
 /nullable.kt:(760,778): info: Generated Viper text for safe_call_property:
 field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
 
 method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -264,6 +264,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("interface.kt")
+        public void testInterface() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/interface.kt");
+        }
+
+        @Test
         @TestMetadata("is_operator.kt")
         public void testIs_operator() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/is_operator.kt");


### PR DESCRIPTION
We do this by introducing a dedicated property embedding, so that we can identify when a custom getter/setter should be used when defining the class.

Also fix a bug with member property getter/setter embeddings getting the wrong name.