### PR TITLE
Prevent duplicate `NullableType` application.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/NullableDomain.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/NullableDomain.kt
@@ -15,18 +15,21 @@ import org.jetbrains.kotlin.formver.viper.ast.*
  *   function null_val(): Nullable[T]
  *
  *   axiom some_not_null {
- *     (forall x: T, newType: Type :: { (cast(x, NullableType(newType)): Nullable[T]) }
+ *     (forall x: T, newType: Type ::
+ *       { (cast(x, NullableType(newType)): Nullable[T]) }
  *       !is_nullable_type(newType) ==>
  *         (cast(x, NullableType(newType)): Nullable[T]) != (null_val(): Nullable[T]))
  *   }
  *
  *   axiom val_of_nullable_of_val {
- *     (forall x: T, newType: Type :: { (cast((cast(x, NullableType(newType)): Nullable[T]), (typeOf(x): Type)): T) }
+ *     (forall x: T, newType: Type ::
+ *       { (cast((cast(x, NullableType(newType)): Nullable[T]), (typeOf(x): Type)): T) }
  *       (cast((cast(x, NullableType(newType)): Nullable[T]), (typeOf(x): Type)): T) == x)
  *   }
  *
  *   axiom nullable_of_val_of_nullable {
- *     (forall nx: Nullable[T], newType: Type :: { (cast((cast(nx, newType): T), (typeOf(nx): Type)): Nullable[T]) }
+ *     (forall nx: Nullable[T], newType: Type ::
+ *       { (cast((cast(nx, newType): T), (typeOf(nx): Type)): Nullable[T]) }
  *       nx != (null_val(): Nullable[T]) ==>
  *         (cast((cast(nx, newType): T), (typeOf(nx): Type)): Nullable[T]) == nx)
  *   }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -10,8 +10,9 @@ domain dom$Casting[A, B]  {
 
   axiom dom$Casting$null_cast {
     (forall newType: dom$Type ::
-      { (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), dom$Type$special$Nullable(newType)): dom$Nullable[B]) }
-      (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), dom$Type$special$Nullable(newType)): dom$Nullable[B]) ==
+      { (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), newType): dom$Nullable[B]) }
+      dom$Type$is_nullable_type(newType) ==>
+      (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[A]), newType): dom$Nullable[B]) ==
       (dom$Nullable$null(): dom$Nullable[B]))
   }
 


### PR DESCRIPTION
In `null_cast`, we previously applied `NullableType` to an arbitrary `newType : Type`.  This could lead to a type getting double nullability, which can cause issues in reasoning as it does not make sense in Kotlin. With this change, we instead check that the `newType` is indeed nullable before permitting reasoning about the cast.