### PR TITLE
Remove `FUNCTION_WITH_UNVERIFIED_CONTRACT` warning.

### DIFF
--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -28,11 +28,6 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
         )
         put(
-            PluginErrors.FUNCTION_WITH_UNVERIFIED_CONTRACT,
-            "Function {0} may not satisfy its contract.",
-            CommonRenderers.STRING,
-        )
-        put(
             PluginErrors.INTERNAL_ERROR,
             "Formal verification internal error: {0}",
             CommonRenderers.STRING,

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.warning1
 
 object PluginErrors {
-    val FUNCTION_WITH_UNVERIFIED_CONTRACT by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val VIPER_CONSISTENCY_ERROR by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -73,10 +73,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
             // If the Viper program is not consistent, that's our error; we shouldn't surface it to the user as an unverified contract.
             if (!consistent || !config.shouldVerify(declaration)) return
 
-            val success = verifier.verify(program, onFailure)
-            if (!success) {
-                reporter.reportOn(declaration.source, PluginErrors.FUNCTION_WITH_UNVERIFIED_CONTRACT, declaration.name.asString(), context)
-            }
+            verifier.verify(program, onFailure)
         } catch (e: Exception) {
             val error = errorCollector.formatErrorWithInfos(e.message ?: "No message provided")
             reporter.reportOn(declaration.source, PluginErrors.INTERNAL_ERROR, error, context)

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
@@ -51,19 +51,16 @@ class Verifier {
     /**
      * Verify the program. Returns true on successful verification.
      */
-    fun verify(program: Program, onFailure: (VerificationError) -> Unit): Boolean {
+    fun verify(program: Program, onFailure: (VerificationError) -> Unit) {
         val viperProgram = program.toSilver()
 
         verifier.start()
         val results = verifier.verify(viperProgram, emptySeq<SilverCfg>(), null.toScalaOption<String?>())
 
-        var success = true
         for (result in results) {
             if (result.isFatal) {
                 onFailure(ErrorAdapter.translate(result))
-                success = false
             }
         }
-        return success
     }
 }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -27,8 +27,6 @@ method global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(loca
   ensures true
 
 
-/calls_in_place.kt:(450,472): warning: Function incorrect_at_most_once may not satisfy its contract.
-
 /calls_in_place.kt:(521,550): warning: Viper verification error: Postcondition of global$fun_incorrect_at_most_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$f.special$function_object_call_counter <= old(local$f.special$function_object_call_counter) + 1 might not hold.
 
 /calls_in_place.kt:(661,683): info: Generated Viper text for incorrect_exactly_once:
@@ -50,8 +48,6 @@ method global$fun_incorrect_exactly_once$fun_take$fun_take$T_Int$return$T_Int$re
   goto label$ret$0
   label label$ret$0
 }
-
-/calls_in_place.kt:(661,683): warning: Function incorrect_exactly_once may not satisfy its contract.
 
 /calls_in_place.kt:(732,761): warning: Viper verification error: Postcondition of global$fun_incorrect_exactly_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold.
 
@@ -81,8 +77,6 @@ method global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(loca
     local$f.special$function_object_call_counter
   ensures true
 
-
-/calls_in_place.kt:(866,889): warning: Function incorrect_at_least_once may not satisfy its contract.
 
 /calls_in_place.kt:(938,968): warning: Viper verification error: Postcondition of global$fun_incorrect_at_least_once$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$f.special$function_object_call_counter > old(local$f.special$function_object_call_counter) might not hold.
 
@@ -117,8 +111,6 @@ method global$fun_incorrect_exactly_once_with_catch$fun_take$fun_take$$return$T_
   label label$try_exit$0
   label label$ret$0
 }
-
-/calls_in_place.kt:(1150,1183): warning: Function incorrect_exactly_once_with_catch may not satisfy its contract.
 
 /calls_in_place.kt:(1232,1261): warning: Viper verification error: Postcondition of global$fun_incorrect_exactly_once_with_catch$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold.
 
@@ -155,7 +147,5 @@ method global$fun_incorrect_exactly_once_with_call_in_catch$fun_take$fun_take$$r
   label label$try_exit$0
   label label$ret$0
 }
-
-/calls_in_place.kt:(1478,1519): warning: Function incorrect_exactly_once_with_call_in_catch may not satisfy its contract.
 
 /calls_in_place.kt:(1568,1597): warning: Viper verification error: Postcondition of global$fun_incorrect_exactly_once_with_call_in_catch$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion local$f.special$function_object_call_counter == old(local$f.special$function_object_call_counter) + 1 might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.kt
@@ -15,7 +15,7 @@ fun unknown(f : (Int) -> Int) : Int{
 
 @Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_at_most_once<!>(f : (Int) -> Int) : Int{
+fun <!VIPER_TEXT!>incorrect_at_most_once<!>(f : (Int) -> Int) : Int{
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(f, AT_MOST_ONCE)<!>
     }
@@ -24,7 +24,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_at_most_once<!>(f
 
 @Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_exactly_once<!>(f : (Int) -> Int) : Int{
+fun <!VIPER_TEXT!>incorrect_exactly_once<!>(f : (Int) -> Int) : Int{
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(f, EXACTLY_ONCE)<!>
     }
@@ -33,7 +33,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_exactly_once<!>(f
 
 @Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_at_least_once<!>(f : (Int) -> Int) : Int{
+fun <!VIPER_TEXT!>incorrect_at_least_once<!>(f : (Int) -> Int) : Int{
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(f, AT_LEAST_ONCE)<!>
     }
@@ -43,7 +43,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_at_least_once<!>(
 // Consistency check with current Kotlin contract verification mechanism.
 @Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_exactly_once_with_catch<!>(f : () -> Unit) : Unit {
+fun <!VIPER_TEXT!>incorrect_exactly_once_with_catch<!>(f : () -> Unit) : Unit {
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(f, EXACTLY_ONCE)<!>
     }
@@ -56,7 +56,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_exactly_once_with
 // Consistency check with current Kotlin contract verification mechanism.
 @Suppress("WRONG_INVOCATION_KIND")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrect_exactly_once_with_call_in_catch<!>(f : () -> Unit) : Unit {
+fun <!VIPER_TEXT!>incorrect_exactly_once_with_call_in_catch<!>(f : () -> Unit) : Unit {
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(f, EXACTLY_ONCE)<!>
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
@@ -22,8 +22,6 @@ method global$fun_invalid_calls_in_place$fun_take$fun_take$$return$T_Unit$return
   label label$ret$0
 }
 
-/calls_in_place_leak.kt:(607,629): warning: Function invalid_calls_in_place may not satisfy its contract.
-
 /calls_in_place_leak.kt:(697,706): warning: Viper verification error: The precondition of method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion special$duplicable(local$f) might not hold.
 
 /calls_in_place_leak.kt:(787,807): info: Generated Viper text for function_object_call:
@@ -50,7 +48,5 @@ method global$fun_function_object_call$fun_take$fun_take$fun_take$$return$T_Unit
   goto label$ret$0
   label label$ret$0
 }
-
-/calls_in_place_leak.kt:(787,807): warning: Function function_object_call may not satisfy its contract.
 
 /calls_in_place_leak.kt:(906,910): warning: Viper verification error: Assert might fail. Assertion special$duplicable(local$g) might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt
@@ -14,7 +14,7 @@ fun escape(f : () -> Unit) {
 
 @Suppress("LEAKED_IN_PLACE_LAMBDA")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>invalid_calls_in_place<!>(f : () -> Unit) {
+fun <!VIPER_TEXT!>invalid_calls_in_place<!>(f : () -> Unit) {
     contract {
         callsInPlace(f)
     }
@@ -23,7 +23,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>invalid_calls_in_place<!>(f
 
 @Suppress("LEAKED_IN_PLACE_LAMBDA")
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>function_object_call<!>(f: (() -> Unit) -> Unit, g: () -> Unit) {
+fun <!VIPER_TEXT!>function_object_call<!>(f: (() -> Unit) -> Unit, g: () -> Unit) {
     contract {
         callsInPlace(g)
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.fir.diag.txt
@@ -32,8 +32,6 @@ method global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(
   label label$ret$0
 }
 
-/inlining_captured.kt:(354,365): warning: Function nested_call may not satisfy its contract.
-
 /inlining_captured.kt:(413,442): warning: Viper verification error: Postcondition of global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$g.special$function_object_call_counter == old(local$g.special$function_object_call_counter) + 1 might not hold.
 
 /inlining_captured.kt:(585,596): info: Generated Viper text for double_call:
@@ -69,7 +67,5 @@ method global$fun_double_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(
   goto label$ret$0
   label label$ret$0
 }
-
-/inlining_captured.kt:(585,596): warning: Function double_call may not satisfy its contract.
 
 /inlining_captured.kt:(644,673): warning: Viper verification error: Postcondition of global$fun_double_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int might not hold. Assertion local$g.special$function_object_call_counter <= old(local$g.special$function_object_call_counter) + 1 might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.kt
@@ -10,7 +10,7 @@ inline fun invoke(f: (Int) -> Int): Int {
 
 @OptIn(ExperimentalContracts::class)
 @Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>nested_call<!>(g: (Int) -> Int): Int {
+fun <!VIPER_TEXT!>nested_call<!>(g: (Int) -> Int): Int {
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(g, EXACTLY_ONCE)<!>
     }
@@ -19,7 +19,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>nested_call<!>(g: (Int) -> 
 
 @OptIn(ExperimentalContracts::class)
 @Suppress("WRONG_INVOCATION_KIND", "LEAKED_IN_PLACE_LAMBDA")
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>double_call<!>(g: (Int) -> Int): Int {
+fun <!VIPER_TEXT!>double_call<!>(g: (Int) -> Int): Int {
     contract {
         <!VIPER_VERIFICATION_ERROR!>callsInPlace(g, AT_MOST_ONCE)<!>
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -16,8 +16,6 @@ method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Int)
 
 
-/is_type_contract.kt:(121,142): warning: Function unverifiableTypeCheck may not satisfy its contract.
-
 /is_type_contract.kt:(186,215): warning: Viper verification error: Postcondition of global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Unit()) might not hold.
 
 /is_type_contract.kt:(289,311): info: Generated Viper text for nullableNotNonNullable:
@@ -29,7 +27,5 @@ method global$fun_nullableNotNonNullable$fun_take$NT_Int$return$T_Unit(local$x: 
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
   label label$ret$0
 }
-
-/is_type_contract.kt:(289,311): warning: Function nullableNotNonNullable may not satisfy its contract.
 
 /is_type_contract.kt:(346,374): warning: Viper verification error: Postcondition of global$fun_nullableNotNonNullable$fun_take$NT_Int$return$T_Unit might not hold. Assertion true ==> dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$Int()) might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.kt
@@ -2,7 +2,7 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>unverifiableTypeCheck<!>(x: Int?): Boolean {
+fun <!VIPER_TEXT!>unverifiableTypeCheck<!>(x: Int?): Boolean {
     contract {
         <!VIPER_VERIFICATION_ERROR!>returns() implies (x is Unit)<!>
     }
@@ -10,7 +10,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>unverifiableTypeCheck<!>(x:
 }
 
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>nullableNotNonNullable<!>(x: Int?) {
+fun <!VIPER_TEXT!>nullableNotNonNullable<!>(x: Int?) {
     contract {
         <!VIPER_VERIFICATION_ERROR!>returns() implies (x is Int)<!>
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -36,8 +36,6 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures ret.special$size == 0
 
 
-/list.kt:(91,105): warning: Function empty_list_get may not satisfy its contract.
-
 /list.kt:(162,171): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local0$myList.special$size > 0 might not hold.
 
 /list.kt:(193,204): info: Generated Viper text for unsafe_last:
@@ -72,8 +70,6 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   ensures this.special$size >= 0
   ensures this.special$size == old(this.special$size)
 
-
-/list.kt:(193,204): warning: Function unsafe_last may not satisfy its contract.
 
 /list.kt:(238,251): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion anonymous$0 - 1 >= 0 might not hold.
 
@@ -120,7 +116,5 @@ method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kot
   ensures this.special$size >= 0
   ensures this.special$size == old(this.special$size)
 
-
-/list.kt:(273,280): warning: Function add_get may not satisfy its contract.
 
 /list.kt:(329,333): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int might not hold. Assertion local$l.special$size > 1 might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
@@ -3,18 +3,18 @@
 import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
 
 @AlwaysVerify
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>empty_list_get<!>() {
+fun <!VIPER_TEXT!>empty_list_get<!>() {
     val myList: List<Int> = emptyList()
     val s = <!VIPER_VERIFICATION_ERROR!>myList[0]<!>
 }
 
 @AlwaysVerify
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>unsafe_last<!>(l: List<Int>) : Int {
+fun <!VIPER_TEXT!>unsafe_last<!>(l: List<Int>) : Int {
     return <!VIPER_VERIFICATION_ERROR!>l[l.size - 1]<!>
 }
 
 @AlwaysVerify
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>add_get<!>(l: MutableList<Int>) {
+fun <!VIPER_TEXT!>add_get<!>(l: MutableList<Int>) {
     l.add(1)
     val n = <!VIPER_VERIFICATION_ERROR!>l[1]<!>
 }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_booleans.fir.diag.txt
@@ -8,6 +8,4 @@ method global$fun_incorrectly_returns_false$fun_take$$return$T_Boolean()
   label label$ret$0
 }
 
-/returns_booleans.kt:(121,146): warning: Function incorrectly_returns_false may not satisfy its contract.
-
 /returns_booleans.kt:(183,196): warning: Viper verification error: Postcondition of global$fun_incorrectly_returns_false$fun_take$$return$T_Boolean might not hold. Assertion ret == true might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_booleans.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_booleans.kt
@@ -2,7 +2,7 @@ import kotlin.contracts.contract
 import kotlin.contracts.ExperimentalContracts
 
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>incorrectly_returns_false<!>(): Boolean {
+fun <!VIPER_TEXT!>incorrectly_returns_false<!>(): Boolean {
     contract {
         <!VIPER_VERIFICATION_ERROR!>returns(true)<!>
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
@@ -10,8 +10,6 @@ method global$fun_returns_null_unverifiable$fun_take$NT_Int$return$NT_Int(local$
   label label$ret$0
 }
 
-/returns_null.kt:(121,146): warning: Function returns_null_unverifiable may not satisfy its contract.
-
 /returns_null.kt:(187,210): warning: Viper verification error: Postcondition of global$fun_returns_null_unverifiable$fun_take$NT_Int$return$NT_Int might not hold. Assertion true ==> false might not hold.
 
 /returns_null.kt:(277,302): info: Generated Viper text for non_nullable_returns_null:
@@ -23,7 +21,5 @@ method global$fun_non_nullable_returns_null$fun_take$T_Int$return$T_Int(local$x:
   goto label$ret$0
   label label$ret$0
 }
-
-/returns_null.kt:(277,302): warning: Function non_nullable_returns_null may not satisfy its contract.
 
 /returns_null.kt:(341,354): warning: Viper verification error: Postcondition of global$fun_non_nullable_returns_null$fun_take$T_Int$return$T_Int might not hold. Assertion false might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.kt
@@ -2,7 +2,7 @@ import kotlin.contracts.contract
 import kotlin.contracts.ExperimentalContracts
 
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>returns_null_unverifiable<!>(x: Int?): Int? {
+fun <!VIPER_TEXT!>returns_null_unverifiable<!>(x: Int?): Int? {
     contract {
         <!VIPER_VERIFICATION_ERROR!>returns() implies false<!>
     }
@@ -10,7 +10,7 @@ fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>returns_null_unverifiable<!
 }
 
 @OptIn(ExperimentalContracts::class)
-fun <!FUNCTION_WITH_UNVERIFIED_CONTRACT, VIPER_TEXT!>non_nullable_returns_null<!>(x: Int): Int {
+fun <!VIPER_TEXT!>non_nullable_returns_null<!>(x: Int): Int {
     contract {
         <!VIPER_VERIFICATION_ERROR!>returns(null)<!>
     }


### PR DESCRIPTION
This warning was only emitted in combination with other warnings, and so gave no additional information, and moreover was inaccurate for functions using lists (which need not have a contract).