### PR TITLE
Stronger inhale in safe as

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -100,6 +100,9 @@ interface TypeEmbedding {
      * Note that nullability doesn't stack, hence nullable types must return themselves.
      */
     fun getNullable(): TypeEmbedding = NullableTypeEmbedding(this)
+
+    val isNullable: Boolean
+        get() = false
 }
 
 fun <R> TypeEmbedding.flatMapUniqueFields(action: (SimpleKotlinName, FieldEmbedding) -> List<R>): List<R> {
@@ -177,6 +180,8 @@ data class NullableTypeEmbedding(val elementType: TypeEmbedding) : TypeEmbedding
     }
 
     override fun getNullable(): TypeEmbedding = this
+
+    override val isNullable = true
 }
 
 abstract class UnspecifiedFunctionTypeEmbedding : TypeEmbedding {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
@@ -42,8 +42,7 @@ method global$fun_getX$fun_take$T_Any$return$NT_Int(local$a: dom$Any)
   inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$Any())
   if (dom$Type$isSubtype((dom$TypeOf$typeOf(local$a): dom$Type), dom$Type$global$class_IntHolder())) {
     anonymous$0 := (dom$Casting$cast(local$a, dom$Type$special$Nullable(dom$Type$global$class_IntHolder())): dom$Nullable[Ref])
-    inhale anonymous$0 != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-      acc((dom$Casting$cast(anonymous$0, dom$Type$global$class_IntHolder()): Ref).class_IntHolder$member_x, wildcard)
+    inhale acc((dom$Casting$cast(anonymous$0, dom$Type$global$class_IntHolder()): Ref).class_IntHolder$member_x, wildcard)
   } else {
     anonymous$0 := (dom$Nullable$null(): dom$Nullable[Ref])}
   if (anonymous$0 == (dom$Nullable$null(): dom$Nullable[Ref])) {


### PR DESCRIPTION
Since we know that the type we are casting from is non-nullable, we can be sure that if the cast succeeds, the result is non-null.  This allows us to make stronger assumptions about the result in the success case.