### PR TITLE
Maintain access permissions of `val` properties.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/AccessPolicy.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/AccessPolicy.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+enum class AccessPolicy {
+    ALWAYS_INHALE_EXHALE, ALWAYS_READABLE, ALWAYS_WRITEABLE;
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
@@ -10,9 +10,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Type
 
 object SpecialFields {
     val FunctionObjectCallCounterField = BuiltinField(SpecialName("function_object_call_counter"), Type.Int)
-    val ListSizeField = BuiltinField(SpecialName("size"), Type.Int)
     val all = listOf(
         FunctionObjectCallCounterField,
-        ListSizeField
     )
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -5,16 +5,17 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
+import org.jetbrains.kotlin.formver.embeddings.ListSizeFieldEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.*
 
-fun LocalVar.sameSize(): Exp = EqCmp(fieldAccess(SpecialFields.ListSizeField), Old(fieldAccess(SpecialFields.ListSizeField)))
+fun LocalVar.sameSize(): Exp = EqCmp(fieldAccess(ListSizeFieldEmbedding.toViper()), Old(fieldAccess(ListSizeFieldEmbedding.toViper())))
 fun LocalVar.increasedSize(amount: Int): Exp =
-    EqCmp(fieldAccess(SpecialFields.ListSizeField), Add(Old(fieldAccess(SpecialFields.ListSizeField)), IntLit(amount)))
+    EqCmp(fieldAccess(ListSizeFieldEmbedding.toViper()), Add(Old(fieldAccess(ListSizeFieldEmbedding.toViper())), IntLit(amount)))
 
 fun NamedFunctionSignature.stdLibPreConditions(): List<Exp> =
-    if (isCollection) {
+    if (inCollectionsPkg) {
         when (sourceName) {
             "emptyList" -> listOf()
             "get" -> {
@@ -22,7 +23,7 @@ fun NamedFunctionSignature.stdLibPreConditions(): List<Exp> =
                 val indexArg = formalArgs[1].toViper()
                 listOf(
                     GeCmp(indexArg, IntLit(0)),
-                    GtCmp(receiver.fieldAccess(SpecialFields.ListSizeField), indexArg),
+                    GtCmp(receiver.fieldAccess(ListSizeFieldEmbedding.toViper()), indexArg),
                 )
             }
             else -> listOf()
@@ -35,10 +36,10 @@ fun NamedFunctionSignature.stdLibPreConditions(): List<Exp> =
 fun NamedFunctionSignature.stdLibPostConditions(): List<Exp> {
     val retVar = LocalVar(ReturnVariableName, returnType.viperType)
     val receiver = receiver?.toViper()
-    return if (isCollection) {
+    return if (inCollectionsPkg) {
         when (sourceName) {
             "emptyList" -> listOf(
-                EqCmp(retVar.fieldAccess(SpecialFields.ListSizeField), IntLit(0))
+                EqCmp(retVar.fieldAccess(ListSizeFieldEmbedding.toViper()), IntLit(0))
             )
             "get" -> {
                 listOf(receiver!!.sameSize())
@@ -49,8 +50,8 @@ fun NamedFunctionSignature.stdLibPostConditions(): List<Exp> {
             "isEmpty" -> {
                 listOf(
                     receiver!!.sameSize(),
-                    Implies(retVar, EqCmp(receiver.fieldAccess(SpecialFields.ListSizeField), IntLit(0))),
-                    Implies(Not(retVar), GtCmp(receiver.fieldAccess(SpecialFields.ListSizeField), IntLit(0)))
+                    Implies(retVar, EqCmp(receiver.fieldAccess(ListSizeFieldEmbedding.toViper()), IntLit(0))),
+                    Implies(Not(retVar), GtCmp(receiver.fieldAccess(ListSizeFieldEmbedding.toViper()), IntLit(0)))
                 )
             }
             else -> listOf()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
@@ -16,14 +16,13 @@ abstract class BackingFieldAccess(val field: FieldEmbedding) {
         ctx: StmtConversionContext<RTC>,
         action: StmtConversionContext<RTC>.(access: FieldAccess) -> Unit,
     ) {
-        val fieldAccess = FieldAccess(receiver, field)
-        val accPred = fieldAccess.getAccessPredicate()
-        if (field.inhaleOnAccess) {
-            ctx.addStatement(Stmt.Inhale(accPred))
+        val invariant = field.accessInvariantForAccess(receiver.toViper())
+        invariant?.let {
+            ctx.addStatement(Stmt.Inhale(it))
         }
-        ctx.action(fieldAccess)
-        if (field.inhaleOnAccess) {
-            ctx.addStatement(Stmt.Exhale(accPred))
+        ctx.action(FieldAccess(receiver, field))
+        invariant?.let {
+            ctx.addStatement(Stmt.Exhale(it))
         }
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -5,20 +5,57 @@
 
 package org.jetbrains.kotlin.formver.embeddings
 
-import org.jetbrains.kotlin.formver.conversion.SpecialFields
+import org.jetbrains.kotlin.formver.conversion.AccessPolicy
+import org.jetbrains.kotlin.formver.conversion.SpecialName
 import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Field
+import org.jetbrains.kotlin.formver.viper.ast.PermExp
 
-// inhalePolicy is true when it is necessary to inhale permission before accessing the field
-class FieldEmbedding(val name: MangledName, val type: TypeEmbedding, val inhaleOnAccess: Boolean = true) {
+/**
+ * Embedding of a backing field of a property.
+ */
+interface FieldEmbedding {
+    val name: MangledName
+    val type: TypeEmbedding
+    val accessPolicy: AccessPolicy
+
     fun toViper(): Field = Field(name, type.viperType)
+
+    fun extraAccessInvariantsForParameter(v: Exp): List<Exp> = listOf()
+
+    fun accessInvariantsForParameter(v: Exp): List<Exp> =
+        when (accessPolicy) {
+            AccessPolicy.ALWAYS_INHALE_EXHALE -> listOf()
+            AccessPolicy.ALWAYS_READABLE -> listOf(v.fieldAccessPredicate(toViper(), PermExp.WildcardPerm()))
+            AccessPolicy.ALWAYS_WRITEABLE -> listOf(v.fieldAccessPredicate(toViper(), PermExp.FullPerm()))
+        } + extraAccessInvariantsForParameter(v)
+
+    fun accessInvariantForAccess(v: Exp): Exp? =
+        when (accessPolicy) {
+            AccessPolicy.ALWAYS_INHALE_EXHALE -> v.fieldAccessPredicate(toViper(), PermExp.FullPerm())
+            AccessPolicy.ALWAYS_READABLE, AccessPolicy.ALWAYS_WRITEABLE -> null
+        }
+}
+
+class UserFieldEmbedding(override val name: ScopedKotlinName, override val type: TypeEmbedding, readOnly: Boolean) : FieldEmbedding {
+    override val accessPolicy: AccessPolicy = if (readOnly) AccessPolicy.ALWAYS_READABLE else AccessPolicy.ALWAYS_INHALE_EXHALE
+}
+
+object ListSizeFieldEmbedding : FieldEmbedding {
+    override val name = SpecialName("size")
+    override val type = IntTypeEmbedding
+
+    override val accessPolicy = AccessPolicy.ALWAYS_WRITEABLE
+    override fun extraAccessInvariantsForParameter(v: Exp): List<Exp> =
+        listOf(Exp.GeCmp(v.fieldAccess(toViper()), Exp.IntLit(0)))
 }
 
 fun ScopedKotlinName.specialEmbedding(): FieldEmbedding? {
     // in the future, new special properties can be added here (e.g. String.length)
     return when {
         isCollection -> when ((name as? MemberKotlinName)?.name.toString()) {
-            "size" -> FieldEmbedding(SpecialFields.ListSizeField.name, IntTypeEmbedding, false)
+            "size" -> ListSizeFieldEmbedding
             else -> null
         }
         else -> null

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
@@ -34,6 +34,7 @@ fun CallableId.embedExtensionGetterName(type: TypeEmbedding): ScopedKotlinName =
 fun CallableId.embedExtensionSetterName(type: TypeEmbedding): ScopedKotlinName =
     embedScopedWithType(type, ExtensionSetterKotlinName(callableName))
 fun CallableId.embedMemberPropertyName(): ScopedKotlinName = embedScoped(MemberKotlinName(callableName))
+fun CallableId.embedUnscopedPropertyName(): SimpleKotlinName = SimpleKotlinName(callableName)
 fun CallableId.embedFunctionName(type: TypeEmbedding): ScopedKotlinName =
     embedScopedWithType(type, FunctionKotlinName(callableName))
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ScopedKotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ScopedKotlinName.kt
@@ -16,6 +16,15 @@ data class ScopedKotlinName(val scope: NameScope, val name: KotlinName, val type
         get() = listOfNotNull(scope.mangled, name.mangled, type?.name?.mangled).joinToString("$")
 
     val isCollection: Boolean
+        // TODO: make this neater
+        get() = if (scope is ClassScope && scope.className.name is ClassKotlinName) {
+            scope.packageName.asString() == "kotlin.collections" && scope.className.name.name.asStringStripSpecialMarkers() == "Collection"
+        } else {
+            false
+        }
+
+    val inCollectionsPkg: Boolean
+        // TODO: make this neater
         get() = if (scope is PackagePrefixScope) {
             scope.packageName.asString() == "kotlin.collections"
         } else {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
@@ -34,8 +34,7 @@ class VariableEmbedding(val name: MangledName, override val type: TypeEmbedding)
         ctx.addStatement(Stmt.LocalVarAssign(toViper(), value.withType(type).toViper()))
     }
 
-    fun invariants(): List<Exp> = type.invariants(toViper())
-
+    fun pureInvariants(): List<Exp> = type.pureInvariants(toViper())
     fun provenInvariants(): List<Exp> = type.provenInvariants(toViper())
     fun accessInvariants(): List<Exp> = type.accessInvariants(toViper())
     fun dynamicInvariants(): List<Exp> = type.dynamicInvariants(toViper())

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NamedFunctionSignature.kt
@@ -21,9 +21,9 @@ interface NamedFunctionSignature : FunctionSignature {
             else -> null
         }
 
-    val isCollection: Boolean
+    val inCollectionsPkg: Boolean
         get() = when (val signatureName = name) {
-            is ScopedKotlinName -> signatureName.isCollection
+            is ScopedKotlinName -> signatureName.inCollectionsPkg
             else -> false
         }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -39,10 +39,7 @@ object KotlinContractFunction : SpecialKotlinFunction {
     override val name: String = "contract"
 
     private val contractBuilderType =
-        ClassTypeEmbedding(
-            ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(Name.identifier("ContractBuilder"))),
-            listOf(AnyTypeEmbedding)
-        )
+        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(Name.identifier("ContractBuilder"))))
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -1,4 +1,6 @@
 /list.kt:(91,105): info: Generated Viper text for empty_list_get:
+field special$size: Int
+
 method global$fun_empty_list_get$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -40,6 +42,8 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
 /list.kt:(91,105): warning: Function empty_list_get may not satisfy its contract.
 
 /list.kt:(193,204): info: Generated Viper text for unsafe_last:
+field special$size: Int
+
 method global$fun_unsafe_last$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Int(local$l: Ref)
   returns (ret: Int)
   requires acc(local$l.special$size, write)
@@ -76,6 +80,8 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
 /list.kt:(193,204): warning: Function unsafe_last may not satisfy its contract.
 
 /list.kt:(273,280): info: Generated Viper text for add_get:
+field special$size: Int
+
 method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$return$T_Unit(local$l: Ref)
   returns (ret: dom$Unit)
   requires acc(local$l.special$size, write)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -49,6 +49,7 @@ field class_scope_global$class_Foo$member_bar: Ref
 method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_bar, wildcard)
 
 
 method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
@@ -67,6 +68,8 @@ field class_scope_global$class_Foo$member_bar: Ref
 
 method global$fun_subtypeSuperType$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
+  requires acc(local$bar.class_scope_global$class_Foo$member_bar, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_bar, wildcard)
   ensures true ==>
     dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Foo())
 {
@@ -79,15 +82,15 @@ field class_scope_global$class_Foo$member_bar: Ref
 
 method global$fun_typeOfField$fun_take$T_class_global$class_Foo$return$T_Boolean(local$foo: Ref)
   returns (ret: Bool)
+  requires acc(local$foo.class_scope_global$class_Foo$member_bar, wildcard)
+  ensures acc(local$foo.class_scope_global$class_Foo$member_bar, wildcard)
   ensures ret == true
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$foo): dom$Type), dom$Type$global$class_Foo())
   if (true) {
     var anonymous$0: Ref
-    inhale acc(local$foo.class_scope_global$class_Foo$member_bar, write)
     anonymous$0 := local$foo.class_scope_global$class_Foo$member_bar
     inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_Bar())
-    exhale acc(local$foo.class_scope_global$class_Foo$member_bar, write)
     if (dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_Bar())) {
       ret := true
       goto label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -1,4 +1,6 @@
 /list.kt:(77,88): info: Generated Viper text for declaration:
+field special$size: Int
+
 method global$fun_declaration$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
@@ -9,6 +11,8 @@ method global$fun_declaration$fun_take$$return$T_Unit()
 }
 
 /list.kt:(187,201): info: Generated Viper text for initialization:
+field special$size: Int
+
 method global$fun_initialization$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Unit(local$l: Ref)
   returns (ret: dom$Unit)
   requires acc(local$l.special$size, write)
@@ -35,6 +39,8 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
 
 
 /list.kt:(297,304): info: Generated Viper text for add_get:
+field special$size: Int
+
 method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$return$T_Unit(local$l: Ref)
   returns (ret: dom$Unit)
   requires acc(local$l.special$size, write)
@@ -77,6 +83,8 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Mu
 
 
 /list.kt:(379,391): info: Generated Viper text for last_or_null:
+field special$size: Int
+
 method global$fun_last_or_null$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$NT_Int(local$l: Ref)
   returns (ret: dom$Nullable[Int])
   requires acc(local$l.special$size, write)
@@ -119,6 +127,8 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
 
 
 /list.kt:(545,553): info: Generated Viper text for is_empty:
+field special$size: Int
+
 method global$fun_is_empty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Int(local$l: Ref)
   returns (ret: Int)
   requires acc(local$l.special$size, write)
@@ -168,6 +178,8 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
 
 
 /list.kt:(670,683): info: Generated Viper text for nullable_list:
+field special$size: Int
+
 method global$fun_nullable_list$fun_take$NT_class_pkg$kotlin$collections$global$class_List$return$T_Unit(local$l: dom$Nullable[Ref])
   returns (ret: dom$Unit)
   requires local$l != (dom$Nullable$null(): dom$Nullable[Ref]) ==>

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -77,6 +77,8 @@ method global$fun_call_fun_with_contracts$fun_take$T_Boolean$return$T_Boolean(lo
 }
 
 /returns_booleans.kt:(1268,1281): info: Generated Viper text for isNullOrEmpty:
+field special$size: Int
+
 method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: dom$Nullable[Ref])
   returns (ret: Bool)
   requires this != (dom$Nullable$null(): dom$Nullable[Ref]) ==>

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
@@ -4,17 +4,20 @@ field class_scope_global$class_Foo$member_a: Int
 method class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Bool)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
 
 
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Int,
   local$x2: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
 
 
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
 
 
 method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
@@ -34,22 +37,16 @@ method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
   var local0$test: Int
   anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(true)
   local0$f1 := anonymous$0
-  inhale acc(local0$f1.class_scope_global$class_Foo$member_a, write)
   anonymous$1 := local0$f1.class_scope_global$class_Foo$member_a
-  exhale acc(local0$f1.class_scope_global$class_Foo$member_a, write)
   local0$shouldBeOne := anonymous$1
   anonymous$2 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
   local0$f2 := anonymous$2
-  inhale acc(local0$f2.class_scope_global$class_Foo$member_a, write)
   anonymous$3 := local0$f2.class_scope_global$class_Foo$member_a
-  exhale acc(local0$f2.class_scope_global$class_Foo$member_a, write)
   local0$shouldBeAnswer := anonymous$3
   anonymous$4 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
     32)
   local0$f3 := anonymous$4
-  inhale acc(local0$f3.class_scope_global$class_Foo$member_a, write)
   anonymous$5 := local0$f3.class_scope_global$class_Foo$member_a
-  exhale acc(local0$f3.class_scope_global$class_Foo$member_a, write)
   local0$test := anonymous$5
   label label$ret$0
 }
@@ -60,11 +57,13 @@ field class_scope_global$class_Bar$member_a: Int
 method class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Bool)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+  ensures acc(ret.class_scope_global$class_Bar$member_a, wildcard)
 
 
 method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+  ensures acc(ret.class_scope_global$class_Bar$member_a, wildcard)
 
 
 method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
@@ -80,15 +79,11 @@ method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
   var local0$shouldBeAnswer: Int
   anonymous$0 := class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(false)
   local0$b1 := anonymous$0
-  inhale acc(local0$b1.class_scope_global$class_Bar$member_a, write)
   anonymous$1 := local0$b1.class_scope_global$class_Bar$member_a
-  exhale acc(local0$b1.class_scope_global$class_Bar$member_a, write)
   local0$shouldBeZero := anonymous$1
   anonymous$2 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(42)
   local0$b2 := anonymous$2
-  inhale acc(local0$b2.class_scope_global$class_Bar$member_a, write)
   anonymous$3 := local0$b2.class_scope_global$class_Bar$member_a
-  exhale acc(local0$b2.class_scope_global$class_Bar$member_a, write)
   local0$shouldBeAnswer := anonymous$3
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -7,10 +7,15 @@ method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_cl
   local$b: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(ret.class_scope_global$class_Foo$member_b, wildcard)
 
 
-method global$fun_createFoo$fun_take$$return$T_Unit()
-  returns (ret: dom$Unit)
+method global$fun_createFoo$fun_take$$return$T_class_global$class_Foo()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(ret.class_scope_global$class_Foo$member_b, wildcard)
 {
   var anonymous$0: Ref
   var local0$f: Ref
@@ -21,23 +26,26 @@ method global$fun_createFoo$fun_take$$return$T_Unit()
   anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
     20)
   local0$f := anonymous$0
-  inhale acc(local0$f.class_scope_global$class_Foo$member_a, write)
   anonymous$1 := local0$f.class_scope_global$class_Foo$member_a
-  exhale acc(local0$f.class_scope_global$class_Foo$member_a, write)
   local0$fa := anonymous$1
-  inhale acc(local0$f.class_scope_global$class_Foo$member_b, write)
   anonymous$2 := local0$f.class_scope_global$class_Foo$member_b
-  exhale acc(local0$f.class_scope_global$class_Foo$member_b, write)
   local0$fb := anonymous$2
+  ret := local0$f
+  goto label$ret$0
   label label$ret$0
 }
 
-/classes.kt:(147,156): info: Generated Viper text for createBar:
+/classes.kt:(165,174): info: Generated Viper text for createBar:
 field class_scope_global$class_Bar$member_a: dom$Nullable[Ref]
 
 method class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: dom$Nullable[Ref])
   returns (ret: Ref)
+  requires local$a != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$a, dom$Type$global$class_Bar()): Ref).class_scope_global$class_Bar$member_a, wildcard)
+  ensures local$a != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$a, dom$Type$global$class_Bar()): Ref).class_scope_global$class_Bar$member_a, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+  ensures acc(ret.class_scope_global$class_Bar$member_a, wildcard)
 
 
 method global$fun_createBar$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.kt
@@ -1,9 +1,10 @@
 class Foo(val a: Int, val b: Int)
 
-fun <!VIPER_TEXT!>createFoo<!>() {
+fun <!VIPER_TEXT!>createFoo<!>(): Foo {
     val f: Foo = Foo(10, 20)
     val fa = f.a
     val fb = f.b
+    return f
 }
 
 class Bar(val a: Bar?)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -4,10 +4,13 @@ field class_scope_global$class_IntWrapper$member_n: Int
 method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
+  ensures acc(ret.class_scope_global$class_IntWrapper$member_n, wildcard)
 
 
 method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
+  ensures acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
 
 
 method global$fun_testGetter$fun_take$$return$T_Unit()
@@ -33,13 +36,20 @@ field class_scope_global$class_Foo$member_b: Int
 
 method class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
   returns (ret: Ref)
+  requires acc(local$f.class_scope_global$class_Foo$member_a, wildcard)
+  requires acc(local$f.class_scope_global$class_Foo$member_b, wildcard)
+  ensures acc(local$f.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(local$f.class_scope_global$class_Foo$member_b, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
+  ensures acc(ret.class_scope_global$class_Bar$member_f, wildcard)
 
 
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
   local$b: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(ret.class_scope_global$class_Foo$member_b, wildcard)
 
 
 method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
@@ -60,21 +70,13 @@ method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
   local0$foo := anonymous$0
   anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local0$foo)
   local0$bar := anonymous$1
-  inhale acc(local0$bar.class_scope_global$class_Bar$member_f, write)
   anonymous$2 := local0$bar.class_scope_global$class_Bar$member_f
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$global$class_Foo())
-  exhale acc(local0$bar.class_scope_global$class_Bar$member_f, write)
-  inhale acc(anonymous$2.class_scope_global$class_Foo$member_a, write)
   anonymous$3 := anonymous$2.class_scope_global$class_Foo$member_a
-  exhale acc(anonymous$2.class_scope_global$class_Foo$member_a, write)
   local0$bfa := anonymous$3
-  inhale acc(local0$bar.class_scope_global$class_Bar$member_f, write)
   anonymous$4 := local0$bar.class_scope_global$class_Bar$member_f
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$4): dom$Type), dom$Type$global$class_Foo())
-  exhale acc(local0$bar.class_scope_global$class_Bar$member_f, write)
-  inhale acc(anonymous$4.class_scope_global$class_Foo$member_b, write)
   anonymous$5 := anonymous$4.class_scope_global$class_Foo$member_b
-  exhale acc(anonymous$4.class_scope_global$class_Foo$member_b, write)
   local0$bfb := anonymous$5
   label label$ret$0
 }
@@ -87,15 +89,21 @@ field class_scope_global$class_IntWrapperContainer$member_i: Ref
 method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
+  ensures acc(ret.class_scope_global$class_IntWrapper$member_n, wildcard)
 
 
 method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
+  ensures acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
 
 
 method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
   returns (ret: Ref)
+  requires acc(local$i.class_scope_global$class_IntWrapper$member_n, wildcard)
+  ensures acc(local$i.class_scope_global$class_IntWrapper$member_n, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
+  ensures acc(ret.class_scope_global$class_IntWrapperContainer$member_i, wildcard)
 
 
 method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
@@ -110,10 +118,8 @@ method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   anonymous$0 := class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
   anonymous$1 := class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(anonymous$0)
   local0$wrapper := anonymous$1
-  inhale acc(local0$wrapper.class_scope_global$class_IntWrapperContainer$member_i, write)
   anonymous$2 := local0$wrapper.class_scope_global$class_IntWrapperContainer$member_i
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$global$class_IntWrapper())
-  exhale acc(local0$wrapper.class_scope_global$class_IntWrapperContainer$member_i, write)
   anonymous$3 := class_scope_global$class_IntWrapper$getter_succ(anonymous$2)
   local0$succ := anonymous$3
   label label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -44,10 +44,13 @@ field class_scope_global$class_Foo$member_x: Int
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$fun_extensionGetterPropertyUserDefinedClass$fun_take$$return$T_Unit()
@@ -70,15 +73,20 @@ field class_scope_global$class_Foo$member_x: Int
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$ext_getter_strange$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$T_Unit(this: Ref,
   local$v: Int)
   returns (ret: dom$Unit)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$fun_extensionSetterPropertyUserDefinedClass$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -263,14 +263,13 @@ field class_scope_global$class_Foo$member_x: Int
 
 field special$function_object_call_counter: Int
 
-field special$size: Int
-
 function special$duplicable(anonymous$0: Ref): Bool
 
 
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$fun_f$fun_take$$return$T_Unit() returns (ret: dom$Unit)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -7,12 +7,14 @@ field class_scope_global$class_Foo$member_y: Int
 
 method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
-  inhale acc(this.class_scope_global$class_Foo$member_y, write)
   anonymous$0 := this.class_scope_global$class_Foo$member_y
-  exhale acc(this.class_scope_global$class_Foo$member_y, write)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
@@ -29,16 +31,18 @@ field class_scope_global$class_Foo$member_y: Int
 
 method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(this.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(this.class_scope_global$class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   var anonymous$1: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Bar())
-  inhale acc(this.class_scope_global$class_Foo$member_x, write)
   anonymous$0 := this.class_scope_global$class_Foo$member_x
-  exhale acc(this.class_scope_global$class_Foo$member_x, write)
-  inhale acc(this.class_scope_global$class_Bar$member_z, write)
   anonymous$1 := this.class_scope_global$class_Bar$member_z
-  exhale acc(this.class_scope_global$class_Bar$member_z, write)
   ret := anonymous$0 + anonymous$1
   goto label$ret$0
   label label$ret$0
@@ -55,10 +59,20 @@ field class_scope_global$class_Foo$member_y: Int
 
 method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
 
 
 method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
+  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
@@ -80,6 +94,12 @@ field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_accessSuperField$fun_take$T_class_global$class_Bar$return$T_Boolean(local$bar: Ref)
   returns (ret: Bool)
+  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
 {
   var anonymous$0: Bool
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
@@ -102,12 +122,16 @@ field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_accessNewField$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
+  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
-  inhale acc(local$bar.class_scope_global$class_Bar$member_z, write)
   anonymous$0 := local$bar.class_scope_global$class_Bar$member_z
-  exhale acc(local$bar.class_scope_global$class_Bar$member_z, write)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
@@ -124,10 +148,22 @@ field class_scope_global$class_Foo$member_y: Int
 
 method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(this.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(this.class_scope_global$class_Bar$member_z, wildcard)
 
 
 method global$fun_callNewMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
+  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
@@ -148,6 +184,12 @@ field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_setSuperField$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
+  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
   inhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
@@ -167,12 +209,16 @@ field class_scope_global$class_Foo$member_y: Int
 
 method global$fun_accessSuperSuperField$fun_take$T_class_global$class_Baz$return$T_Int(local$baz: Ref)
   returns (ret: Int)
+  requires acc(local$baz.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$baz.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(local$baz.class_scope_global$class_Bar$member_z, wildcard)
+  ensures acc(local$baz.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$baz.class_scope_global$class_Foo$member_y, wildcard)
+  ensures acc(local$baz.class_scope_global$class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$baz): dom$Type), dom$Type$global$class_Baz())
-  inhale acc(local$baz.class_scope_global$class_Foo$member_x, write)
   anonymous$0 := local$baz.class_scope_global$class_Foo$member_x
-  exhale acc(local$baz.class_scope_global$class_Foo$member_x, write)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -3,12 +3,12 @@ field class_scope_global$class_Foo$member_x: Int
 
 method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
-  inhale acc(this.class_scope_global$class_Foo$member_x, write)
   anonymous$0 := this.class_scope_global$class_Foo$member_x
-  exhale acc(this.class_scope_global$class_Foo$member_x, write)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
@@ -19,6 +19,8 @@ field class_scope_global$class_Foo$member_x: Int
 
 method class_scope_global$class_Foo$fun_call_member_fun$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
   returns (ret: dom$Unit)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
@@ -28,6 +30,8 @@ method class_scope_global$class_Foo$fun_call_member_fun$fun_take$T_class_global$
 
 method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 
 
 /member_functions.kt:(140,152): info: Generated Viper text for sibling_call:
@@ -35,11 +39,17 @@ field class_scope_global$class_Foo$member_x: Int
 
 method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method class_scope_global$class_Foo$fun_sibling_call$fun_take$T_class_global$class_Foo$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$other: Ref)
   returns (ret: dom$Unit)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(local$other.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(local$other.class_scope_global$class_Foo$member_x, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
@@ -54,10 +64,13 @@ field class_scope_global$class_Foo$member_x: Int
 method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
+  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
+  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
 
 
 method global$fun_outer_member_fun_call$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -146,6 +146,10 @@ field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
 method global$fun_safe_call$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
+  requires local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
+  ensures local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
 {
   var anonymous$0: dom$Nullable[Int]
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$s): dom$Type), dom$Type$special$Nullable(dom$Type$pkg$kotlin$global$class_String()))
@@ -173,6 +177,10 @@ field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
 
 method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
+  requires local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
+  ensures local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
 {
   var anonymous$0: dom$Nullable[Int]
   var local0$l: dom$Nullable[Int]
@@ -181,9 +189,7 @@ method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_S
     anonymous$0 := (dom$Nullable$null(): dom$Nullable[Int])
   } else {
     var anonymous$1: Int
-    inhale acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, write)
     anonymous$1 := (dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length
-    exhale acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, write)
     anonymous$0 := (dom$Casting$cast(anonymous$1, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
   }
   local0$l := anonymous$0
@@ -199,11 +205,19 @@ field class_scope_global$class_Foo$member_v: Int
 
 method class_scope_global$class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo(this: Ref)
   returns (ret: dom$Nullable[Ref])
+  requires acc(this.class_scope_global$class_Foo$member_v, wildcard)
+  ensures acc(this.class_scope_global$class_Foo$member_v, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$global$class_Foo()))
+  ensures ret != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(ret, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, wildcard)
 
 
 method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_Int(local$foo: dom$Nullable[Ref])
   returns (ret: dom$Nullable[Int])
+  requires local$foo != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$foo, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, wildcard)
+  ensures local$foo != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc((dom$Casting$cast(local$foo, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 {
   var anonymous$0: dom$Nullable[Ref]
@@ -230,9 +244,7 @@ method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_I
     anonymous$4 := (dom$Nullable$null(): dom$Nullable[Int])
   } else {
     var anonymous$5: Int
-    inhale acc((dom$Casting$cast(anonymous$2, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, write)
     anonymous$5 := (dom$Casting$cast(anonymous$2, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v
-    exhale acc((dom$Casting$cast(anonymous$2, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, write)
     anonymous$4 := (dom$Casting$cast(anonymous$5, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
   }
   ret := anonymous$4


### PR DESCRIPTION
This unlocks some possibilities for reasoning about `val` properties, since we can keep any conclusions we draw about them.  To actually draw these conclusions we will need to add extra postconditions onto constructors; that will be in a follow-up PR.

Currently only works for class properties, Viper can figure out that local `val` properties don't change anyway.