### PR TITLE
Sort Viper output.

### DIFF
--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -22,11 +22,11 @@ data class Program(
     val trafos: Trafos = Trafos.NoTrafos,
 ) : IntoSilver<viper.silver.ast.Program> {
     override fun toSilver(): viper.silver.ast.Program = viper.silver.ast.Program(
-        domains.toSilver().toScalaSeq(),
-        fields.toSilver().toScalaSeq(),
-        functions.toSilver().toScalaSeq(),
+        domains.sortedBy { it.name.mangled }.toSilver().toScalaSeq(),
+        fields.sortedBy { it.name.mangled }.toSilver().toScalaSeq(),
+        functions.sortedBy { it.name.mangled }.toSilver().toScalaSeq(),
         emptySeq(), /* predicates */
-        methods.toSilver().toScalaSeq(),
+        methods.sortedBy { it.name.mangled }.toSilver().toScalaSeq(),
         emptySeq(), /* extensions */
         pos.toSilver(),
         info.toSilver(),

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
@@ -1,4 +1,13 @@
 /calls_in_place_leak.kt:(364,386): info: Generated Viper text for invalid_calls_in_place:
+method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
+  returns (ret: dom$Unit)
+  requires acc(local$f.special$function_object_call_counter, write)
+  requires special$duplicable(local$f)
+  ensures acc(local$f.special$function_object_call_counter, write)
+  ensures old(local$f.special$function_object_call_counter) <=
+    local$f.special$function_object_call_counter
+
+
 method global$fun_invalid_calls_in_place$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
   returns (ret: dom$Unit)
   requires acc(local$f.special$function_object_call_counter, write)
@@ -12,15 +21,6 @@ method global$fun_invalid_calls_in_place$fun_take$fun_take$$return$T_Unit$return
   anonymous$0 := global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f)
   label label$ret$0
 }
-
-method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
-  returns (ret: dom$Unit)
-  requires acc(local$f.special$function_object_call_counter, write)
-  requires special$duplicable(local$f)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
-
 
 /calls_in_place_leak.kt:(364,386): warning: Viper verification error: The precondition of method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion special$duplicable(local$f) might not hold. (<no position>)
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,10 +1,6 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
 field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
-  returns (ret: Int)
-
-
 method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullable[dom$Any])
   returns (ret: Bool)
   ensures ret == true ==>
@@ -16,12 +12,12 @@ method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullabl
   label label$ret$0
 }
 
-/is_type_contract.kt:(322,330): info: Generated Viper text for isString:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
-
 method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
+
+/is_type_contract.kt:(322,330): info: Generated Viper text for isString:
+field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
 method global$fun_isString$fun_take$T_Any$return$T_Boolean(this: dom$Any)
   returns (ret: Bool)
@@ -33,6 +29,10 @@ method global$fun_isString$fun_take$T_Any$return$T_Boolean(this: dom$Any)
   goto label$ret$0
   label label$ret$0
 }
+
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
 
 /is_type_contract.kt:(491,508): info: Generated Viper text for subtypeTransitive:
 method global$fun_subtypeTransitive$fun_take$T_Unit$return$T_Unit(local$x: dom$Unit)
@@ -46,6 +46,11 @@ method global$fun_subtypeTransitive$fun_take$T_Unit$return$T_Unit(local$x: dom$U
 /is_type_contract.kt:(686,707): info: Generated Viper text for constructorReturnType:
 field class_scope_global$class_Foo$member_bar: Ref
 
+method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
 method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
   returns (ret: Bool)
   ensures ret == true
@@ -56,11 +61,6 @@ method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
   goto label$ret$0
   label label$ret$0
 }
-
-method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
 
 /is_type_contract.kt:(832,848): info: Generated Viper text for subtypeSuperType:
 field class_scope_global$class_Foo$member_bar: Ref

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -55,6 +55,13 @@ method global$fun_logical_not$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
 }
 
 /returns_booleans.kt:(1052,1075): info: Generated Viper text for call_fun_with_contracts:
+method global$fun_binary_logic_expressions$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$a: Bool,
+  local$b: Bool)
+  returns (ret: Bool)
+  ensures ret == false ==> local$b && false
+  ensures ret == true ==> (true || local$a) && (local$b || true)
+
+
 method global$fun_call_fun_with_contracts$fun_take$T_Boolean$return$T_Boolean(local$b: Bool)
   returns (ret: Bool)
   ensures ret == true
@@ -69,18 +76,7 @@ method global$fun_call_fun_with_contracts$fun_take$T_Boolean$return$T_Boolean(lo
   label label$ret$0
 }
 
-method global$fun_binary_logic_expressions$fun_take$T_Boolean$T_Boolean$return$T_Boolean(local$a: Bool,
-  local$b: Bool)
-  returns (ret: Bool)
-  ensures ret == false ==> local$b && false
-  ensures ret == true ==> (true || local$a) && (local$b || true)
-
-
 /returns_booleans.kt:(1268,1281): info: Generated Viper text for isNullOrEmpty:
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$getter_size(this: Ref)
-  returns (ret: Int)
-
-
 method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: dom$Nullable[Ref])
   returns (ret: Bool)
   ensures ret == false ==> this != (dom$Nullable$null(): dom$Nullable[Ref])
@@ -109,4 +105,8 @@ method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$
 
 method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: Ref)
   returns (ret: Bool)
+
+
+method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$getter_size(this: Ref)
+  returns (ret: Int)
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
@@ -1,6 +1,22 @@
 /class_constructors.kt:(389,411): info: Generated Viper text for onlySecondConstructors:
 field class_scope_global$class_Foo$member_a: Int
 
+method class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Bool)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Int,
+  local$x2: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
 method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -38,24 +54,18 @@ method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Bool)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Int,
-  local$x2: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
 /class_constructors.kt:(590,617): info: Generated Viper text for primaryAndSecondConstructor:
 field class_scope_global$class_Bar$member_a: Int
+
+method class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Bool)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
 
 method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -82,12 +92,3 @@ method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
   local0$shouldBeAnswer := anonymous$3
   label label$ret$0
 }
-
-method class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Bool)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-
-
-method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -3,6 +3,12 @@ field class_scope_global$class_Foo$member_a: Int
 
 field class_scope_global$class_Foo$member_b: Int
 
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
+  local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
 method global$fun_createFoo$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -26,14 +32,13 @@ method global$fun_createFoo$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
-  local$b: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
 /classes.kt:(147,156): info: Generated Viper text for createBar:
 field class_scope_global$class_Bar$member_a: dom$Nullable[Ref]
+
+method class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: dom$Nullable[Ref])
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
 
 method global$fun_createBar$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -45,7 +50,3 @@ method global$fun_createBar$fun_take$$return$T_Unit()
   local0$b := anonymous$0
   label label$ret$0
 }
-
-method class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: dom$Nullable[Ref])
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -1,6 +1,15 @@
 /classes_getters.kt:(195,205): info: Generated Viper text for testGetter:
 field class_scope_global$class_IntWrapper$member_n: Int
 
+method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
+
+
+method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
+  returns (ret: Int)
+
+
 method global$fun_testGetter$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -15,21 +24,23 @@ method global$fun_testGetter$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
-  returns (ret: Int)
-
-
-method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
-
-
 /classes_getters.kt:(278,295): info: Generated Viper text for testCascadeGetter:
+field class_scope_global$class_Bar$member_f: Ref
+
 field class_scope_global$class_Foo$member_a: Int
 
 field class_scope_global$class_Foo$member_b: Int
 
-field class_scope_global$class_Bar$member_f: Ref
+method class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
+  local$b: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
 
 method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -68,21 +79,24 @@ method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
-  local$b: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-
-
 /classes_getters.kt:(401,425): info: Generated Viper text for testCascadeCustomGetters:
 field class_scope_global$class_IntWrapper$member_n: Int
 
 field class_scope_global$class_IntWrapperContainer$member_i: Ref
+
+method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
+
+
+method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
+  returns (ret: Int)
+
+
+method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
+
 
 method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -104,17 +118,3 @@ method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   local0$succ := anonymous$3
   label label$ret$0
 }
-
-method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
-  returns (ret: Int)
-
-
-method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
-
-
-method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -3,6 +3,19 @@ field class_scope_global$class_AlwaysPlusOne$member_b: Int
 
 field class_scope_global$class_AlwaysPlusOne$member_num: Int
 
+method class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_AlwaysPlusOne())
+
+
+method class_scope_global$class_AlwaysPlusOne$getter_num(this: Ref)
+  returns (ret: Int)
+
+
+method class_scope_global$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
+
 method global$fun_testCustomSetter$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -19,21 +32,13 @@ method global$fun_testCustomSetter$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_AlwaysPlusOne$getter_num(this: Ref)
-  returns (ret: Int)
-
-
-method class_scope_global$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
-  returns (ret: dom$Unit)
-
-
-method class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_AlwaysPlusOne())
-
-
 /classes_setters.kt:(490,500): info: Generated Viper text for testSetter:
 field class_scope_global$class_Person$member_age: Int
+
+method class_scope_global$class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(local$age: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Person())
+
 
 method global$fun_testSetter$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -53,15 +58,20 @@ method global$fun_testSetter$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(local$age: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Person())
-
-
 /classes_setters.kt:(572,589): info: Generated Viper text for testSetterCascade:
 field class_scope_global$class_Bar$member_a: Int
 
 field class_scope_global$class_Foo$member_b: Ref
+
+method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
 
 method global$fun_testSetterCascade$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -83,18 +93,20 @@ method global$fun_testSetterCascade$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-
-
 /classes_setters.kt:(641,665): info: Generated Viper text for testSetterNoBackingField:
 field class_scope_global$class_Baz$member__a: Int
+
+method class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Baz())
+
+
+method class_scope_global$class_Baz$getter_a(this: Ref) returns (ret: Int)
+
+
+method class_scope_global$class_Baz$setter_a(this: Ref, local$value: Int)
+  returns (ret: dom$Unit)
+
 
 method global$fun_testSetterNoBackingField$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -108,20 +120,13 @@ method global$fun_testSetterNoBackingField$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method class_scope_global$class_Baz$getter_a(this: Ref) returns (ret: Int)
-
-
-method class_scope_global$class_Baz$setter_a(this: Ref, local$value: Int)
-  returns (ret: dom$Unit)
-
-
-method class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Baz())
-
-
 /classes_setters.kt:(805,821): info: Generated Viper text for testSetterLambda:
 field class_scope_global$class_Bar$member_a: Int
+
+method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
 
 method global$fun_testSetterLambda$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -137,8 +142,3 @@ method global$fun_testSetterLambda$fun_take$$return$T_Unit()
   }
   label label$ret$0
 }
-
-method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
@@ -1,6 +1,11 @@
 /exp_side_effects.kt:(27,34): info: Generated Viper text for get_foo:
 field class_scope_global$class_Foo$member_x: Int
 
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
 method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
@@ -12,11 +17,6 @@ method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
 /exp_side_effects.kt:(55,66): info: Generated Viper text for side_effect:
 method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)
 {
@@ -27,6 +27,14 @@ method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)
 
 /exp_side_effects.kt:(83,87): info: Generated Viper text for test:
 field class_scope_global$class_Foo$member_x: Int
+
+method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
+method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)
+
 
 method global$fun_test$fun_take$$return$T_Unit() returns (ret: dom$Unit)
 {
@@ -49,11 +57,3 @@ method global$fun_test$fun_take$$return$T_Unit() returns (ret: dom$Unit)
   local0$y := anonymous$3 + anonymous$4
   label label$ret$0
 }
-
-method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -1,4 +1,8 @@
 /extension_properties.kt:(125,148): info: Generated Viper text for extensionGetterProperty:
+method global$ext_getter_succ$fun_take$T_Int$return$T_Int(this: Int)
+  returns (ret: Int)
+
+
 method global$fun_extensionGetterProperty$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -15,20 +19,7 @@ method global$fun_extensionGetterProperty$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method global$ext_getter_succ$fun_take$T_Int$return$T_Int(this: Int)
-  returns (ret: Int)
-
-
 /extension_properties.kt:(204,227): info: Generated Viper text for extensionSetterProperty:
-method global$fun_extensionSetterProperty$fun_take$$return$T_Unit()
-  returns (ret: dom$Unit)
-{
-  var anonymous$0: dom$Unit
-  anonymous$0 := global$ext_setter_strange$fun_take$T_Int$T_Int$return$T_Unit(42,
-    0)
-  label label$ret$0
-}
-
 method global$ext_getter_strange$fun_take$T_Int$return$T_Int(this: Int)
   returns (ret: Int)
 
@@ -38,8 +29,26 @@ method global$ext_setter_strange$fun_take$T_Int$T_Int$return$T_Unit(this: Int,
   returns (ret: dom$Unit)
 
 
+method global$fun_extensionSetterProperty$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
+{
+  var anonymous$0: dom$Unit
+  anonymous$0 := global$ext_setter_strange$fun_take$T_Int$T_Int$return$T_Unit(42,
+    0)
+  label label$ret$0
+}
+
 /extension_properties.kt:(409,448): info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
 field class_scope_global$class_Foo$member_x: Int
+
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
+method global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
+
 
 method global$fun_extensionGetterPropertyUserDefinedClass$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -55,30 +64,8 @@ method global$fun_extensionGetterPropertyUserDefinedClass$fun_take$$return$T_Uni
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
-  returns (ret: Int)
-
-
 /extension_properties.kt:(499,538): info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
 field class_scope_global$class_Foo$member_x: Int
-
-method global$fun_extensionSetterPropertyUserDefinedClass$fun_take$$return$T_Unit()
-  returns (ret: dom$Unit)
-{
-  var anonymous$0: Ref
-  var local0$f: Ref
-  var anonymous$1: dom$Unit
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
-  local0$f := anonymous$0
-  anonymous$1 := global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$T_Unit(local0$f,
-    42)
-  label label$ret$0
-}
 
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
@@ -93,3 +80,16 @@ method global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$
   local$v: Int)
   returns (ret: dom$Unit)
 
+
+method global$fun_extensionSetterPropertyUserDefinedClass$fun_take$$return$T_Unit()
+  returns (ret: dom$Unit)
+{
+  var anonymous$0: Ref
+  var local0$f: Ref
+  var anonymous$1: dom$Unit
+  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
+  local0$f := anonymous$0
+  anonymous$1 := global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$T_Unit(local0$f,
+    42)
+  label label$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -1,12 +1,25 @@
 /full_viper_dump.kt:(54,55): info: Generated Viper text for f:
-domain dom$Unit  {
+domain dom$Any  {
 
-  function dom$Unit$element(): dom$Unit
 
-  axiom {
-    (forall u: dom$Unit ::
-      { (dom$TypeOf$typeOf(u): dom$Type) }
-      (dom$TypeOf$typeOf(u): dom$Type) == dom$Type$Unit())
+}
+
+domain dom$Casting[A, B]  {
+
+  function dom$Casting$cast(a: A, newType: dom$Type): B
+
+  axiom dom$Casting$null_cast {
+    (forall newType: dom$Type ::
+      { (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), dom$Type$special$Nullable(newType)): dom$Nullable[B]) }
+      (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), dom$Type$special$Nullable(newType)): dom$Nullable[B]) ==
+      (dom$Nullable$null(): dom$Nullable[B]))
+  }
+
+  axiom dom$Casting$type_of_cast {
+    (forall a: A, newType: dom$Type ::
+      { (dom$TypeOf$typeOf((dom$Casting$cast(a, newType): B)): dom$Type) }
+      dom$Type$isSubtype((dom$TypeOf$typeOf((dom$Casting$cast(a, newType): B)): dom$Type),
+      newType))
   }
 }
 
@@ -37,42 +50,6 @@ domain dom$Nullable[T]  {
       nx != (dom$Nullable$null(): dom$Nullable[T]) ==>
       (dom$Casting$cast((dom$Casting$cast(nx, newType): T), (dom$TypeOf$typeOf(nx): dom$Type)): dom$Nullable[T]) ==
       nx)
-  }
-}
-
-domain dom$Casting[A, B]  {
-
-  function dom$Casting$cast(a: A, newType: dom$Type): B
-
-  axiom dom$Casting$null_cast {
-    (forall newType: dom$Type ::
-      { (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), dom$Type$special$Nullable(newType)): dom$Nullable[B]) }
-      (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), dom$Type$special$Nullable(newType)): dom$Nullable[B]) ==
-      (dom$Nullable$null(): dom$Nullable[B]))
-  }
-
-  axiom dom$Casting$type_of_cast {
-    (forall a: A, newType: dom$Type ::
-      { (dom$TypeOf$typeOf((dom$Casting$cast(a, newType): B)): dom$Type) }
-      dom$Type$isSubtype((dom$TypeOf$typeOf((dom$Casting$cast(a, newType): B)): dom$Type),
-      newType))
-  }
-}
-
-domain dom$TypeOf[T]  {
-
-  function dom$TypeOf$typeOf(x: T): dom$Type
-
-  axiom {
-    (forall i: Int ::
-      { (dom$TypeOf$typeOf(i): dom$Type) }
-      (dom$TypeOf$typeOf(i): dom$Type) == dom$Type$Int())
-  }
-
-  axiom {
-    (forall b: Bool ::
-      { (dom$TypeOf$typeOf(b): dom$Type) }
-      (dom$TypeOf$typeOf(b): dom$Type) == dom$Type$Boolean())
   }
 }
 
@@ -254,23 +231,44 @@ domain dom$Type  {
   }
 }
 
-domain dom$Any  {
+domain dom$TypeOf[T]  {
 
+  function dom$TypeOf$typeOf(x: T): dom$Type
 
+  axiom {
+    (forall i: Int ::
+      { (dom$TypeOf$typeOf(i): dom$Type) }
+      (dom$TypeOf$typeOf(i): dom$Type) == dom$Type$Int())
+  }
+
+  axiom {
+    (forall b: Bool ::
+      { (dom$TypeOf$typeOf(b): dom$Type) }
+      (dom$TypeOf$typeOf(b): dom$Type) == dom$Type$Boolean())
+  }
 }
 
-field special$function_object_call_counter: Int
+domain dom$Unit  {
+
+  function dom$Unit$element(): dom$Unit
+
+  axiom {
+    (forall u: dom$Unit ::
+      { (dom$TypeOf$typeOf(u): dom$Type) }
+      (dom$TypeOf$typeOf(u): dom$Type) == dom$Type$Unit())
+  }
+}
 
 field class_scope_global$class_Foo$member_x: Int
+
+field special$function_object_call_counter: Int
 
 function special$duplicable(anonymous$0: Ref): Bool
 
 
-method special$invoke_function_object(anonymous$0: Ref)
-  requires acc(anonymous$0.special$function_object_call_counter, write)
-  ensures acc(anonymous$0.special$function_object_call_counter, write)
-  ensures old(anonymous$0.special$function_object_call_counter) + 1 ==
-    anonymous$0.special$function_object_call_counter
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
 method global$fun_f$fun_take$$return$T_Unit() returns (ret: dom$Unit)
@@ -282,7 +280,9 @@ method global$fun_f$fun_take$$return$T_Unit() returns (ret: dom$Unit)
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+method special$invoke_function_object(anonymous$0: Ref)
+  requires acc(anonymous$0.special$function_object_call_counter, write)
+  ensures acc(anonymous$0.special$function_object_call_counter, write)
+  ensures old(anonymous$0.special$function_object_call_counter) + 1 ==
+    anonymous$0.special$function_object_call_counter
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_call.fir.diag.txt
@@ -1,4 +1,8 @@
 /function_call.kt:(99,112): info: Generated Viper text for function_call:
+method global$fun_f$fun_take$T_Int$return$T_Int(local$x: Int)
+  returns (ret: Int)
+
+
 method global$fun_function_call$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -9,11 +13,11 @@ method global$fun_function_call$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
+/function_call.kt:(142,162): info: Generated Viper text for function_call_nested:
 method global$fun_f$fun_take$T_Int$return$T_Int(local$x: Int)
   returns (ret: Int)
 
 
-/function_call.kt:(142,162): info: Generated Viper text for function_call_nested:
 method global$fun_function_call_nested$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -25,6 +29,3 @@ method global$fun_function_call_nested$fun_take$$return$T_Unit()
   anonymous$2 := global$fun_f$fun_take$T_Int$return$T_Int(anonymous$1)
   label label$ret$0
 }
-
-method global$fun_f$fun_take$T_Int$return$T_Int(local$x: Int)
-  returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -49,6 +49,32 @@ method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
 }
 
 /function_overloading.kt:(200,226): info: Generated Viper text for testGlobalScopeOverloading:
+method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
+method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
+  returns (ret: dom$Unit)
+
+
+method global$fun_fakePrint$fun_take$T_Int$return$T_Unit(local$value: Int)
+  returns (ret: dom$Unit)
+
+
+method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
+  returns (ret: dom$Unit)
+
+
+method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
+  returns (ret: dom$Unit)
+
+
 method global$fun_testGlobalScopeOverloading$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -67,15 +93,19 @@ method global$fun_testGlobalScopeOverloading$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method global$fun_fakePrint$fun_take$T_Int$return$T_Unit(local$value: Int)
+/function_overloading.kt:(318,346): info: Generated Viper text for testClassFunctionOverloading:
+method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+
+
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
+  local$b: Ref)
   returns (ret: dom$Unit)
 
 
-method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
-  returns (ret: dom$Unit)
-
-
-method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
+method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
+  local$f: Ref)
   returns (ret: dom$Unit)
 
 
@@ -84,16 +114,6 @@ method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
 
-method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
-  returns (ret: dom$Unit)
-
-
-method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-
-
-/function_overloading.kt:(318,346): info: Generated Viper text for testClassFunctionOverloading:
 method global$fun_testClassFunctionOverloading$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -113,22 +133,3 @@ method global$fun_testClassFunctionOverloading$fun_take$$return$T_Unit()
     anonymous$3)
   label label$ret$0
 }
-
-method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-
-
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
-  local$f: Ref)
-  returns (ret: dom$Unit)
-
-
-method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
-  local$b: Ref)
-  returns (ret: dom$Unit)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
@@ -16,6 +16,11 @@ method class_scope_global$class_Box$fun_genericMethod$fun_take$T_class_global$cl
 /generics.kt:(88,97): info: Generated Viper text for createBox:
 field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
 
+method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
+
+
 method global$fun_createBox$fun_take$$return$T_Int() returns (ret: Int)
 {
   var anonymous$0: Ref
@@ -45,13 +50,13 @@ method global$fun_createBox$fun_take$$return$T_Int() returns (ret: Int)
   label label$ret$0
 }
 
+/generics.kt:(208,223): info: Generated Viper text for setGenericField:
+field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
+
 method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
 
-
-/generics.kt:(208,223): info: Generated Viper text for setGenericField:
-field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
 
 method global$fun_setGenericField$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -66,11 +71,6 @@ method global$fun_setGenericField$fun_take$$return$T_Unit()
   exhale acc(local0$box.class_scope_global$class_Box$member_t, write)
   label label$ret$0
 }
-
-method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
-
 
 /generics.kt:(274,284): info: Generated Viper text for genericFun:
 method global$fun_genericFun$fun_take$NT_Any$return$NT_Any(local$t: dom$Nullable[dom$Any])

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
@@ -52,8 +52,9 @@ method global$fun_if_as_expression$fun_take$$return$T_Boolean()
   label label$ret$0
 }
 
-method global$fun_simple_if$fun_take$$return$T_Int() returns (ret: Int)
-
-
 method global$fun_if_on_parameter$fun_take$T_Boolean$return$T_Int(local$b: Bool)
   returns (ret: Int)
+
+
+method global$fun_simple_if$fun_take$$return$T_Int() returns (ret: Int)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -1,9 +1,9 @@
 /inheritance.kt:(74,78): info: Generated Viper text for getY:
+field class_scope_global$class_Foo$member_b: Bool
+
 field class_scope_global$class_Foo$member_x: Int
 
 field class_scope_global$class_Foo$member_y: Int
-
-field class_scope_global$class_Foo$member_b: Bool
 
 method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
@@ -19,13 +19,13 @@ method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$r
 }
 
 /inheritance.kt:(171,174): info: Generated Viper text for sum:
-field class_scope_global$class_Foo$member_x: Int
-
-field class_scope_global$class_Foo$member_y: Int
+field class_scope_global$class_Bar$member_z: Int
 
 field class_scope_global$class_Foo$member_b: Bool
 
-field class_scope_global$class_Bar$member_z: Int
+field class_scope_global$class_Foo$member_x: Int
+
+field class_scope_global$class_Foo$member_y: Int
 
 method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret: Int)
@@ -45,13 +45,17 @@ method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$re
 }
 
 /inheritance.kt:(217,232): info: Generated Viper text for callSuperMethod:
+field class_scope_global$class_Bar$member_z: Int
+
+field class_scope_global$class_Foo$member_b: Bool
+
 field class_scope_global$class_Foo$member_x: Int
 
 field class_scope_global$class_Foo$member_y: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
 
-field class_scope_global$class_Bar$member_z: Int
 
 method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
@@ -65,18 +69,14 @@ method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
-  returns (ret: Int)
-
-
 /inheritance.kt:(279,295): info: Generated Viper text for accessSuperField:
-field class_scope_global$class_Foo$member_x: Int
-
-field class_scope_global$class_Foo$member_y: Int
+field class_scope_global$class_Bar$member_z: Int
 
 field class_scope_global$class_Foo$member_b: Bool
 
-field class_scope_global$class_Bar$member_z: Int
+field class_scope_global$class_Foo$member_x: Int
+
+field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_accessSuperField$fun_take$T_class_global$class_Bar$return$T_Boolean(local$bar: Ref)
   returns (ret: Bool)
@@ -92,13 +92,13 @@ method global$fun_accessSuperField$fun_take$T_class_global$class_Bar$return$T_Bo
 }
 
 /inheritance.kt:(341,355): info: Generated Viper text for accessNewField:
-field class_scope_global$class_Foo$member_x: Int
-
-field class_scope_global$class_Foo$member_y: Int
+field class_scope_global$class_Bar$member_z: Int
 
 field class_scope_global$class_Foo$member_b: Bool
 
-field class_scope_global$class_Bar$member_z: Int
+field class_scope_global$class_Foo$member_x: Int
+
+field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_accessNewField$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
@@ -114,13 +114,17 @@ method global$fun_accessNewField$fun_take$T_class_global$class_Bar$return$T_Int(
 }
 
 /inheritance.kt:(397,410): info: Generated Viper text for callNewMethod:
+field class_scope_global$class_Bar$member_z: Int
+
+field class_scope_global$class_Foo$member_b: Bool
+
 field class_scope_global$class_Foo$member_x: Int
 
 field class_scope_global$class_Foo$member_y: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
+  returns (ret: Int)
 
-field class_scope_global$class_Bar$member_z: Int
 
 method global$fun_callNewMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
@@ -133,18 +137,14 @@ method global$fun_callNewMethod$fun_take$T_class_global$class_Bar$return$T_Int(l
   label label$ret$0
 }
 
-method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
-  returns (ret: Int)
-
-
 /inheritance.kt:(456,469): info: Generated Viper text for setSuperField:
-field class_scope_global$class_Foo$member_x: Int
-
-field class_scope_global$class_Foo$member_y: Int
+field class_scope_global$class_Bar$member_z: Int
 
 field class_scope_global$class_Foo$member_b: Bool
 
-field class_scope_global$class_Bar$member_z: Int
+field class_scope_global$class_Foo$member_x: Int
+
+field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_setSuperField$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
@@ -157,13 +157,13 @@ method global$fun_setSuperField$fun_take$T_class_global$class_Bar$return$T_Unit(
 }
 
 /inheritance.kt:(506,527): info: Generated Viper text for accessSuperSuperField:
-field class_scope_global$class_Foo$member_x: Int
-
-field class_scope_global$class_Foo$member_y: Int
+field class_scope_global$class_Bar$member_z: Int
 
 field class_scope_global$class_Foo$member_b: Bool
 
-field class_scope_global$class_Bar$member_z: Int
+field class_scope_global$class_Foo$member_x: Int
+
+field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_accessSuperSuperField$fun_take$T_class_global$class_Baz$return$T_Int(local$baz: Ref)
   returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
@@ -1,14 +1,14 @@
 /interface.kt:(65,80): info: Generated Viper text for test_properties:
+method class_scope_global$class_Foo$getter_valProp(this: Ref)
+  returns (ret: Int)
+
+
 method class_scope_global$class_Foo$getter_varProp(this: Ref)
   returns (ret: Int)
 
 
 method class_scope_global$class_Foo$setter_varProp(this: Ref, local$value: Int)
   returns (ret: dom$Unit)
-
-
-method class_scope_global$class_Foo$getter_valProp(this: Ref)
-  returns (ret: Int)
 
 
 method global$fun_test_properties$fun_take$T_class_global$class_Foo$return$T_Unit(local$foo: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -33,6 +33,10 @@ method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class
 /member_functions.kt:(140,152): info: Generated Viper text for sibling_call:
 field class_scope_global$class_Foo$member_x: Int
 
+method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+  returns (ret: Int)
+
+
 method class_scope_global$class_Foo$fun_sibling_call$fun_take$T_class_global$class_Foo$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$other: Ref)
   returns (ret: dom$Unit)
@@ -44,12 +48,17 @@ method class_scope_global$class_Foo$fun_sibling_call$fun_take$T_class_global$cla
   label label$ret$0
 }
 
+/member_functions.kt:(207,228): info: Generated Viper text for outer_member_fun_call:
+field class_scope_global$class_Foo$member_x: Int
+
+method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+
+
 method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
 
-
-/member_functions.kt:(207,228): info: Generated Viper text for outer_member_fun_call:
-field class_scope_global$class_Foo$member_x: Int
 
 method global$fun_outer_member_fun_call$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -62,11 +71,3 @@ method global$fun_outer_member_fun_call$fun_take$$return$T_Unit()
   anonymous$1 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local0$f)
   label label$ret$0
 }
-
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
-  returns (ret: Ref)
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-
-
-method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
-  returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -94,6 +94,10 @@ method global$fun_elvis_operator$fun_take$NT_Int$return$T_Int(local$x: dom$Nulla
 }
 
 /nullable.kt:(522,544): info: Generated Viper text for elvis_operator_complex:
+method global$fun_elvis_operator$fun_take$NT_Int$return$T_Int(local$x: dom$Nullable[Int])
+  returns (ret: Int)
+
+
 method global$fun_elvis_operator_complex$fun_take$NT_Int$return$T_Int(local$x: dom$Nullable[Int])
   returns (ret: Int)
 {
@@ -118,10 +122,6 @@ method global$fun_pass_nullable_parameter$fun_take$NT_Int$return$NT_Int(local$x:
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 
 
-method global$fun_elvis_operator$fun_take$NT_Int$return$T_Int(local$x: dom$Nullable[Int])
-  returns (ret: Int)
-
-
 /nullable.kt:(627,648): info: Generated Viper text for evlis_operator_return:
 method global$fun_evlis_operator_return$fun_take$NT_Int$return$T_Int(local$x: dom$Nullable[Int])
   returns (ret: Int)
@@ -144,10 +144,6 @@ method global$fun_evlis_operator_return$fun_take$NT_Int$return$T_Int(local$x: do
 /nullable.kt:(711,720): info: Generated Viper text for safe_call:
 field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
-  returns (ret: Int)
-
-
 method global$fun_safe_call$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
 {
@@ -168,12 +164,12 @@ method pkg$kotlin$class_scope_pkg$kotlin$global$class_Any$fun_hashCode$fun_take$
   returns (ret: Int)
 
 
-/nullable.kt:(760,778): info: Generated Viper text for safe_call_property:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
-
 method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
+
+/nullable.kt:(760,778): info: Generated Viper text for safe_call_property:
+field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
 method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
@@ -194,8 +190,17 @@ method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_S
   label label$ret$0
 }
 
+method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+  returns (ret: Int)
+
+
 /nullable.kt:(899,914): info: Generated Viper text for safe_call_chain:
 field class_scope_global$class_Foo$member_v: Int
+
+method class_scope_global$class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo(this: Ref)
+  returns (ret: dom$Nullable[Ref])
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$global$class_Foo()))
+
 
 method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_Int(local$foo: dom$Nullable[Ref])
   returns (ret: dom$Nullable[Int])
@@ -234,8 +239,3 @@ method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_I
   goto label$ret$0
   label label$ret$0
 }
-
-method class_scope_global$class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo(this: Ref)
-  returns (ret: dom$Nullable[Ref])
-  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$global$class_Foo()))
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/try_catch.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/try_catch.fir.diag.txt
@@ -1,4 +1,8 @@
 /try_catch.kt:(139,148): info: Generated Viper text for try_catch:
+method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Int)
+  returns (ret: dom$Unit)
+
+
 method global$fun_try_catch$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -27,11 +31,11 @@ method global$fun_try_catch$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
+/try_catch.kt:(253,269): info: Generated Viper text for nested_try_catch:
 method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 
 
-/try_catch.kt:(253,269): info: Generated Viper text for nested_try_catch:
 method global$fun_nested_try_catch$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -76,11 +80,11 @@ method global$fun_nested_try_catch$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
+/try_catch.kt:(559,580): info: Generated Viper text for try_catch_with_inline:
 method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Int)
   returns (ret: dom$Unit)
 
 
-/try_catch.kt:(559,580): info: Generated Viper text for try_catch_with_inline:
 method global$fun_try_catch_with_inline$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -113,10 +117,6 @@ method global$fun_try_catch_with_inline$fun_take$$return$T_Unit()
   label label$ret$0
 }
 
-method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Int)
-  returns (ret: dom$Unit)
-
-
 /try_catch.kt:(674,693): info: Generated Viper text for try_catch_shadowing:
 method global$fun_try_catch_shadowing$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
@@ -147,6 +147,10 @@ method global$fun_try_catch_shadowing$fun_take$$return$T_Unit()
 }
 
 /try_catch.kt:(804,820): info: Generated Viper text for multiple_catches:
+method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Int)
+  returns (ret: dom$Unit)
+
+
 method global$fun_multiple_catches$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -188,7 +192,3 @@ method global$fun_multiple_catches$fun_take$$return$T_Unit()
   label label$try_exit$0
   label label$ret$0
 }
-
-method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Int)
-  returns (ret: dom$Unit)
-


### PR DESCRIPTION
This ensures that changes in program logic don't cause diffs because things get processed earlier or later (though name changes still can, of course).