### PR TITLE
Throwing more specific exceptions based on context

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -49,7 +49,7 @@ class ContractDescriptionConversionVisitor(
     ): Exp = when (booleanConstantDescriptor) {
         ConeContractConstantValues.TRUE -> BoolLit(true)
         ConeContractConstantValues.FALSE -> BoolLit(false)
-        else -> throw Exception("Unexpected boolean constant: $booleanConstantDescriptor")
+        else -> throw IllegalArgumentException("Unexpected boolean constant: $booleanConstantDescriptor")
     }
 
     override fun visitReturnsEffectDeclaration(
@@ -68,7 +68,7 @@ class ContractDescriptionConversionVisitor(
             ConeContractConstantValues.NOT_NULL -> signature.returnVar.nullCmp(true)
             ConeContractConstantValues.TRUE -> EqCmp(retVar, BoolLit(true))
             ConeContractConstantValues.FALSE -> EqCmp(retVar, BoolLit(false))
-            else -> throw Exception("Unexpected constant: ${returnsEffect.value}")
+            else -> throw IllegalArgumentException("Unexpected constant: ${returnsEffect.value}")
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -236,7 +236,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
     override fun visitProperty(property: FirProperty, data: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
         val symbol = property.symbol
         if (!symbol.isLocal) {
-            throw Exception("StmtConversionVisitor should not encounter non-local properties.")
+            throw IllegalStateException("StmtConversionVisitor should not encounter non-local properties.")
         }
         data.declareLocal(symbol.name, data.embedType(symbol.resolvedReturnType), property.initializer?.let { data.convert(it) })
         return UnitLit
@@ -285,7 +285,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
         data: StmtConversionContext<ResultTrackingContext>,
     ): ExpEmbedding {
         val propertyAccess = variableAssignment.lValue as? FirPropertyAccessExpression
-            ?: throw Exception("Left hand of an assignment must be a property access.")
+            ?: throw IllegalArgumentException("Left hand of an assignment must be a property access.")
         val embedding = data.embedPropertyAccess(propertyAccess)
         val convertedRValue = data.convert(variableAssignment.rValue)
         embedding.setValue(convertedRValue, data)
@@ -471,7 +471,7 @@ object StmtConversionVisitorExceptionWrapper : FirVisitor<ExpEmbedding, StmtConv
     override fun visitElement(element: FirElement, data: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
         try {
             return element.accept(StmtConversionVisitor, data)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             data.errorCollector.addErrorInfo("... while converting ${element.source.text}")
             throw e
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/LambdaExp.kt
@@ -26,7 +26,7 @@ class LambdaExp(
     override fun toViper(): Exp = TODO("create new function object with counter, duplicable (requires toViper restructuring)")
 
     override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
-        val inlineBody = function.body ?: throw Exception("Lambda $function has a null body")
+        val inlineBody = function.body ?: throw IllegalArgumentException("Lambda $function has a null body")
         val paramNames = function.valueParameters.map { it.name }
         return ctx.insertInlineFunctionCall(signature, paramNames, args, inlineBody, parentCtx, ctx.signature.sourceName)
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
@@ -18,7 +18,7 @@ class InlineNamedFunction(
 ) : CallableEmbedding, FullNamedFunctionSignature by signature {
     @OptIn(SymbolInternals::class)
     override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext<ResultTrackingContext>): ExpEmbedding {
-        val inlineBody = symbol.fir.body ?: throw Exception("Function symbol $symbol has a null body")
+        val inlineBody = symbol.fir.body ?: throw IllegalArgumentException("Function symbol $symbol has a null body")
         val paramNames = symbol.valueParameterSymbols.map { it.name }
         return ctx.insertInlineFunctionCall(signature, paramNames, args, inlineBody)
     }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -71,7 +71,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
             if (!success) {
                 reporter.reportOn(declaration.source, PluginErrors.FUNCTION_WITH_UNVERIFIED_CONTRACT, declaration.name.asString(), context)
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             val error = errorCollector.formatErrorWithInfos(e.message ?: "No message provided")
             reporter.reportOn(declaration.source, PluginErrors.INTERNAL_ERROR, error, context)
             // Note that the below text is only visible during plugin development; Gradle hides it when running the plugin


### PR DESCRIPTION
Replaces all the occurrences where an instance of class `Exception` were thrown with more specific subclasses. 

In addition, now we do not catch `Throwable` (since they include `Error`: `An Error is a subclass of Throwable that indicates serious problems that a reasonable application should not try to catch.`).