### PR TITLE
Simplify class naming structure.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/KotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/KotlinName.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -31,8 +32,10 @@ data class SetterKotlinName(val name: Name) : PrefixedKotlinName("setter", name)
 data class ExtensionSetterKotlinName(val name: Name) : PrefixedKotlinName("ext_setter", name)
 data class ExtensionGetterKotlinName(val name: Name) : PrefixedKotlinName("ext_getter", name)
 
-data class ClassKotlinName(val name: Name) : KotlinName {
-    override val mangled: String = "class_${name.asStringStripSpecialMarkers()}"
+data class ClassKotlinName(val name: FqName) : KotlinName {
+    override val mangled: String = "class_${name.asViperString()}"
+
+    constructor(classSegments: List<String>) : this(FqName.fromSegments(classSegments))
 }
 
 data object ConstructorKotlinName : KotlinName {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameEmbeddings.kt
@@ -20,13 +20,13 @@ import org.jetbrains.kotlin.name.ClassId
 fun CallableId.embedScopeName(): NameScope =
     when (val id = this.classId) {
         null -> GlobalScope(packageName)
-        else -> ClassScope(packageName, id.embedName())
+        else -> ClassScope(packageName, ClassKotlinName(id.relativeClassName))
     }
 
 fun CallableId.embedScoped(name: KotlinName) = ScopedKotlinName(embedScopeName(), name)
 fun CallableId.embedScopedWithType(type: TypeEmbedding, name: KotlinName) = ScopedKotlinName(embedScopeName(), name, type)
 
-fun ClassId.embedName(): ScopedKotlinName = ScopedKotlinName(GlobalScope(packageFqName), ClassKotlinName(shortClassName))
+fun ClassId.embedName(): ScopedKotlinName = ScopedKotlinName(GlobalScope(packageFqName), ClassKotlinName(relativeClassName))
 fun CallableId.embedGetterName(): ScopedKotlinName = embedScoped(GetterKotlinName(callableName))
 fun CallableId.embedSetterName(): ScopedKotlinName = embedScoped(SetterKotlinName(callableName))
 fun CallableId.embedExtensionGetterName(type: TypeEmbedding): ScopedKotlinName =

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameScope.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/NameScope.kt
@@ -27,13 +27,11 @@ data class GlobalScope(override val packageName: FqName) : PackagePrefixScope {
     constructor(segments: List<String>) : this(FqName.fromSegments(segments))
 }
 
-// We use the embedded class name here.  It's not clear whether className.scope can be anything
-// but GlobalScope(packageName) here, but this approach makes the embedName implementation make
-// more sense.
-data class ClassScope(override val packageName: FqName, val className: ScopedKotlinName) : PackagePrefixScope {
-    override val suffix = "class_scope_${className.mangled}"
+data class ClassScope(override val packageName: FqName, val className: ClassKotlinName) : PackagePrefixScope {
+    // We don't need to prefix this with "class_scope" since the class name will already be prefixed with "class".
+    override val suffix = className.mangled
 
-    constructor(packageSegments: List<String>, className: ScopedKotlinName) : this(FqName.fromSegments(packageSegments), className)
+    constructor(packageSegments: List<String>, className: ClassKotlinName) : this(FqName.fromSegments(packageSegments), className)
 }
 
 data object ParameterScope : NameScope {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ScopedKotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ScopedKotlinName.kt
@@ -17,8 +17,8 @@ data class ScopedKotlinName(val scope: NameScope, val name: KotlinName, val type
 
     val isCollection: Boolean
         // TODO: make this neater
-        get() = if (scope is ClassScope && scope.className.name is ClassKotlinName) {
-            scope.packageName.asString() == "kotlin.collections" && scope.className.name.name.asStringStripSpecialMarkers() == "Collection"
+        get() = if (scope is ClassScope) {
+            scope.packageName.asString() == "kotlin.collections" && scope.className.name.asString() == "Collection"
         } else {
             false
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -39,7 +39,7 @@ object KotlinContractFunction : SpecialKotlinFunction {
     override val name: String = "contract"
 
     private val contractBuilderType =
-        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(Name.identifier("ContractBuilder"))))
+        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(listOf("ContractBuilder"))))
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_type_contract.kt:(121,142): info: Generated Viper text for unverifiableTypeCheck:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+field pkg$kotlin$class_String$member_length: Int
 
 method global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean(local$x: dom$Nullable[Int])
   returns (ret: Bool)
@@ -12,7 +12,7 @@ method global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean(local$x
   label label$ret$0
 }
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -10,13 +10,13 @@ method global$fun_empty_list_get$fun_take$$return$T_Unit()
   var local0$s: Int
   anonymous$0 := pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
   local0$myList := anonymous$0
-  anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local0$myList,
+  anonymous$1 := pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local0$myList,
     0)
   local0$s := anonymous$1
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -36,7 +36,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures ret.special$size == 0
 
 
-/list.kt:(91,105): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local0$myList.special$size > 0 might not hold. (<no position>)
+/list.kt:(91,105): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local0$myList.special$size > 0 might not hold. (<no position>)
 
 
 /list.kt:(91,105): warning: Function empty_list_get may not satisfy its contract.
@@ -55,14 +55,14 @@ method global$fun_unsafe_last$fun_take$T_class_pkg$kotlin$collections$global$cla
   var anonymous$1: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$l): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
   anonymous$0 := local$l.special$size
-  anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local$l,
+  anonymous$1 := pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local$l,
     anonymous$0 - 1)
   ret := anonymous$1
   goto label$ret$0
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -74,7 +74,7 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
   ensures this.special$size == old(this.special$size)
 
 
-/list.kt:(193,204): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion anonymous$0 - 1 >= 0 might not hold. (<no position>)
+/list.kt:(193,204): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion anonymous$0 - 1 >= 0 might not hold. (<no position>)
 
 
 /list.kt:(193,204): warning: Function unsafe_last may not satisfy its contract.
@@ -93,15 +93,15 @@ method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_M
   var anonymous$1: Int
   var local0$n: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$l): dom$Type), dom$Type$pkg$kotlin$collections$global$class_MutableList())
-  anonymous$0 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(local$l,
+  anonymous$0 := pkg$kotlin$collections$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(local$l,
     1)
-  anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(local$l,
+  anonymous$1 := pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(local$l,
     1)
   local0$n := anonymous$1
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(this: Ref,
+method pkg$kotlin$collections$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(this: Ref,
   local$element: Int)
   returns (ret: Bool)
   requires acc(this.special$size, write)
@@ -111,7 +111,7 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Mu
   ensures this.special$size == old(this.special$size) + 1
 
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -123,7 +123,7 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Mu
   ensures this.special$size == old(this.special$size)
 
 
-/list.kt:(273,280): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int might not hold. Assertion local$l.special$size > 1 might not hold. (<no position>)
+/list.kt:(273,280): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int might not hold. Assertion local$l.special$size > 1 might not hold. (<no position>)
 
 
 /list.kt:(273,280): warning: Function add_get may not satisfy its contract.

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+field pkg$kotlin$class_String$member_length: Int
 
 method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullable[dom$Any])
   returns (ret: Bool)
@@ -12,12 +12,12 @@ method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: dom$Nullabl
   label label$ret$0
 }
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
 
 /is_type_contract.kt:(322,330): info: Generated Viper text for isString:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+field pkg$kotlin$class_String$member_length: Int
 
 method global$fun_isString$fun_take$T_Any$return$T_Boolean(this: dom$Any)
   returns (ret: Bool)
@@ -30,7 +30,7 @@ method global$fun_isString$fun_take$T_Any$return$T_Boolean(this: dom$Any)
   label label$ret$0
 }
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
 
@@ -44,12 +44,12 @@ method global$fun_subtypeTransitive$fun_take$T_Unit$return$T_Unit(local$x: dom$U
 }
 
 /is_type_contract.kt:(686,707): info: Generated Viper text for constructorReturnType:
-field class_scope_global$class_Foo$member_bar: Ref
+field class_Foo$member_bar: Ref
 
-method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_bar, wildcard)
+  ensures acc(ret.class_Foo$member_bar, wildcard)
 
 
 method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
@@ -57,19 +57,19 @@ method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
   ensures ret == true
 {
   var anonymous$0: Ref
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  anonymous$0 := class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   ret := dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_Foo())
   goto label$ret$0
   label label$ret$0
 }
 
 /is_type_contract.kt:(832,848): info: Generated Viper text for subtypeSuperType:
-field class_scope_global$class_Foo$member_bar: Ref
+field class_Foo$member_bar: Ref
 
 method global$fun_subtypeSuperType$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
-  requires acc(local$bar.class_scope_global$class_Foo$member_bar, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_bar, wildcard)
+  requires acc(local$bar.class_Foo$member_bar, wildcard)
+  ensures acc(local$bar.class_Foo$member_bar, wildcard)
   ensures true ==>
     dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Foo())
 {
@@ -78,18 +78,18 @@ method global$fun_subtypeSuperType$fun_take$T_class_global$class_Bar$return$T_Un
 }
 
 /is_type_contract.kt:(965,976): info: Generated Viper text for typeOfField:
-field class_scope_global$class_Foo$member_bar: Ref
+field class_Foo$member_bar: Ref
 
 method global$fun_typeOfField$fun_take$T_class_global$class_Foo$return$T_Boolean(local$foo: Ref)
   returns (ret: Bool)
-  requires acc(local$foo.class_scope_global$class_Foo$member_bar, wildcard)
-  ensures acc(local$foo.class_scope_global$class_Foo$member_bar, wildcard)
+  requires acc(local$foo.class_Foo$member_bar, wildcard)
+  ensures acc(local$foo.class_Foo$member_bar, wildcard)
   ensures ret == true
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$foo): dom$Type), dom$Type$global$class_Foo())
   if (true) {
     var anonymous$0: Ref
-    anonymous$0 := local$foo.class_scope_global$class_Foo$member_bar
+    anonymous$0 := local$foo.class_Foo$member_bar
     inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_Bar())
     if (dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_Bar())) {
       ret := true

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -52,15 +52,15 @@ method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_M
   var anonymous$1: Int
   var local0$n: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$l): dom$Type), dom$Type$pkg$kotlin$collections$global$class_MutableList())
-  anonymous$0 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(local$l,
+  anonymous$0 := pkg$kotlin$collections$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(local$l,
     1)
-  anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(local$l,
+  anonymous$1 := pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(local$l,
     0)
   local0$n := anonymous$1
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(this: Ref,
+method pkg$kotlin$collections$class_MutableList$fun_add$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Boolean(this: Ref,
   local$element: Int)
   returns (ret: Bool)
   requires acc(this.special$size, write)
@@ -70,7 +70,7 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Mu
   ensures this.special$size == old(this.special$size) + 1
 
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -101,7 +101,7 @@ method global$fun_last_or_null$fun_take$T_class_pkg$kotlin$collections$global$cl
   if (true) {
     if (!(local0$size == 0)) {
       var anonymous$1: Int
-      anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local$l,
+      anonymous$1 := pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local$l,
         local0$size - 1)
       ret := (dom$Casting$cast(anonymous$1, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
       goto label$ret$0
@@ -114,7 +114,7 @@ method global$fun_last_or_null$fun_take$T_class_pkg$kotlin$collections$global$cl
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -140,10 +140,10 @@ method global$fun_is_empty$fun_take$T_class_pkg$kotlin$collections$global$class_
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$l): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
   if (true) {
     var anonymous$1: Bool
-    anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean(local$l)
+    anonymous$1 := pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean(local$l)
     if (!anonymous$1) {
       var anonymous$2: Int
-      anonymous$2 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local$l,
+      anonymous$2 := pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(local$l,
         0)
       anonymous$0 := anonymous$2
     } else {
@@ -154,7 +154,7 @@ method global$fun_is_empty$fun_take$T_class_pkg$kotlin$collections$global$class_
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -166,7 +166,7 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
   ensures this.special$size == old(this.special$size)
 
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean(this: Ref)
+method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean(this: Ref)
   returns (ret: Bool)
   requires acc(this.special$size, write)
   requires this.special$size >= 0
@@ -205,7 +205,7 @@ method global$fun_nullable_list$fun_take$NT_class_pkg$kotlin$collections$global$
     (dom$Casting$cast(local$l, dom$Type$pkg$kotlin$collections$global$class_List()): Ref) ==
     (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]), dom$Type$pkg$kotlin$collections$global$class_List()): Ref))) {
       var anonymous$1: Bool
-      anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean((dom$Casting$cast(local$l,
+      anonymous$1 := pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean((dom$Casting$cast(local$l,
         dom$Type$pkg$kotlin$collections$global$class_List()): Ref))
       anonymous$0 := !anonymous$1
     } else {
@@ -215,7 +215,7 @@ method global$fun_nullable_list$fun_take$NT_class_pkg$kotlin$collections$global$
       var anonymous$3: Int
       var local2$x: Int
       anonymous$2 := (dom$Casting$cast(local$l, dom$Type$pkg$kotlin$collections$global$class_List()): Ref).special$size
-      anonymous$3 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int((dom$Casting$cast(local$l,
+      anonymous$3 := pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int((dom$Casting$cast(local$l,
         dom$Type$pkg$kotlin$collections$global$class_List()): Ref), anonymous$2 -
         1)
       local2$x := anonymous$3
@@ -224,7 +224,7 @@ method global$fun_nullable_list$fun_take$NT_class_pkg$kotlin$collections$global$
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
+method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
   local$index: Int)
   returns (ret: Int)
   requires acc(this.special$size, write)
@@ -236,7 +236,7 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
   ensures this.special$size == old(this.special$size)
 
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean(this: Ref)
+method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Boolean(this: Ref)
   returns (ret: Bool)
   requires acc(this.special$size, write)
   requires this.special$size >= 0
@@ -245,4 +245,3 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Li
   ensures this.special$size == old(this.special$size)
   ensures ret ==> this.special$size == 0
   ensures !ret ==> this.special$size > 0
-

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -106,7 +106,7 @@ method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$
     anonymous$0 := true
   } else {
     var anonymous$1: Bool
-    anonymous$1 := pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean((dom$Casting$cast(this,
+    anonymous$1 := pkg$kotlin$collections$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean((dom$Casting$cast(this,
       dom$Type$pkg$kotlin$collections$global$class_Collection()): Ref))
     anonymous$0 := anonymous$1
   }
@@ -115,7 +115,7 @@ method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$
   label label$ret$0
 }
 
-method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: Ref)
+method pkg$kotlin$collections$class_Collection$fun_isEmpty$fun_take$T_class_pkg$kotlin$collections$global$class_Collection$return$T_Boolean(this: Ref)
   returns (ret: Bool)
   requires acc(this.special$size, write)
   requires this.special$size >= 0
@@ -124,4 +124,3 @@ method pkg$kotlin$collections$class_scope_pkg$kotlin$collections$global$class_Co
   ensures this.special$size == old(this.special$size)
   ensures ret ==> this.special$size == 0
   ensures !ret ==> this.special$size > 0
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
@@ -1,23 +1,23 @@
 /class_constructors.kt:(389,411): info: Generated Viper text for onlySecondConstructors:
-field class_scope_global$class_Foo$member_a: Int
+field class_Foo$member_a: Int
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Bool)
+method class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Bool)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(ret.class_Foo$member_a, wildcard)
 
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Int,
+method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Int,
   local$x2: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(ret.class_Foo$member_a, wildcard)
 
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Int)
+method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
+  ensures acc(ret.class_Foo$member_a, wildcard)
 
 
 method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
@@ -35,35 +35,35 @@ method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
   var local0$f3: Ref
   var anonymous$5: Int
   var local0$test: Int
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(true)
+  anonymous$0 := class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(true)
   local0$f1 := anonymous$0
-  anonymous$1 := local0$f1.class_scope_global$class_Foo$member_a
+  anonymous$1 := local0$f1.class_Foo$member_a
   local0$shouldBeOne := anonymous$1
-  anonymous$2 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
+  anonymous$2 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
   local0$f2 := anonymous$2
-  anonymous$3 := local0$f2.class_scope_global$class_Foo$member_a
+  anonymous$3 := local0$f2.class_Foo$member_a
   local0$shouldBeAnswer := anonymous$3
-  anonymous$4 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
+  anonymous$4 := class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
     32)
   local0$f3 := anonymous$4
-  anonymous$5 := local0$f3.class_scope_global$class_Foo$member_a
+  anonymous$5 := local0$f3.class_Foo$member_a
   local0$test := anonymous$5
   label label$ret$0
 }
 
 /class_constructors.kt:(590,617): info: Generated Viper text for primaryAndSecondConstructor:
-field class_scope_global$class_Bar$member_a: Int
+field class_Bar$member_a: Int
 
-method class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Bool)
+method class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Bool)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-  ensures acc(ret.class_scope_global$class_Bar$member_a, wildcard)
+  ensures acc(ret.class_Bar$member_a, wildcard)
 
 
-method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-  ensures acc(ret.class_scope_global$class_Bar$member_a, wildcard)
+  ensures acc(ret.class_Bar$member_a, wildcard)
 
 
 method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
@@ -77,13 +77,13 @@ method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
   var local0$b2: Ref
   var anonymous$3: Int
   var local0$shouldBeAnswer: Int
-  anonymous$0 := class_scope_global$class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(false)
+  anonymous$0 := class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(false)
   local0$b1 := anonymous$0
-  anonymous$1 := local0$b1.class_scope_global$class_Bar$member_a
+  anonymous$1 := local0$b1.class_Bar$member_a
   local0$shouldBeZero := anonymous$1
-  anonymous$2 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(42)
+  anonymous$2 := class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(42)
   local0$b2 := anonymous$2
-  anonymous$3 := local0$b2.class_scope_global$class_Bar$member_a
+  anonymous$3 := local0$b2.class_Bar$member_a
   local0$shouldBeAnswer := anonymous$3
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -1,21 +1,21 @@
 /classes.kt:(39,48): info: Generated Viper text for createFoo:
-field class_scope_global$class_Foo$member_a: Int
+field class_Foo$member_a: Int
 
-field class_scope_global$class_Foo$member_b: Int
+field class_Foo$member_b: Int
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
+method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
   local$b: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
-  ensures acc(ret.class_scope_global$class_Foo$member_b, wildcard)
+  ensures acc(ret.class_Foo$member_a, wildcard)
+  ensures acc(ret.class_Foo$member_b, wildcard)
 
 
 method global$fun_createFoo$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
-  ensures acc(ret.class_scope_global$class_Foo$member_b, wildcard)
+  ensures acc(ret.class_Foo$member_a, wildcard)
+  ensures acc(ret.class_Foo$member_b, wildcard)
 {
   var anonymous$0: Ref
   var local0$f: Ref
@@ -23,12 +23,12 @@ method global$fun_createFoo$fun_take$$return$T_class_global$class_Foo()
   var local0$fa: Int
   var anonymous$2: Int
   var local0$fb: Int
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
     20)
   local0$f := anonymous$0
-  anonymous$1 := local0$f.class_scope_global$class_Foo$member_a
+  anonymous$1 := local0$f.class_Foo$member_a
   local0$fa := anonymous$1
-  anonymous$2 := local0$f.class_scope_global$class_Foo$member_b
+  anonymous$2 := local0$f.class_Foo$member_b
   local0$fb := anonymous$2
   ret := local0$f
   goto label$ret$0
@@ -36,16 +36,16 @@ method global$fun_createFoo$fun_take$$return$T_class_global$class_Foo()
 }
 
 /classes.kt:(165,174): info: Generated Viper text for createBar:
-field class_scope_global$class_Bar$member_a: dom$Nullable[Ref]
+field class_Bar$member_a: dom$Nullable[Ref]
 
-method class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: dom$Nullable[Ref])
+method class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: dom$Nullable[Ref])
   returns (ret: Ref)
   requires local$a != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$a, dom$Type$global$class_Bar()): Ref).class_scope_global$class_Bar$member_a, wildcard)
+    acc((dom$Casting$cast(local$a, dom$Type$global$class_Bar()): Ref).class_Bar$member_a, wildcard)
   ensures local$a != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$a, dom$Type$global$class_Bar()): Ref).class_scope_global$class_Bar$member_a, wildcard)
+    acc((dom$Casting$cast(local$a, dom$Type$global$class_Bar()): Ref).class_Bar$member_a, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-  ensures acc(ret.class_scope_global$class_Bar$member_a, wildcard)
+  ensures acc(ret.class_Bar$member_a, wildcard)
 
 
 method global$fun_createBar$fun_take$$return$T_Unit()
@@ -53,7 +53,7 @@ method global$fun_createBar$fun_take$$return$T_Unit()
 {
   var anonymous$0: Ref
   var local0$b: Ref
-  anonymous$0 := class_scope_global$class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar((dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]),
+  anonymous$0 := class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar((dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]),
     dom$Type$special$Nullable(dom$Type$global$class_Bar())): dom$Nullable[Ref]))
   local0$b := anonymous$0
   label label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -1,16 +1,15 @@
 /classes_getters.kt:(195,205): info: Generated Viper text for testGetter:
-field class_scope_global$class_IntWrapper$member_n: Int
+field class_IntWrapper$member_n: Int
 
-method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
+method class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
-  ensures acc(ret.class_scope_global$class_IntWrapper$member_n, wildcard)
+  ensures acc(ret.class_IntWrapper$member_n, wildcard)
 
 
-method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
-  returns (ret: Int)
-  requires acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
-  ensures acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
+method class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+  requires acc(this.class_IntWrapper$member_n, wildcard)
+  ensures acc(this.class_IntWrapper$member_n, wildcard)
 
 
 method global$fun_testGetter$fun_take$$return$T_Unit()
@@ -20,36 +19,36 @@ method global$fun_testGetter$fun_take$$return$T_Unit()
   var local0$wrapper: Ref
   var anonymous$1: Int
   var local0$succ: Int
-  anonymous$0 := class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
+  anonymous$0 := class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
   local0$wrapper := anonymous$0
-  anonymous$1 := class_scope_global$class_IntWrapper$getter_succ(local0$wrapper)
+  anonymous$1 := class_IntWrapper$getter_succ(local0$wrapper)
   local0$succ := anonymous$1
   label label$ret$0
 }
 
 /classes_getters.kt:(278,295): info: Generated Viper text for testCascadeGetter:
-field class_scope_global$class_Bar$member_f: Ref
+field class_Bar$member_f: Ref
 
-field class_scope_global$class_Foo$member_a: Int
+field class_Foo$member_a: Int
 
-field class_scope_global$class_Foo$member_b: Int
+field class_Foo$member_b: Int
 
-method class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
+method class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
   returns (ret: Ref)
-  requires acc(local$f.class_scope_global$class_Foo$member_a, wildcard)
-  requires acc(local$f.class_scope_global$class_Foo$member_b, wildcard)
-  ensures acc(local$f.class_scope_global$class_Foo$member_a, wildcard)
-  ensures acc(local$f.class_scope_global$class_Foo$member_b, wildcard)
+  requires acc(local$f.class_Foo$member_a, wildcard)
+  requires acc(local$f.class_Foo$member_b, wildcard)
+  ensures acc(local$f.class_Foo$member_a, wildcard)
+  ensures acc(local$f.class_Foo$member_b, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
-  ensures acc(ret.class_scope_global$class_Bar$member_f, wildcard)
+  ensures acc(ret.class_Bar$member_f, wildcard)
 
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
+method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Int,
   local$b: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_a, wildcard)
-  ensures acc(ret.class_scope_global$class_Foo$member_b, wildcard)
+  ensures acc(ret.class_Foo$member_a, wildcard)
+  ensures acc(ret.class_Foo$member_b, wildcard)
 
 
 method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
@@ -65,45 +64,44 @@ method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
   var anonymous$4: Ref
   var anonymous$5: Int
   var local0$bfb: Int
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(10,
     20)
   local0$foo := anonymous$0
-  anonymous$1 := class_scope_global$class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local0$foo)
+  anonymous$1 := class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local0$foo)
   local0$bar := anonymous$1
-  anonymous$2 := local0$bar.class_scope_global$class_Bar$member_f
+  anonymous$2 := local0$bar.class_Bar$member_f
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$global$class_Foo())
-  anonymous$3 := anonymous$2.class_scope_global$class_Foo$member_a
+  anonymous$3 := anonymous$2.class_Foo$member_a
   local0$bfa := anonymous$3
-  anonymous$4 := local0$bar.class_scope_global$class_Bar$member_f
+  anonymous$4 := local0$bar.class_Bar$member_f
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$4): dom$Type), dom$Type$global$class_Foo())
-  anonymous$5 := anonymous$4.class_scope_global$class_Foo$member_b
+  anonymous$5 := anonymous$4.class_Foo$member_b
   local0$bfb := anonymous$5
   label label$ret$0
 }
 
 /classes_getters.kt:(401,425): info: Generated Viper text for testCascadeCustomGetters:
-field class_scope_global$class_IntWrapper$member_n: Int
+field class_IntWrapper$member_n: Int
 
-field class_scope_global$class_IntWrapperContainer$member_i: Ref
+field class_IntWrapperContainer$member_i: Ref
 
-method class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
+method class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapper())
-  ensures acc(ret.class_scope_global$class_IntWrapper$member_n, wildcard)
+  ensures acc(ret.class_IntWrapper$member_n, wildcard)
 
 
-method class_scope_global$class_IntWrapper$getter_succ(this: Ref)
-  returns (ret: Int)
-  requires acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
-  ensures acc(this.class_scope_global$class_IntWrapper$member_n, wildcard)
+method class_IntWrapper$getter_succ(this: Ref) returns (ret: Int)
+  requires acc(this.class_IntWrapper$member_n, wildcard)
+  ensures acc(this.class_IntWrapper$member_n, wildcard)
 
 
-method class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
+method class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
   returns (ret: Ref)
-  requires acc(local$i.class_scope_global$class_IntWrapper$member_n, wildcard)
-  ensures acc(local$i.class_scope_global$class_IntWrapper$member_n, wildcard)
+  requires acc(local$i.class_IntWrapper$member_n, wildcard)
+  ensures acc(local$i.class_IntWrapper$member_n, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_IntWrapperContainer())
-  ensures acc(ret.class_scope_global$class_IntWrapperContainer$member_i, wildcard)
+  ensures acc(ret.class_IntWrapperContainer$member_i, wildcard)
 
 
 method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
@@ -115,12 +113,12 @@ method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   var anonymous$2: Ref
   var anonymous$3: Int
   var local0$succ: Int
-  anonymous$0 := class_scope_global$class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
-  anonymous$1 := class_scope_global$class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(anonymous$0)
+  anonymous$0 := class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(42)
+  anonymous$1 := class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(anonymous$0)
   local0$wrapper := anonymous$1
-  anonymous$2 := local0$wrapper.class_scope_global$class_IntWrapperContainer$member_i
+  anonymous$2 := local0$wrapper.class_IntWrapperContainer$member_i
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$global$class_IntWrapper())
-  anonymous$3 := class_scope_global$class_IntWrapper$getter_succ(anonymous$2)
+  anonymous$3 := class_IntWrapper$getter_succ(anonymous$2)
   local0$succ := anonymous$3
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -1,18 +1,17 @@
 /classes_setters.kt:(408,424): info: Generated Viper text for testCustomSetter:
-field class_scope_global$class_AlwaysPlusOne$member_b: Int
+field class_AlwaysPlusOne$member_b: Int
 
-field class_scope_global$class_AlwaysPlusOne$member_num: Int
+field class_AlwaysPlusOne$member_num: Int
 
-method class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
+method class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_AlwaysPlusOne())
 
 
-method class_scope_global$class_AlwaysPlusOne$getter_num(this: Ref)
-  returns (ret: Int)
+method class_AlwaysPlusOne$getter_num(this: Ref) returns (ret: Int)
 
 
-method class_scope_global$class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
+method class_AlwaysPlusOne$setter_num(this: Ref, local$value: Int)
   returns (ret: dom$Unit)
 
 
@@ -22,20 +21,19 @@ method global$fun_testCustomSetter$fun_take$$return$T_Unit()
   var anonymous$0: Ref
   var local0$f: Ref
   var anonymous$1: dom$Unit
-  anonymous$0 := class_scope_global$class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
+  anonymous$0 := class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
   local0$f := anonymous$0
-  inhale acc(local0$f.class_scope_global$class_AlwaysPlusOne$member_b, write)
-  local0$f.class_scope_global$class_AlwaysPlusOne$member_b := 1
-  exhale acc(local0$f.class_scope_global$class_AlwaysPlusOne$member_b, write)
-  anonymous$1 := class_scope_global$class_AlwaysPlusOne$setter_num(local0$f,
-    1)
+  inhale acc(local0$f.class_AlwaysPlusOne$member_b, write)
+  local0$f.class_AlwaysPlusOne$member_b := 1
+  exhale acc(local0$f.class_AlwaysPlusOne$member_b, write)
+  anonymous$1 := class_AlwaysPlusOne$setter_num(local0$f, 1)
   label label$ret$0
 }
 
 /classes_setters.kt:(490,500): info: Generated Viper text for testSetter:
-field class_scope_global$class_Person$member_age: Int
+field class_Person$member_age: Int
 
-method class_scope_global$class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(local$age: Int)
+method class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(local$age: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Person())
 
@@ -46,29 +44,28 @@ method global$fun_testSetter$fun_take$$return$T_Unit()
   var anonymous$0: Ref
   var local0$person: Ref
   var anonymous$1: Int
-  anonymous$0 := class_scope_global$class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(19)
+  anonymous$0 := class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(19)
   local0$person := anonymous$0
-  inhale acc(local0$person.class_scope_global$class_Person$member_age, write)
-  anonymous$1 := local0$person.class_scope_global$class_Person$member_age
-  exhale acc(local0$person.class_scope_global$class_Person$member_age, write)
-  inhale acc(local0$person.class_scope_global$class_Person$member_age, write)
-  local0$person.class_scope_global$class_Person$member_age := anonymous$1 +
-    1
-  exhale acc(local0$person.class_scope_global$class_Person$member_age, write)
+  inhale acc(local0$person.class_Person$member_age, write)
+  anonymous$1 := local0$person.class_Person$member_age
+  exhale acc(local0$person.class_Person$member_age, write)
+  inhale acc(local0$person.class_Person$member_age, write)
+  local0$person.class_Person$member_age := anonymous$1 + 1
+  exhale acc(local0$person.class_Person$member_age, write)
   label label$ret$0
 }
 
 /classes_setters.kt:(572,589): info: Generated Viper text for testSetterCascade:
-field class_scope_global$class_Bar$member_a: Int
+field class_Bar$member_a: Int
 
-field class_scope_global$class_Foo$member_b: Ref
+field class_Foo$member_b: Ref
 
-method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
-method class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
+method class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
@@ -80,31 +77,31 @@ method global$fun_testSetterCascade$fun_take$$return$T_Unit()
   var anonymous$1: Ref
   var local0$f: Ref
   var anonymous$2: Ref
-  anonymous$0 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(10)
-  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(anonymous$0)
+  anonymous$0 := class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(10)
+  anonymous$1 := class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(anonymous$0)
   local0$f := anonymous$1
-  inhale acc(local0$f.class_scope_global$class_Foo$member_b, write)
-  anonymous$2 := local0$f.class_scope_global$class_Foo$member_b
+  inhale acc(local0$f.class_Foo$member_b, write)
+  anonymous$2 := local0$f.class_Foo$member_b
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$2): dom$Type), dom$Type$global$class_Bar())
-  exhale acc(local0$f.class_scope_global$class_Foo$member_b, write)
-  inhale acc(anonymous$2.class_scope_global$class_Bar$member_a, write)
-  anonymous$2.class_scope_global$class_Bar$member_a := 42
-  exhale acc(anonymous$2.class_scope_global$class_Bar$member_a, write)
+  exhale acc(local0$f.class_Foo$member_b, write)
+  inhale acc(anonymous$2.class_Bar$member_a, write)
+  anonymous$2.class_Bar$member_a := 42
+  exhale acc(anonymous$2.class_Bar$member_a, write)
   label label$ret$0
 }
 
 /classes_setters.kt:(641,665): info: Generated Viper text for testSetterNoBackingField:
-field class_scope_global$class_Baz$member__a: Int
+field class_Baz$member__a: Int
 
-method class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
+method class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Baz())
 
 
-method class_scope_global$class_Baz$getter_a(this: Ref) returns (ret: Int)
+method class_Baz$getter_a(this: Ref) returns (ret: Int)
 
 
-method class_scope_global$class_Baz$setter_a(this: Ref, local$value: Int)
+method class_Baz$setter_a(this: Ref, local$value: Int)
   returns (ret: dom$Unit)
 
 
@@ -114,16 +111,16 @@ method global$fun_testSetterNoBackingField$fun_take$$return$T_Unit()
   var anonymous$0: Ref
   var local0$baz: Ref
   var anonymous$1: dom$Unit
-  anonymous$0 := class_scope_global$class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
+  anonymous$0 := class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   local0$baz := anonymous$0
-  anonymous$1 := class_scope_global$class_Baz$setter_a(local0$baz, 42)
+  anonymous$1 := class_Baz$setter_a(local0$baz, 42)
   label label$ret$0
 }
 
 /classes_setters.kt:(805,821): info: Generated Viper text for testSetterLambda:
-field class_scope_global$class_Bar$member_a: Int
+field class_Bar$member_a: Int
 
-method class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
+method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
@@ -133,11 +130,11 @@ method global$fun_testSetterLambda$fun_take$$return$T_Unit()
 {
   var anonymous$0: Ref
   var anonymous$1: dom$Unit
-  anonymous$0 := class_scope_global$class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(0)
+  anonymous$0 := class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(0)
   if (true) {
-    inhale acc(anonymous$0.class_scope_global$class_Bar$member_a, write)
-    anonymous$0.class_scope_global$class_Bar$member_a := 42
-    exhale acc(anonymous$0.class_scope_global$class_Bar$member_a, write)
+    inhale acc(anonymous$0.class_Bar$member_a, write)
+    anonymous$0.class_Bar$member_a := 42
+    exhale acc(anonymous$0.class_Bar$member_a, write)
     label label$ret$1
   }
   label label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
@@ -1,7 +1,7 @@
 /exp_side_effects.kt:(27,34): info: Generated Viper text for get_foo:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
@@ -11,7 +11,7 @@ method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 {
   var anonymous$0: Ref
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(0)
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(0)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
@@ -26,7 +26,7 @@ method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Int)
 }
 
 /exp_side_effects.kt:(83,87): info: Generated Viper text for test:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
 method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
@@ -46,13 +46,13 @@ method global$fun_test$fun_take$$return$T_Unit() returns (ret: dom$Unit)
   var local0$y: Int
   anonymous$0 := global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   anonymous$1 := global$fun_side_effect$fun_take$$return$T_Int()
-  inhale acc(anonymous$0.class_scope_global$class_Foo$member_x, write)
-  anonymous$0.class_scope_global$class_Foo$member_x := anonymous$1
-  exhale acc(anonymous$0.class_scope_global$class_Foo$member_x, write)
+  inhale acc(anonymous$0.class_Foo$member_x, write)
+  anonymous$0.class_Foo$member_x := anonymous$1
+  exhale acc(anonymous$0.class_Foo$member_x, write)
   anonymous$2 := global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
-  inhale acc(anonymous$2.class_scope_global$class_Foo$member_x, write)
-  anonymous$3 := anonymous$2.class_scope_global$class_Foo$member_x
-  exhale acc(anonymous$2.class_scope_global$class_Foo$member_x, write)
+  inhale acc(anonymous$2.class_Foo$member_x, write)
+  anonymous$3 := anonymous$2.class_Foo$member_x
+  exhale acc(anonymous$2.class_Foo$member_x, write)
   anonymous$4 := global$fun_side_effect$fun_take$$return$T_Int()
   local0$y := anonymous$3 + anonymous$4
   label label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_function.fir.diag.txt
@@ -12,9 +12,9 @@ method global$fun_extension_method_call$fun_take$$return$T_Unit()
   returns (ret: dom$Unit)
 {
   var anonymous$0: Int
-  anonymous$0 := pkg$kotlin$class_scope_pkg$kotlin$global$class_Int$fun_inc$fun_take$T_Int$return$T_Int(3)
+  anonymous$0 := pkg$kotlin$class_Int$fun_inc$fun_take$T_Int$return$T_Int(3)
   label label$ret$0
 }
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_Int$fun_inc$fun_take$T_Int$return$T_Int(this: Int)
+method pkg$kotlin$class_Int$fun_inc$fun_take$T_Int$return$T_Int(this: Int)
   returns (ret: Int)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -39,18 +39,18 @@ method global$fun_extensionSetterProperty$fun_take$$return$T_Unit()
 }
 
 /extension_properties.kt:(409,448): info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(ret.class_Foo$member_x, wildcard)
 
 
 method global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 
 
 method global$fun_extensionGetterPropertyUserDefinedClass$fun_take$$return$T_Unit()
@@ -60,7 +60,7 @@ method global$fun_extensionGetterPropertyUserDefinedClass$fun_take$$return$T_Uni
   var local0$f: Ref
   var anonymous$1: Int
   var local0$x: Int
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
   local0$f := anonymous$0
   anonymous$1 := global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(local0$f)
   local0$x := anonymous$1
@@ -68,25 +68,25 @@ method global$fun_extensionGetterPropertyUserDefinedClass$fun_take$$return$T_Uni
 }
 
 /extension_properties.kt:(499,538): info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(ret.class_Foo$member_x, wildcard)
 
 
 method global$ext_getter_strange$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 
 
 method global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$T_Unit(this: Ref,
   local$v: Int)
   returns (ret: dom$Unit)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 
 
 method global$fun_extensionSetterPropertyUserDefinedClass$fun_take$$return$T_Unit()
@@ -95,7 +95,7 @@ method global$fun_extensionSetterPropertyUserDefinedClass$fun_take$$return$T_Uni
   var anonymous$0: Ref
   var local0$f: Ref
   var anonymous$1: dom$Unit
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(42)
   local0$f := anonymous$0
   anonymous$1 := global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$T_Unit(local0$f,
     42)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -259,24 +259,24 @@ domain dom$Unit  {
   }
 }
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
 field special$function_object_call_counter: Int
 
 function special$duplicable(anonymous$0: Ref): Bool
 
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(ret.class_Foo$member_x, wildcard)
 
 
 method global$fun_f$fun_take$$return$T_Unit() returns (ret: dom$Unit)
 {
   var anonymous$0: Ref
   var local0$foo: Ref
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(0)
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(0)
   local0$foo := anonymous$0
   label label$ret$0
 }
@@ -286,4 +286,3 @@ method special$invoke_function_object(anonymous$0: Ref)
   ensures acc(anonymous$0.special$function_object_call_counter, write)
   ensures old(anonymous$0.special$function_object_call_counter) + 1 ==
     anonymous$0.special$function_object_call_counter
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -1,5 +1,5 @@
 /function_overloading.kt:(30,33): info: Generated Viper text for baz:
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
+method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$f: Ref)
   returns (ret: dom$Unit)
 {
@@ -9,7 +9,7 @@ method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_
 }
 
 /function_overloading.kt:(55,58): info: Generated Viper text for baz:
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
+method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
   local$b: Ref)
   returns (ret: dom$Unit)
 {
@@ -49,12 +49,12 @@ method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Bool)
 }
 
 /function_overloading.kt:(200,226): info: Generated Viper text for testGlobalScopeOverloading:
-method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+method class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
-method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
@@ -86,30 +86,30 @@ method global$fun_testGlobalScopeOverloading$fun_take$$return$T_Unit()
   var anonymous$5: dom$Unit
   anonymous$0 := global$fun_fakePrint$fun_take$T_Int$return$T_Unit(42)
   anonymous$1 := global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(true)
-  anonymous$2 := class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  anonymous$2 := class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   anonymous$3 := global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(anonymous$2)
-  anonymous$4 := class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  anonymous$4 := class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   anonymous$5 := global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(anonymous$4)
   label label$ret$0
 }
 
 /function_overloading.kt:(318,346): info: Generated Viper text for testClassFunctionOverloading:
-method class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+method class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Bar())
 
 
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
+method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
   local$b: Ref)
   returns (ret: dom$Unit)
 
 
-method class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
+method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$f: Ref)
   returns (ret: dom$Unit)
 
 
-method class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
 
@@ -123,13 +123,13 @@ method global$fun_testClassFunctionOverloading$fun_take$$return$T_Unit()
   var anonymous$2: dom$Unit
   var anonymous$3: Ref
   var anonymous$4: dom$Unit
-  anonymous$0 := class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  anonymous$0 := class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   local0$b := anonymous$0
-  anonymous$1 := class_scope_global$class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
-  anonymous$2 := class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(local0$b,
+  anonymous$1 := class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
+  anonymous$2 := class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(local0$b,
     anonymous$1)
-  anonymous$3 := class_scope_global$class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
-  anonymous$4 := class_scope_global$class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(local0$b,
+  anonymous$3 := class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
+  anonymous$4 := class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(local0$b,
     anonymous$3)
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
@@ -1,7 +1,7 @@
 /generics.kt:(33,46): info: Generated Viper text for genericMethod:
-field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
+field class_Box$member_t: dom$Nullable[dom$Any]
 
-method class_scope_global$class_Box$fun_genericMethod$fun_take$T_class_global$class_Box$NT_Any$return$NT_Any(this: Ref,
+method class_Box$fun_genericMethod$fun_take$T_class_global$class_Box$NT_Any$return$NT_Any(this: Ref,
   local$x: dom$Nullable[dom$Any])
   returns (ret: dom$Nullable[dom$Any])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
@@ -14,9 +14,9 @@ method class_scope_global$class_Box$fun_genericMethod$fun_take$T_class_global$cl
 }
 
 /generics.kt:(88,97): info: Generated Viper text for createBox:
-field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
+field class_Box$member_t: dom$Nullable[dom$Any]
 
-method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
+method class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
 
@@ -30,30 +30,30 @@ method global$fun_createBox$fun_take$$return$T_Int() returns (ret: Int)
   var anonymous$2: Ref
   var local0$intBox: Ref
   var anonymous$3: dom$Nullable[dom$Any]
-  anonymous$0 := class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(true,
+  anonymous$0 := class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(true,
     dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
   local0$boolBox := anonymous$0
-  inhale acc(local0$boolBox.class_scope_global$class_Box$member_t, write)
-  anonymous$1 := local0$boolBox.class_scope_global$class_Box$member_t
+  inhale acc(local0$boolBox.class_Box$member_t, write)
+  anonymous$1 := local0$boolBox.class_Box$member_t
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$1): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-  exhale acc(local0$boolBox.class_scope_global$class_Box$member_t, write)
+  exhale acc(local0$boolBox.class_Box$member_t, write)
   local0$b := (dom$Casting$cast(anonymous$1, dom$Type$Boolean()): Bool)
-  anonymous$2 := class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(2,
+  anonymous$2 := class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(2,
     dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
   local0$intBox := anonymous$2
-  inhale acc(local0$intBox.class_scope_global$class_Box$member_t, write)
-  anonymous$3 := local0$intBox.class_scope_global$class_Box$member_t
+  inhale acc(local0$intBox.class_Box$member_t, write)
+  anonymous$3 := local0$intBox.class_Box$member_t
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$3): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-  exhale acc(local0$intBox.class_scope_global$class_Box$member_t, write)
+  exhale acc(local0$intBox.class_Box$member_t, write)
   ret := (dom$Casting$cast(anonymous$3, dom$Type$Int()): Int)
   goto label$ret$0
   label label$ret$0
 }
 
 /generics.kt:(208,223): info: Generated Viper text for setGenericField:
-field class_scope_global$class_Box$member_t: dom$Nullable[dom$Any]
+field class_Box$member_t: dom$Nullable[dom$Any]
 
-method class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
+method class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: dom$Nullable[dom$Any])
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Box())
 
@@ -63,12 +63,12 @@ method global$fun_setGenericField$fun_take$$return$T_Unit()
 {
   var anonymous$0: Ref
   var local0$box: Ref
-  anonymous$0 := class_scope_global$class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(3,
+  anonymous$0 := class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box((dom$Casting$cast(3,
     dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any]))
   local0$box := anonymous$0
-  inhale acc(local0$box.class_scope_global$class_Box$member_t, write)
-  local0$box.class_scope_global$class_Box$member_t := (dom$Casting$cast(5, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any])
-  exhale acc(local0$box.class_scope_global$class_Box$member_t, write)
+  inhale acc(local0$box.class_Box$member_t, write)
+  local0$box.class_Box$member_t := (dom$Casting$cast(5, dom$Type$special$Nullable(dom$Type$Any())): dom$Nullable[dom$Any])
+  exhale acc(local0$box.class_Box$member_t, write)
   label label$ret$0
 }
 
@@ -98,4 +98,3 @@ method global$fun_callGenericFunc$fun_take$$return$T_Unit()
 method global$fun_genericFun$fun_take$NT_Any$return$NT_Any(local$t: dom$Nullable[dom$Any])
   returns (ret: dom$Nullable[dom$Any])
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Any()))
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/if.fir.diag.txt
@@ -57,4 +57,3 @@ method global$fun_if_on_parameter$fun_take$T_Boolean$return$T_Int(local$b: Bool)
 
 
 method global$fun_simple_if$fun_take$$return$T_Int() returns (ret: Int)
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -1,82 +1,82 @@
 /inheritance.kt:(74,78): info: Generated Viper text for getY:
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
-method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+method class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_y, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_y, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
-  anonymous$0 := this.class_scope_global$class_Foo$member_y
+  anonymous$0 := this.class_Foo$member_y
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
 }
 
 /inheritance.kt:(171,174): info: Generated Viper text for sum:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
-method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
+method class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(this.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(this.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_y, wildcard)
+  requires acc(this.class_Bar$member_z, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_y, wildcard)
+  ensures acc(this.class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   var anonymous$1: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Bar())
-  anonymous$0 := this.class_scope_global$class_Foo$member_x
-  anonymous$1 := this.class_scope_global$class_Bar$member_z
+  anonymous$0 := this.class_Foo$member_x
+  anonymous$1 := this.class_Bar$member_z
   ret := anonymous$0 + anonymous$1
   goto label$ret$0
   label label$ret$0
 }
 
 /inheritance.kt:(217,232): info: Generated Viper text for callSuperMethod:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
-method class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+method class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_y, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_y, wildcard)
 
 
 method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
-  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(local$bar.class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
-  anonymous$0 := class_scope_global$class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int((dom$Casting$cast(local$bar,
+  anonymous$0 := class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int((dom$Casting$cast(local$bar,
     dom$Type$global$class_Foo()): Ref))
   ret := anonymous$0
   goto label$ret$0
@@ -84,141 +84,141 @@ method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int
 }
 
 /inheritance.kt:(279,295): info: Generated Viper text for accessSuperField:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
 method global$fun_accessSuperField$fun_take$T_class_global$class_Bar$return$T_Boolean(local$bar: Ref)
   returns (ret: Bool)
-  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(local$bar.class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_Bar$member_z, wildcard)
 {
   var anonymous$0: Bool
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
-  inhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
-  anonymous$0 := local$bar.class_scope_global$class_Foo$member_b
-  exhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
+  inhale acc(local$bar.class_Foo$member_b, write)
+  anonymous$0 := local$bar.class_Foo$member_b
+  exhale acc(local$bar.class_Foo$member_b, write)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
 }
 
 /inheritance.kt:(341,355): info: Generated Viper text for accessNewField:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
 method global$fun_accessNewField$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
-  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(local$bar.class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
-  anonymous$0 := local$bar.class_scope_global$class_Bar$member_z
+  anonymous$0 := local$bar.class_Bar$member_z
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
 }
 
 /inheritance.kt:(397,410): info: Generated Viper text for callNewMethod:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
-method class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
+method class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(this.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(this.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(this.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_y, wildcard)
+  requires acc(this.class_Bar$member_z, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_y, wildcard)
+  ensures acc(this.class_Bar$member_z, wildcard)
 
 
 method global$fun_callNewMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret: Int)
-  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(local$bar.class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
-  anonymous$0 := class_scope_global$class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(local$bar)
+  anonymous$0 := class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(local$bar)
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
 }
 
 /inheritance.kt:(456,469): info: Generated Viper text for setSuperField:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
 method global$fun_setSuperField$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret: dom$Unit)
-  requires acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(local$bar.class_Foo$member_x, wildcard)
+  requires acc(local$bar.class_Foo$member_y, wildcard)
+  requires acc(local$bar.class_Bar$member_z, wildcard)
+  ensures acc(local$bar.class_Foo$member_x, wildcard)
+  ensures acc(local$bar.class_Foo$member_y, wildcard)
+  ensures acc(local$bar.class_Bar$member_z, wildcard)
 {
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$bar): dom$Type), dom$Type$global$class_Bar())
-  inhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
-  local$bar.class_scope_global$class_Foo$member_b := true
-  exhale acc(local$bar.class_scope_global$class_Foo$member_b, write)
+  inhale acc(local$bar.class_Foo$member_b, write)
+  local$bar.class_Foo$member_b := true
+  exhale acc(local$bar.class_Foo$member_b, write)
   label label$ret$0
 }
 
 /inheritance.kt:(506,527): info: Generated Viper text for accessSuperSuperField:
-field class_scope_global$class_Bar$member_z: Int
+field class_Bar$member_z: Int
 
-field class_scope_global$class_Foo$member_b: Bool
+field class_Foo$member_b: Bool
 
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-field class_scope_global$class_Foo$member_y: Int
+field class_Foo$member_y: Int
 
 method global$fun_accessSuperSuperField$fun_take$T_class_global$class_Baz$return$T_Int(local$baz: Ref)
   returns (ret: Int)
-  requires acc(local$baz.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$baz.class_scope_global$class_Foo$member_y, wildcard)
-  requires acc(local$baz.class_scope_global$class_Bar$member_z, wildcard)
-  ensures acc(local$baz.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$baz.class_scope_global$class_Foo$member_y, wildcard)
-  ensures acc(local$baz.class_scope_global$class_Bar$member_z, wildcard)
+  requires acc(local$baz.class_Foo$member_x, wildcard)
+  requires acc(local$baz.class_Foo$member_y, wildcard)
+  requires acc(local$baz.class_Bar$member_z, wildcard)
+  ensures acc(local$baz.class_Foo$member_x, wildcard)
+  ensures acc(local$baz.class_Foo$member_y, wildcard)
+  ensures acc(local$baz.class_Bar$member_z, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$baz): dom$Type), dom$Type$global$class_Baz())
-  anonymous$0 := local$baz.class_scope_global$class_Foo$member_x
+  anonymous$0 := local$baz.class_Foo$member_x
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
@@ -1,13 +1,11 @@
 /interface.kt:(65,80): info: Generated Viper text for test_properties:
-method class_scope_global$class_Foo$getter_valProp(this: Ref)
-  returns (ret: Int)
+method class_Foo$getter_valProp(this: Ref) returns (ret: Int)
 
 
-method class_scope_global$class_Foo$getter_varProp(this: Ref)
-  returns (ret: Int)
+method class_Foo$getter_varProp(this: Ref) returns (ret: Int)
 
 
-method class_scope_global$class_Foo$setter_varProp(this: Ref, local$value: Int)
+method class_Foo$setter_varProp(this: Ref, local$value: Int)
   returns (ret: dom$Unit)
 
 
@@ -19,9 +17,9 @@ method global$fun_test_properties$fun_take$T_class_global$class_Foo$return$T_Uni
   var anonymous$2: Int
   var local0$x: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$foo): dom$Type), dom$Type$global$class_Foo())
-  anonymous$0 := class_scope_global$class_Foo$setter_varProp(local$foo, 0)
-  anonymous$1 := class_scope_global$class_Foo$getter_varProp(local$foo)
-  anonymous$2 := class_scope_global$class_Foo$getter_valProp(local$foo)
+  anonymous$0 := class_Foo$setter_varProp(local$foo, 0)
+  anonymous$1 := class_Foo$getter_varProp(local$foo)
+  anonymous$2 := class_Foo$getter_valProp(local$foo)
   local0$x := anonymous$1 + anonymous$2
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -1,76 +1,76 @@
 /member_functions.kt:(32,42): info: Generated Viper text for member_fun:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
-  anonymous$0 := this.class_scope_global$class_Foo$member_x
+  anonymous$0 := this.class_Foo$member_x
   ret := anonymous$0
   goto label$ret$0
   label label$ret$0
 }
 
 /member_functions.kt:(84,99): info: Generated Viper text for call_member_fun:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$fun_call_member_fun$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
+method class_Foo$fun_call_member_fun$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
   returns (ret: dom$Unit)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
-  anonymous$0 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this)
+  anonymous$0 := class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this)
   label label$ret$0
 }
 
-method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 
 
 /member_functions.kt:(140,152): info: Generated Viper text for sibling_call:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 
 
-method class_scope_global$class_Foo$fun_sibling_call$fun_take$T_class_global$class_Foo$T_class_global$class_Foo$return$T_Unit(this: Ref,
+method class_Foo$fun_sibling_call$fun_take$T_class_global$class_Foo$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$other: Ref)
   returns (ret: dom$Unit)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  requires acc(local$other.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(local$other.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  requires acc(local$other.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
+  ensures acc(local$other.class_Foo$member_x, wildcard)
 {
   var anonymous$0: Int
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(this): dom$Type), dom$Type$global$class_Foo())
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$other): dom$Type), dom$Type$global$class_Foo())
-  anonymous$0 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local$other)
+  anonymous$0 := class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local$other)
   label label$ret$0
 }
 
 /member_functions.kt:(207,228): info: Generated Viper text for outer_member_fun_call:
-field class_scope_global$class_Foo$member_x: Int
+field class_Foo$member_x: Int
 
-method class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
+method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Int)
   returns (ret: Ref)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$global$class_Foo())
-  ensures acc(ret.class_scope_global$class_Foo$member_x, wildcard)
+  ensures acc(ret.class_Foo$member_x, wildcard)
 
 
-method class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
+method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Int)
-  requires acc(this.class_scope_global$class_Foo$member_x, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_x, wildcard)
+  requires acc(this.class_Foo$member_x, wildcard)
+  ensures acc(this.class_Foo$member_x, wildcard)
 
 
 method global$fun_outer_member_fun_call$fun_take$$return$T_Unit()
@@ -79,8 +79,8 @@ method global$fun_outer_member_fun_call$fun_take$$return$T_Unit()
   var anonymous$0: Ref
   var local0$f: Ref
   var anonymous$1: Int
-  anonymous$0 := class_scope_global$class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(3)
+  anonymous$0 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(3)
   local0$f := anonymous$0
-  anonymous$1 := class_scope_global$class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local0$f)
+  anonymous$1 := class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(local0$f)
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -142,14 +142,14 @@ method global$fun_evlis_operator_return$fun_take$NT_Int$return$T_Int(local$x: do
 }
 
 /nullable.kt:(711,720): info: Generated Viper text for safe_call:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+field pkg$kotlin$class_String$member_length: Int
 
 method global$fun_safe_call$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
   requires local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_String$member_length, wildcard)
   ensures local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_String$member_length, wildcard)
 {
   var anonymous$0: dom$Nullable[Int]
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$s): dom$Type), dom$Type$special$Nullable(dom$Type$pkg$kotlin$global$class_String()))
@@ -157,30 +157,30 @@ method global$fun_safe_call$fun_take$NT_class_pkg$kotlin$global$class_String$ret
     anonymous$0 := (dom$Nullable$null(): dom$Nullable[Int])
   } else {
     var anonymous$1: Int
-    anonymous$1 := pkg$kotlin$class_scope_pkg$kotlin$global$class_Any$fun_hashCode$fun_take$T_Any$return$T_Int((dom$Casting$cast((dom$Casting$cast(local$s,
+    anonymous$1 := pkg$kotlin$class_Any$fun_hashCode$fun_take$T_Any$return$T_Int((dom$Casting$cast((dom$Casting$cast(local$s,
       dom$Type$pkg$kotlin$global$class_String()): Ref), dom$Type$Any()): dom$Any))
     anonymous$0 := (dom$Casting$cast(anonymous$1, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
   }
   label label$ret$0
 }
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_Any$fun_hashCode$fun_take$T_Any$return$T_Int(this: dom$Any)
+method pkg$kotlin$class_Any$fun_hashCode$fun_take$T_Any$return$T_Int(this: dom$Any)
   returns (ret: Int)
 
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
 
 /nullable.kt:(760,778): info: Generated Viper text for safe_call_property:
-field pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length: Int
+field pkg$kotlin$class_String$member_length: Int
 
 method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: dom$Nullable[Ref])
   returns (ret: dom$Unit)
   requires local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_String$member_length, wildcard)
   ensures local$s != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length, wildcard)
+    acc((dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_String$member_length, wildcard)
 {
   var anonymous$0: dom$Nullable[Int]
   var local0$l: dom$Nullable[Int]
@@ -189,35 +189,35 @@ method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_S
     anonymous$0 := (dom$Nullable$null(): dom$Nullable[Int])
   } else {
     var anonymous$1: Int
-    anonymous$1 := (dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_scope_pkg$kotlin$global$class_String$member_length
+    anonymous$1 := (dom$Casting$cast(local$s, dom$Type$pkg$kotlin$global$class_String()): Ref).pkg$kotlin$class_String$member_length
     anonymous$0 := (dom$Casting$cast(anonymous$1, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
   }
   local0$l := anonymous$0
   label label$ret$0
 }
 
-method pkg$kotlin$class_scope_pkg$kotlin$global$class_CharSequence$getter_length(this: Ref)
+method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
 
 /nullable.kt:(899,914): info: Generated Viper text for safe_call_chain:
-field class_scope_global$class_Foo$member_v: Int
+field class_Foo$member_v: Int
 
-method class_scope_global$class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo(this: Ref)
+method class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo(this: Ref)
   returns (ret: dom$Nullable[Ref])
-  requires acc(this.class_scope_global$class_Foo$member_v, wildcard)
-  ensures acc(this.class_scope_global$class_Foo$member_v, wildcard)
+  requires acc(this.class_Foo$member_v, wildcard)
+  ensures acc(this.class_Foo$member_v, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$global$class_Foo()))
   ensures ret != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(ret, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, wildcard)
+    acc((dom$Casting$cast(ret, dom$Type$global$class_Foo()): Ref).class_Foo$member_v, wildcard)
 
 
 method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_Int(local$foo: dom$Nullable[Ref])
   returns (ret: dom$Nullable[Int])
   requires local$foo != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$foo, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, wildcard)
+    acc((dom$Casting$cast(local$foo, dom$Type$global$class_Foo()): Ref).class_Foo$member_v, wildcard)
   ensures local$foo != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc((dom$Casting$cast(local$foo, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v, wildcard)
+    acc((dom$Casting$cast(local$foo, dom$Type$global$class_Foo()): Ref).class_Foo$member_v, wildcard)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
 {
   var anonymous$0: dom$Nullable[Ref]
@@ -228,7 +228,7 @@ method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_I
     anonymous$0 := (dom$Nullable$null(): dom$Nullable[Ref])
   } else {
     var anonymous$1: dom$Nullable[Ref]
-    anonymous$1 := class_scope_global$class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo((dom$Casting$cast(local$foo,
+    anonymous$1 := class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo((dom$Casting$cast(local$foo,
       dom$Type$global$class_Foo()): Ref))
     anonymous$0 := anonymous$1
   }
@@ -236,7 +236,7 @@ method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_I
     anonymous$2 := (dom$Nullable$null(): dom$Nullable[Ref])
   } else {
     var anonymous$3: dom$Nullable[Ref]
-    anonymous$3 := class_scope_global$class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo((dom$Casting$cast(anonymous$0,
+    anonymous$3 := class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo((dom$Casting$cast(anonymous$0,
       dom$Type$global$class_Foo()): Ref))
     anonymous$2 := anonymous$3
   }
@@ -244,7 +244,7 @@ method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_I
     anonymous$4 := (dom$Nullable$null(): dom$Nullable[Int])
   } else {
     var anonymous$5: Int
-    anonymous$5 := (dom$Casting$cast(anonymous$2, dom$Type$global$class_Foo()): Ref).class_scope_global$class_Foo$member_v
+    anonymous$5 := (dom$Casting$cast(anonymous$2, dom$Type$global$class_Foo()): Ref).class_Foo$member_v
     anonymous$4 := (dom$Casting$cast(anonymous$5, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
   }
   ret := anonymous$4


### PR DESCRIPTION
We were including the package in both the class and member scopes; looking at how the compiler deals with this, these have to be equal so we can separate the names.