### PR TITLE
Restructure how we decide what functions to generate methods for

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
@@ -17,7 +17,7 @@ class InlineNamedFunction(
     val signature: FullNamedFunctionSignature,
     val symbol: FirFunctionSymbol<*>,
     val body: FirBlock,
-) : CallableEmbedding, FullNamedFunctionSignature by signature {
+) : ViperAwareCallableEmbedding, FullNamedFunctionSignature by signature {
     override fun insertCallImpl(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext<ResultTrackingContext>,
@@ -26,4 +26,6 @@ class InlineNamedFunction(
         val paramNames = symbol.valueParameterSymbols.map { it.name }
         return ctx.insertInlineFunctionCall(signature, paramNames, args, body)
     }
+
+    override fun toViperMethod(): Nothing? = null
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
@@ -11,10 +11,12 @@ import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.conversion.withResult
 import org.jetbrains.kotlin.formver.embeddings.ExpEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Method
 
 class NonInlineNamedFunction(
     val signature: FullNamedFunctionSignature,
-) : CallableEmbedding, FullNamedFunctionSignature by signature {
+    val source: KtSourceElement?,
+) : ViperAwareCallableEmbedding, FullNamedFunctionSignature by signature {
     override fun insertCallImpl(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext<ResultTrackingContext>,
@@ -24,4 +26,6 @@ class NonInlineNamedFunction(
             addStatement(toMethodCall(args, resultCtx.resultVar, source.asPosition))
             resultExp
         }
+
+    override fun toViperMethod(): Method = signature.toViperMethod(null, source.asPosition)
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/ViperAwareCallableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/ViperAwareCallableEmbedding.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.callables
+
+import org.jetbrains.kotlin.formver.viper.ast.Method
+
+/**
+ * A callable embedding that is aware of how it will be called in the resulting Viper code.
+ */
+interface ViperAwareCallableEmbedding : CallableEmbedding {
+    fun toViperMethod(): Method?
+}


### PR DESCRIPTION
As it is, we treat certain inline functions as non-inline but don't generate the corresponding methods.

I tried creating a test for this but it requires some access to the standard library that is hard to set up.