### PR TITLE
Add comparison operators

### DIFF
--- a/plugins/formal-verification/testData/diagnostics/no_contracts/comparison.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/comparison.fir.diag.txt
@@ -1,0 +1,38 @@
+/comparison.kt:(4,8): info: Generated Viper text for less:
+method global$fun_less$fun_take$T_Int$T_Int$return$T_Boolean(local$x: Int, local$y: Int)
+  returns (ret: Bool)
+{
+  ret := local$x < local$y
+  goto label$ret$0
+  label label$ret$0
+}
+
+/comparison.kt:(60,70): info: Generated Viper text for less_equal:
+method global$fun_less_equal$fun_take$T_Int$T_Int$return$T_Boolean(local$x: Int,
+  local$y: Int)
+  returns (ret: Bool)
+{
+  ret := local$x <= local$y
+  goto label$ret$0
+  label label$ret$0
+}
+
+/comparison.kt:(123,130): info: Generated Viper text for greater:
+method global$fun_greater$fun_take$T_Int$T_Int$return$T_Boolean(local$x: Int,
+  local$y: Int)
+  returns (ret: Bool)
+{
+  ret := local$x > local$y
+  goto label$ret$0
+  label label$ret$0
+}
+
+/comparison.kt:(182,195): info: Generated Viper text for greater_equal:
+method global$fun_greater_equal$fun_take$T_Int$T_Int$return$T_Boolean(local$x: Int,
+  local$y: Int)
+  returns (ret: Bool)
+{
+  ret := local$x >= local$y
+  goto label$ret$0
+  label label$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/comparison.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/comparison.kt
@@ -1,0 +1,15 @@
+fun <!VIPER_TEXT!>less<!>(x: Int, y: Int): Boolean {
+    return x < y
+}
+
+fun <!VIPER_TEXT!>less_equal<!>(x: Int, y: Int): Boolean {
+    return x <= y
+}
+
+fun <!VIPER_TEXT!>greater<!>(x: Int, y: Int): Boolean {
+    return x > y
+}
+
+fun <!VIPER_TEXT!>greater_equal<!>(x: Int, y: Int): Boolean {
+    return x >= y
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -186,6 +186,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("comparison.kt")
+        public void testComparison() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/comparison.kt");
+        }
+
+        @Test
         @TestMetadata("exp_side_effects.kt")
         public void testExp_side_effects() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.kt");


### PR DESCRIPTION
Comparison in Kotlin are implemented in the following way: `a < b` corresponds to `a.compareTo(b) < 0`
The `compareTo` method is nothing more than a subtraction. I don't know if this method deserves to be represented as a `specialKotlinFunction` since I think it is not used much. Moreover it has several overloadings that can make the encoding a bit hard
