### PR TITLE
Update invariants and pre-/postconditions to use `ExpEmbedding`

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Method
 import org.jetbrains.kotlin.formver.viper.ast.Program
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
-import org.jetbrains.kotlin.utils.addToStdlib.ifFalse
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 /**
@@ -50,8 +49,8 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     val program: Program
         get() = Program(
             domains = listOf(UnitDomain, NullableDomain, CastingDomain, TypeOfDomain, TypeDomain(classes.values.toList()), AnyDomain),
-            fields = SpecialFields.all + classes.values.flatMap { it.flatMapUniqueFields { _, field -> listOf(field.toViper()) } }
-                .distinctBy { it.name },
+            fields = SpecialFields.all.map { it.toViper() } +
+                    classes.values.flatMap { it.flatMapUniqueFields { _, field -> listOf(field.toViper()) } }.distinctBy { it.name },
             functions = SpecialFunctions.all + classes.values.flatMap { it.getterFunctions() }.distinctBy { it.name },
             methods = SpecialMethods.all + methods.values.mapNotNull { it.viperMethod }.toList(),
             predicates = classes.values.map { it.predicate }
@@ -274,7 +273,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                 // Unfortunately Silicon for some reason does not allow Assumes. However, it doesn't matter as long as the
                 // provenInvariants don't contain permissions.
                 arg.provenInvariants().forEach { invariant ->
-                    stmtCtx.addStatement(Stmt.Inhale(invariant, arg.source.asPosition))
+                    stmtCtx.addStatement(Stmt.Inhale(invariant.toViper(), arg.source.asPosition))
                 }
             }
             stmtCtx.addDeclaration(methodCtx.returnLabel.toDecl())

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
@@ -5,12 +5,20 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
+import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
+import org.jetbrains.kotlin.formver.embeddings.IntTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.names.SpecialName
-import org.jetbrains.kotlin.formver.viper.ast.BuiltinField
-import org.jetbrains.kotlin.formver.viper.ast.Type
+import org.jetbrains.kotlin.formver.viper.MangledName
+
+class SpecialField(baseName: String, override val type: TypeEmbedding) : FieldEmbedding {
+    override val name: MangledName = SpecialName(baseName)
+    override val accessPolicy: AccessPolicy = AccessPolicy.ALWAYS_WRITEABLE
+    override val includeInShortDump: Boolean = false
+}
 
 object SpecialFields {
-    val FunctionObjectCallCounterField = BuiltinField(SpecialName("function_object_call_counter"), Type.Int)
+    val FunctionObjectCallCounterField = SpecialField("function_object_call_counter", IntTypeEmbedding)
     val all = listOf(
         FunctionObjectCallCounterField,
     )

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -5,49 +5,49 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.formver.embeddings.ListSizeFieldEmbedding
+import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
 import org.jetbrains.kotlin.formver.names.NameMatcher
-import org.jetbrains.kotlin.formver.viper.ast.Exp
-import org.jetbrains.kotlin.formver.viper.ast.Exp.*
 
-fun LocalVar.sameSize(): Exp = EqCmp(fieldAccess(ListSizeFieldEmbedding.toViper()), Old(fieldAccess(ListSizeFieldEmbedding.toViper())))
-fun LocalVar.increasedSize(amount: Int): Exp =
-    EqCmp(fieldAccess(ListSizeFieldEmbedding.toViper()), Add(Old(fieldAccess(ListSizeFieldEmbedding.toViper())), IntLit(amount)))
+fun VariableEmbedding.sameSize(): ExpEmbedding =
+    EqCmp(FieldAccess(this, ListSizeFieldEmbedding), Old(FieldAccess(this, ListSizeFieldEmbedding)))
 
-fun NamedFunctionSignature.stdLibPreConditions(): List<Exp> =
+fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding =
+    EqCmp(FieldAccess(this, ListSizeFieldEmbedding), Add(Old(FieldAccess(this, ListSizeFieldEmbedding)), IntLit(amount)))
+
+fun NamedFunctionSignature.stdLibPreConditions(): List<ExpEmbedding> =
     NameMatcher.match(this.name) {
         ifInCollectionsPkg {
             ifFunctionName("get") {
-                val receiver = receiver!!.toViper()
-                val indexArg = formalArgs[1].toViper()
+                val receiver = receiver!!
+                val indexArg = formalArgs[1]
                 return listOf(
                     GeCmp(indexArg, IntLit(0)),
-                    GtCmp(receiver.fieldAccess(ListSizeFieldEmbedding.toViper()), indexArg),
+                    GtCmp(FieldAccess(receiver, ListSizeFieldEmbedding), indexArg),
                 )
             }
             ifFunctionName("subList") {
-                val receiver = receiver!!.toViper()
-                val fromIndexArg = formalArgs[1].toViper()
-                val toIndexArg = formalArgs[2].toViper()
+                val receiver = receiver!!
+                val fromIndexArg = formalArgs[1]
+                val toIndexArg = formalArgs[2]
                 return listOf(
                     LeCmp(fromIndexArg, toIndexArg),
                     GeCmp(fromIndexArg, IntLit(0)),
-                    LeCmp(toIndexArg, receiver.fieldAccess(ListSizeFieldEmbedding.toViper()))
+                    LeCmp(toIndexArg, FieldAccess(receiver, ListSizeFieldEmbedding))
                 )
             }
         }
         return listOf()
     }
 
-fun NamedFunctionSignature.stdLibPostConditions(): List<Exp> =
+fun NamedFunctionSignature.stdLibPostConditions(): List<ExpEmbedding> =
     NameMatcher.match(this.name) {
-        val retVar = this@stdLibPostConditions.returnVar.toViper()
-        val receiver = receiver?.toViper()
+        val retVar = this@stdLibPostConditions.returnVar
+        val receiver = receiver
         ifInCollectionsPkg {
             ifFunctionName("emptyList") {
                 return listOf(
-                    EqCmp(retVar.fieldAccess(ListSizeFieldEmbedding.toViper()), IntLit(0))
+                    EqCmp(FieldAccess(retVar, ListSizeFieldEmbedding), IntLit(0))
                 )
             }
             ifFunctionName("get") {
@@ -59,16 +59,16 @@ fun NamedFunctionSignature.stdLibPostConditions(): List<Exp> =
             ifFunctionName("isEmpty") {
                 return listOf(
                     receiver!!.sameSize(),
-                    Implies(retVar, EqCmp(receiver.fieldAccess(ListSizeFieldEmbedding.toViper()), IntLit(0))),
-                    Implies(Not(retVar), GtCmp(receiver.fieldAccess(ListSizeFieldEmbedding.toViper()), IntLit(0)))
+                    Implies(retVar, EqCmp(FieldAccess(receiver, ListSizeFieldEmbedding), IntLit(0))),
+                    Implies(Not(retVar), GtCmp(FieldAccess(receiver, ListSizeFieldEmbedding), IntLit(0)))
                 )
             }
             ifFunctionName("subList") {
-                val fromIndexArg = formalArgs[1].toViper()
-                val toIndexArg = formalArgs[2].toViper()
+                val fromIndexArg = formalArgs[1]
+                val toIndexArg = formalArgs[2]
                 return listOf(
                     receiver!!.sameSize(),
-                    EqCmp(retVar.fieldAccess(ListSizeFieldEmbedding.toViper()), Sub(toIndexArg, fromIndexArg))
+                    EqCmp(FieldAccess(retVar, ListSizeFieldEmbedding), Sub(toIndexArg, fromIndexArg))
                 )
             }
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -277,7 +277,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
             data.addStatement(
                 Stmt.While(
                     condCtx.resultExp.toViper(),
-                    invariants = postconditions,
+                    invariants = postconditions.toViper(),
                     bodyBlock,
                     whileLoop.source.asPosition
                 )
@@ -369,7 +369,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
                 // TODO: this may require special handling of access permissions; we should look into a more systematic solution.
                 resultCtx.resultVar.setValue(argument, this, typeOperatorCall.source)
                 for (invariant in resultCtx.resultVar.accessInvariants()) {
-                    addStatement(Stmt.Inhale(invariant))
+                    addStatement(Stmt.Inhale(invariant.toViper()))
                 }
             }
             FirOperation.SAFE_AS -> data.withResult(conversionType.getNullable()) {
@@ -384,7 +384,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
                     }
 
                     for (invariant in invariants) {
-                        addStatement(Stmt.Inhale(invariant))
+                        addStatement(Stmt.Inhale(invariant.toViper()))
                     }
                 }
                 val elseBlock = withNewScopeToBlock {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/TypingDomain.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/TypingDomain.kt
@@ -264,7 +264,7 @@ object TypeOfDomain : BuiltinDomain("TypeOf") {
         TypeDomain.Type
     )
 
-    fun typeOf(x: Exp): Exp = funcApp(typeOfFunc, listOf(x), mapOf(T to x.type))
+    fun typeOf(x: Exp, pos: Position = Position.NoPosition): Exp = funcApp(typeOfFunc, listOf(x), mapOf(T to x.type), pos)
 
     override val functions: List<DomainFunc> = listOf(typeOfFunc)
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
@@ -21,11 +21,11 @@ abstract class BackingFieldAccess(val field: FieldEmbedding) {
     ) {
         val invariant = field.accessInvariantForAccess(receiver.toViper())
         invariant?.let {
-            ctx.addStatement(Stmt.Inhale(it, source.asPosition))
+            ctx.addStatement(Stmt.Inhale(it.toViper(), source.asPosition))
         }
         ctx.action(FieldAccess(receiver, field, source))
         invariant?.let {
-            ctx.addStatement(Stmt.Exhale(it, source.asPosition))
+            ctx.addStatement(Stmt.Exhale(it.toViper(), source.asPosition))
         }
     }
 }
@@ -40,7 +40,7 @@ class BackingFieldGetter(field: FieldEmbedding) : BackingFieldAccess(field), Get
             access(receiver, this, source) {
                 addStatement(Stmt.assign(resultExp.toViper(), it.toViper(), source.asPosition))
                 field.type.provenInvariants(resultExp.toViper()).forEach { inv ->
-                    addStatement(Stmt.Inhale(inv, source.asPosition))
+                    addStatement(Stmt.Inhale(inv.toViper(), source.asPosition))
                 }
             }
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/VariableEmbedding.kt
@@ -38,8 +38,8 @@ class VariableEmbedding(val name: MangledName, override val type: TypeEmbedding,
         ctx.addStatement(Stmt.LocalVarAssign(toViper(), value.withType(type).toViper(), source.asPosition))
     }
 
-    fun pureInvariants(): List<Exp> = type.pureInvariants(toViper())
-    fun provenInvariants(): List<Exp> = type.provenInvariants(toViper())
-    fun accessInvariants(): List<Exp> = type.accessInvariants(toViper())
-    fun dynamicInvariants(): List<Exp> = type.dynamicInvariants(toViper())
+    fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants(toViper())
+    fun provenInvariants(): List<ExpEmbedding> = type.provenInvariants(toViper())
+    fun accessInvariants(): List<ExpEmbedding> = type.accessInvariants(toViper())
+    fun dynamicInvariants(): List<ExpEmbedding> = type.dynamicInvariants(toViper())
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
@@ -5,11 +5,13 @@
 
 package org.jetbrains.kotlin.formver.embeddings.callables
 
+import org.jetbrains.kotlin.formver.embeddings.ExpEmbedding
+import org.jetbrains.kotlin.formver.embeddings.toViper
 import org.jetbrains.kotlin.formver.viper.ast.*
 
 interface FullNamedFunctionSignature : NamedFunctionSignature {
-    val preconditions: List<Exp>
-    val postconditions: List<Exp>
+    val preconditions: List<ExpEmbedding>
+    val postconditions: List<ExpEmbedding>
 }
 
 fun FullNamedFunctionSignature.toViperMethod(
@@ -21,8 +23,8 @@ fun FullNamedFunctionSignature.toViperMethod(
     name,
     formalArgs.map { it.toLocalVarDecl() },
     returnVar.toLocalVarDecl(),
-    preconditions,
-    postconditions,
+    preconditions.toViper(),
+    postconditions.toViper(),
     body,
     position,
     info,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialMethods.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialMethods.kt
@@ -6,26 +6,24 @@
 package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.SpecialFields
-import org.jetbrains.kotlin.formver.embeddings.LegacyUnspecifiedFunctionTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.names.AnonymousName
 import org.jetbrains.kotlin.formver.names.SpecialName
 import org.jetbrains.kotlin.formver.viper.ast.BuiltInMethod
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
-import org.jetbrains.kotlin.formver.viper.ast.Exp.*
 
 object InvokeFunctionObjectMethod : BuiltInMethod(SpecialName("invoke_function_object")) {
     private val thisArg = VariableEmbedding(AnonymousName(0), LegacyUnspecifiedFunctionTypeEmbedding)
     private val calls = EqCmp(
-        Add(Old(thisArg.toFieldAccess(SpecialFields.FunctionObjectCallCounterField)), IntLit(1)),
-        thisArg.toFieldAccess(SpecialFields.FunctionObjectCallCounterField)
+        Add(Old(FieldAccess(thisArg, SpecialFields.FunctionObjectCallCounterField)), IntLit(1)),
+        FieldAccess(thisArg, SpecialFields.FunctionObjectCallCounterField)
     )
 
     override val formalArgs: List<Declaration.LocalVarDecl> = listOf(thisArg.toLocalVarDecl())
     override val formalReturns: List<Declaration.LocalVarDecl> = listOf()
-    override val pres: List<Exp> = thisArg.accessInvariants()
-    override val posts: List<Exp> = thisArg.accessInvariants() + listOf(calls)
+    override val pres: List<Exp> = thisArg.accessInvariants().toViper()
+    override val posts: List<Exp> = (thisArg.accessInvariants() + listOf(calls)).toViper()
 }
 
 object SpecialMethods {

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Field.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Field.kt
@@ -8,24 +8,14 @@ package org.jetbrains.kotlin.formver.viper.ast
 import org.jetbrains.kotlin.formver.viper.IntoSilver
 import org.jetbrains.kotlin.formver.viper.MangledName
 
-open class Field(
+class Field(
     val name: MangledName,
     val type: Type,
+    val includeInShortDump: Boolean,
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
 ) : IntoSilver<viper.silver.ast.Field> {
-    open val includeInShortDump: Boolean = true
     override fun toSilver(): viper.silver.ast.Field =
         viper.silver.ast.Field(name.mangled, type.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
-}
-
-class BuiltinField(
-    name: MangledName,
-    type: Type,
-    pos: Position = Position.NoPosition,
-    info: Info = Info.NoInfo,
-    trafos: Trafos = Trafos.NoTrafos,
-) : Field(name, type, pos, info, trafos) {
-    override val includeInShortDump: Boolean = false
 }


### PR DESCRIPTION
Previously, we directly produced `Exp` in these constructions, but this is inconvenient as the rest of our code gradually becomes increasingly high-level.  This change updates the interface of invariants and pre-/postconditions to use `ExpEmbedding` and thus brings it in line with the rest of our code.  Under the hood, we still occasionally need to generate `Exp` instances and then wrap them, but this is something that can be tackled gradually.

This change is in particular an important step towards moving the linearization step to after the conversion from FIR to `ExpEmbedding`.