### PR TITLE
Add data structures for linearization

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.*
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.callables.*
+import org.jetbrains.kotlin.formver.linearization.SeqnBuilder
 import org.jetbrains.kotlin.formver.names.*
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Method

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.formver.calleeSymbol
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
+import org.jetbrains.kotlin.formver.linearization.SeqnBuildContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Label
 import org.jetbrains.kotlin.formver.viper.ast.Stmt

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConverter.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.formver.embeddings.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.linearization.SeqnBuildContext
+import org.jetbrains.kotlin.formver.linearization.SeqnBuilder
 import org.jetbrains.kotlin.formver.names.BreakLabelName
 import org.jetbrains.kotlin.formver.names.ContinueLabelName
 import org.jetbrains.kotlin.formver.viper.ast.Label

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/AssumptionTracker.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/AssumptionTracker.kt
@@ -8,12 +8,10 @@ package org.jetbrains.kotlin.formver.linearization
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 class AssumptionTracker {
-    val assumptions = mutableListOf<Exp>()
+    private val assumptions = LinkedHashSet<Exp>()
 
     fun addAssumption(assumption: Exp) {
-        if (assumption !in assumptions) {
-            assumptions.add(assumption)
-        }
+        assumptions.add(assumption)
     }
 
     fun clear() {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/AssumptionTracker.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/AssumptionTracker.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+
+class AssumptionTracker {
+    val assumptions = mutableListOf<Exp>()
+
+    fun addAssumption(assumption: Exp) {
+        if (assumption !in assumptions) {
+            assumptions.add(assumption)
+        }
+    }
+
+    fun clear() {
+        assumptions.clear()
+    }
+
+    fun forEachForwards(action: (Exp) -> Unit) = assumptions.forEach(action)
+    fun forEachBackwards(action: (Exp) -> Unit) = assumptions.reversed().forEach(action)
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+interface LinearizationContext : SeqnBuildContext {
+    val source: KtSourceElement
+
+    fun newVar(type: TypeEmbedding): VariableEmbedding
+
+    fun inhaleForThisStatement(assumption: Exp)
+    fun withNewScope(action: LinearizationContext.() -> Unit): Stmt.Seqn
+    fun withPosition(newPosition: KtSourceElement, action: LinearizationContext.() -> Unit)
+}
+
+fun <R> LinearizationContext.withNewVar(type: TypeEmbedding, action: (v: VariableEmbedding) -> R): R = action(newVar(type))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -11,6 +11,13 @@ import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
+/**
+ * Context in which an `ExpEmbedding` can be flattened to an `Exp` and a sequence of `Stmt`s.
+ *
+ * We do not distinguish between expressions and statements on the Kotlin side, but we do on the Viper side.
+ * As such, an `ExpEmbedding` can represent a nested structure that has to be flattened into sequences
+ * of statements. We call this process linearization.
+ */
 interface LinearizationContext : SeqnBuildContext {
     val source: KtSourceElement
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Declaration
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+data class Linearizer(
+    val state: SharedLinearizationState,
+    val seqnBuilder: SeqnBuilder,
+    override val source: KtSourceElement,
+) : LinearizationContext {
+    override fun newVar(type: TypeEmbedding): VariableEmbedding = state.freshVar(type)
+
+    override fun inhaleForThisStatement(assumption: Exp) {
+        state.assumptionTracker.addAssumption(assumption)
+    }
+
+    override fun withNewScope(action: LinearizationContext.() -> Unit): Stmt.Seqn {
+        val newBuilder = SeqnBuilder(source)
+        copy(seqnBuilder = newBuilder).action()
+        return newBuilder.block
+    }
+
+    override fun withPosition(newPosition: KtSourceElement, action: LinearizationContext.() -> Unit) {
+        copy(source = newPosition).action()
+    }
+
+    override fun addStatement(stmt: Stmt) {
+        state.assumptionTracker.forEachForwards { seqnBuilder.addStatement(Stmt.Inhale(it)) }
+        seqnBuilder.addStatement(stmt)
+        state.assumptionTracker.forEachBackwards { seqnBuilder.addStatement(Stmt.Exhale(it)) }
+        state.assumptionTracker.clear()
+    }
+
+    override fun addDeclaration(decl: Declaration) {
+        seqnBuilder.addDeclaration(decl)
+    }
+
+    /**
+     * This is a stopgap solution for now. Eventually, we would like to perform on-scope-exit operations here,
+     * so we will need to make an interface that makes it clearer that the builder cannot be reused after
+     * `block` has been called.
+     */
+    override val block: Stmt.Seqn
+        get() = seqnBuilder.block
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
@@ -6,12 +6,19 @@
 package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
+/**
+ * Standard context for linearization.
+ *
+ * Note that the implementation for `SeqnBuilderContext` is not provided directly by the `seqnBuilder` constructor parameter;
+ * the class may insert extra statements at various points.
+ */
 data class Linearizer(
     val state: SharedLinearizationState,
     val seqnBuilder: SeqnBuilder,
@@ -34,9 +41,9 @@ data class Linearizer(
     }
 
     override fun addStatement(stmt: Stmt) {
-        state.assumptionTracker.forEachForwards { seqnBuilder.addStatement(Stmt.Inhale(it)) }
+        state.assumptionTracker.forEachForwards { seqnBuilder.addStatement(Stmt.Inhale(it, source.asPosition)) }
         seqnBuilder.addStatement(stmt)
-        state.assumptionTracker.forEachBackwards { seqnBuilder.addStatement(Stmt.Exhale(it)) }
+        state.assumptionTracker.forEachBackwards { seqnBuilder.addStatement(Stmt.Exhale(it, source.asPosition)) }
         state.assumptionTracker.clear()
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Declaration
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+class PureLinearizerError(val offendingFunction: String) : IllegalStateException(offendingFunction)
+
+class PureLinearizer(override val source: KtSourceElement) : LinearizationContext {
+    override fun withPosition(newPosition: KtSourceElement, action: LinearizationContext.() -> Unit) {
+        PureLinearizer(newPosition).action()
+    }
+
+    override fun newVar(type: TypeEmbedding): VariableEmbedding {
+        throw PureLinearizerError("newVar")
+    }
+
+    override fun inhaleForThisStatement(assumption: Exp) {
+        throw PureLinearizerError("inhaleForThisStatement")
+    }
+
+    override fun withNewScope(action: LinearizationContext.() -> Unit): Stmt.Seqn {
+        throw PureLinearizerError("withNewScope")
+    }
+
+    override fun addStatement(stmt: Stmt) {
+        throw PureLinearizerError("addStatement")
+    }
+
+    override fun addDeclaration(decl: Declaration) {
+        throw PureLinearizerError("addDeclaration")
+    }
+
+    override val block: Stmt.Seqn
+        get() = throw PureLinearizerError("block")
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
@@ -14,6 +14,13 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 class PureLinearizerError(val offendingFunction: String) : IllegalStateException(offendingFunction)
 
+/**
+ * Linearization context that does not permit generation of statements.
+ *
+ * There are cases in Viper where we expect our result to be an expression by itself, for example when
+ * processing preconditions, postconditions, and invariants. In those cases, generating statements
+ * would be an error.
+ */
 class PureLinearizer(override val source: KtSourceElement) : LinearizationContext {
     override fun withPosition(newPosition: KtSourceElement, action: LinearizationContext.() -> Unit) {
         PureLinearizer(newPosition).action()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SeqnBuildContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SeqnBuildContext.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.conversion
+package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Stmt

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SeqnBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SeqnBuilder.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.conversion
+package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SharedLinearizationState.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SharedLinearizationState.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+import org.jetbrains.kotlin.formver.conversion.FreshEntityProducer
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.VariableEmbedding
+import org.jetbrains.kotlin.formver.names.AnonymousName
+
+class SharedLinearizationState {
+    private val producer = FreshEntityProducer { AnonymousName(it) }
+    val assumptionTracker = AssumptionTracker()
+
+    fun freshVar(type: TypeEmbedding) = VariableEmbedding(producer.getFresh(), type)
+}


### PR DESCRIPTION
These replicate some functionality of `StmtConversionContext` and are necessary for the upcoming move to doing linearization after converting to `ExpEmbedding`.