### PR TITLE
Support negated `is` in contracts.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -182,7 +182,8 @@ class ContractDescriptionConversionVisitor(
         data: ContractDescriptionVisitorContext,
     ): Exp {
         val argVar = isInstancePredicate.arg.embeddedVar()
-        return TypeDomain.isSubtype(TypeOfDomain.typeOf(argVar.toViper()), ctx.embedType(isInstancePredicate.type).runtimeType)
+        val subtypeRel = TypeDomain.isSubtype(TypeOfDomain.typeOf(argVar.toViper()), ctx.embedType(isInstancePredicate.type).runtimeType)
+        return if (isInstancePredicate.isNegated) Not(subtypeRel) else subtypeRel
     }
 
     private fun KtValueParameterReference<ConeKotlinType, ConeDiagnostic>.embeddedVar(): VariableEmbedding =

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/NullableDomain.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/NullableDomain.kt
@@ -54,6 +54,13 @@ import org.jetbrains.kotlin.formver.viper.ast.*
  *         (nx == (null_val(): Nullable[T])) ||
  *         isSubtype((typeOf(nx): Type), newType)
  *   }
+ *
+ *   axiom null_not_any {
+ *      (forall nx: Nullable[T], newType: Type ::
+ *        { isSubtype((typeOf(nx): Type), newType) }
+ *        !is_nullable_type(newType) && nx == (null_val(): Nullable[T]) ==>
+ *          !isSubtype((typeOf(nx): Type), newType))
+ *   }
  * }
  * ```
  */
@@ -134,6 +141,14 @@ object NullableDomain : BuiltinDomain("Nullable") {
                     Exp.EqCmp(nx, nullVal(T)),
                     TypeDomain.isSubtype(TypeOfDomain.typeOf(nx), newType)
                 )
+            }
+        }
+        axiom("null_not_any") {
+            Exp.forall(nxVar, newType) { nx, newType ->
+                val isSubsetExp = simpleTrigger { TypeDomain.isSubtype(TypeOfDomain.typeOf(nx), newType) }
+                assumption { Exp.Not(TypeDomain.isNullableType(newType)) }
+                assumption { Exp.EqCmp(nx, nullVal(T)) }
+                Exp.Not(isSubsetExp)
             }
         }
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
@@ -1,0 +1,30 @@
+/as_type_contract.kt:(150,154): info: Generated Viper text for getX:
+field class_IntHolder$member_x: Int
+
+method global$fun_getX$fun_take$T_Any$return$NT_Int(local$a: dom$Any)
+  returns (ret: dom$Nullable[Int])
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
+  ensures ret != (dom$Nullable$null(): dom$Nullable[Int]) ==>
+    !dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$global$class_IntHolder())
+{
+  var anonymous$0: dom$Nullable[Ref]
+  var anonymous$1: dom$Nullable[Int]
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$Any())
+  if (dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$global$class_IntHolder())) {
+    anonymous$0 := (dom$Casting$cast(local$a, dom$Type$special$Nullable(dom$Type$global$class_IntHolder())): dom$Nullable[Ref])
+    inhale acc((dom$Casting$cast(anonymous$0, dom$Type$global$class_IntHolder()): Ref).class_IntHolder$member_x, wildcard)
+  } else {
+    anonymous$0 := (dom$Nullable$null(): dom$Nullable[Ref])}
+  if (anonymous$0 == (dom$Nullable$null(): dom$Nullable[Ref])) {
+    anonymous$1 := (dom$Nullable$null(): dom$Nullable[Int])
+  } else {
+    var anonymous$2: Int
+    anonymous$2 := (dom$Casting$cast(anonymous$0, dom$Type$global$class_IntHolder()): Ref).class_IntHolder$member_x
+    anonymous$1 := (dom$Casting$cast(anonymous$2, dom$Type$special$Nullable(dom$Type$Int())): dom$Nullable[Int])
+  }
+  ret := anonymous$1
+  goto label$ret$0
+  label label$ret$0
+}
+
+/as_type_contract.kt:(194,236): warning: Viper verification error: Postcondition of global$fun_getX$fun_take$T_Any$return$NT_Int might not hold. Assertion ret != (dom$Nullable$null(): dom$Nullable[Int]) ==> !dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$global$class_IntHolder()) might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.kt
@@ -1,0 +1,12 @@
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+class IntHolder(val x: Int)
+
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>getX<!>(a: Any): Int? {
+    contract {
+        <!VIPER_VERIFICATION_ERROR!>returnsNotNull() implies (a !is IntHolder)<!>
+    }
+    return (a as? IntHolder)?.x
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
@@ -36,6 +36,8 @@ method global$fun_getX$fun_take$T_Any$return$NT_Int(local$a: dom$Any)
   ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$special$Nullable(dom$Type$Int()))
   ensures ret != (dom$Nullable$null(): dom$Nullable[Int]) ==>
     dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$global$class_IntHolder())
+  ensures ret == (dom$Nullable$null(): dom$Nullable[Int]) ==>
+    !dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$global$class_IntHolder())
 {
   var anonymous$0: dom$Nullable[Ref]
   var anonymous$1: dom$Nullable[Int]

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.kt
@@ -26,6 +26,7 @@ class IntHolder(val x: Int)
 fun <!VIPER_TEXT!>getX<!>(a: Any): Int? {
     contract {
         returnsNotNull() implies (a is IntHolder)
+        returns(null) implies (a !is IntHolder)
     }
     return (a as? IntHolder)?.x
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -76,6 +76,14 @@ domain dom$Nullable[T]  {
       nx == (dom$Nullable$null(): dom$Nullable[T]) ||
       dom$Type$isSubtype((dom$TypeOf$typeOf(nx): dom$Type), newType))
   }
+
+  axiom dom$Nullable$null_not_any {
+    (forall nx: dom$Nullable[T], newType: dom$Type ::
+      { dom$Type$isSubtype((dom$TypeOf$typeOf(nx): dom$Type), newType) }
+      !dom$Type$is_nullable_type(newType) &&
+      nx == (dom$Nullable$null(): dom$Nullable[T]) ==>
+      !dom$Type$isSubtype((dom$TypeOf$typeOf(nx): dom$Type), newType))
+  }
 }
 
 domain dom$Type  {

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -34,6 +34,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("as_type_contract.kt")
+        public void testAs_type_contract() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.kt");
+        }
+
+        @Test
         @TestMetadata("binary_search.kt")
         public void testBinary_search() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.kt");


### PR DESCRIPTION
We were previously not checking the `isNegated` flag.