### PR TITLE
Implement a debug representation for `ExpEmbedding`

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.callables.asData
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
@@ -40,4 +42,7 @@ class LambdaExp(
         val paramNames = function.valueParameters.map { it.name }
         return ctx.insertInlineFunctionCall(signature, paramNames, args, inlineBody, parentCtx, ctx.signature.sourceName)
     }
+
+    override val debugTreeView: TreeView
+        get() = PlaintextLeaf("Lambda")
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
@@ -9,25 +9,39 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.NullableDomain
 import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 data object UnitLit : UnitResultExpEmbedding {
     // No operation: we just want to return unit.
     override fun toViperSideEffects(ctx: LinearizationContext) = Unit
+
+    override val debugTreeView: TreeView
+        get() = PlaintextLeaf("Unit")
 }
 
 data class IntLit(val value: Int) : PureExpEmbedding {
     override val type = IntTypeEmbedding
     override fun toViper(source: KtSourceElement?): Exp = Exp.IntLit(value, source.asPosition)
+
+    override val debugName: String
+        get() = "Int"
 }
 
 data class BooleanLit(val value: Boolean, override val sourceRole: SourceRole? = null) : PureExpEmbedding {
     override val type = BooleanTypeEmbedding
     override fun toViper(source: KtSourceElement?): Exp = Exp.BoolLit(value, source.asPosition, sourceRole.asInfo)
+
+    override val debugName: String
+        get() = "Boolean"
 }
 
 data class NullLit(val elemType: TypeEmbedding) : PureExpEmbedding {
     override val type = NullableTypeEmbedding(elemType)
     override fun toViper(source: KtSourceElement?): Exp = NullableDomain.nullVal(elemType.viperType, source)
+
+    override val debugName: String
+        get() = "Null[${elemType.name.mangled}]"
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Meta.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Meta.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 
 data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceElement) : PassthroughExpEmbedding {
@@ -14,5 +15,9 @@ data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceEl
 
     override fun ignoringMetaNodes(): ExpEmbedding = inner.ignoringMetaNodes()
     override fun ignoringCastsAndMetaNodes(): ExpEmbedding = inner.ignoringCastsAndMetaNodes()
+
+    // We ignore position information in the debug view.
+    override val debugTreeView: TreeView
+        get() = inner.debugTreeView
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -21,17 +21,23 @@ data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : PureEx
     override fun toViper(source: KtSourceElement?): Exp = value
 }
 
-data object ErrorExp : NoResultExpEmbedding {
+data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override val type: TypeEmbedding = NothingTypeEmbedding
     override fun toViperUnusedResult(ctx: LinearizationContext) {
         ctx.addStatement(Stmt.Inhale(Exp.BoolLit(false)))
     }
+
+    override val debugAnonymousSubexpressions: List<ExpEmbedding>
+        get() = listOf()
 }
 
-data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding {
+data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addStatement(Stmt.Assert(exp.toViper(ctx)))
     }
+
+    override val debugAnonymousSubexpressions: List<ExpEmbedding>
+        get() = listOf(exp)
 }
 
 /**
@@ -40,14 +46,20 @@ data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding {
  * This can cause all kinds of issues with statement ordering, so it's more of a solution for porting legacy stuff than something
  * we should be adding more of going forward.
  */
-data class InhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding {
+data class InhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addStatement(Stmt.Inhale(exp.toViper(ctx)))
     }
+
+    override val debugAnonymousSubexpressions: List<ExpEmbedding>
+        get() = listOf(exp)
 }
 
-data class ExhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding {
+data class ExhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addStatement(Stmt.Exhale(exp.toViper(ctx)))
     }
+
+    override val debugAnonymousSubexpressions: List<ExpEmbedding>
+        get() = listOf(exp)
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/Printer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/Printer.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.expression.debug
+
+import kotlin.math.max
+
+/**
+ * Helper class for pretty-printing tree views.
+ *
+ * Provides support for automatic handling of indentation and tracks line length for the user.
+ */
+class Printer(
+    /**
+     * Number of spaces to add per indent step.
+     */
+    private val indentStep: Int = 4,
+    /**
+     * Maximum line length we recommend that clients use.
+     *
+     * This is not enforced, but clients who want to produce pretty output can use this to make decisions on where to break
+     * up their output.
+     */
+    private val desiredMaxLineLength: Int = 120,
+) {
+    // _currentLine is non-null precisely when a line is currently being constructed.
+    private var _currentLine: StringBuilder? = null
+
+    // currentLine starts on a line if one isn't already being constructed.
+    private val currentLine: StringBuilder
+        get() {
+            if (_currentLine == null) {
+                _currentLine = StringBuilder(" ".repeat(indentLevel))
+            }
+            return _currentLine!!
+        }
+    private val lines = mutableListOf<String>()
+    private var indentLevel = 0
+
+    fun print(ast: TreeView) {
+        with(ast) {
+            this@Printer.printImpl()
+        }
+    }
+
+    fun print(text: String) {
+        currentLine.append(text)
+    }
+
+    fun newLine() {
+        lines.add(currentLine.toString())
+        _currentLine = null
+    }
+
+    fun indent() {
+        assert(_currentLine == null) { "Indenting in the middle of a line has unclear semantics; don't do it." }
+        indentLevel += indentStep
+    }
+
+    fun unindent() {
+        assert(_currentLine == null) { "Unindenting in the middle of a line has unclear semantics; don't do it." }
+        assert(indentLevel >= indentStep) { "Cannot unindent below zero." }
+        indentLevel -= indentStep
+    }
+
+    /**
+     * The number of characters remaining until the desired max line length is reached. Equals zero if all space is used up.
+     */
+    val availableSpace: Int
+        get() = max(0, desiredMaxLineLength - currentLine.length)
+
+    fun getResult(): String {
+        // Ensure we got all the partial results.
+        if (_currentLine != null) newLine()
+
+        return lines.joinToString("\n").also { lines.clear() }
+    }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/TreeView.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/TreeView.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.expression.debug
+
+interface TreeView {
+    // Width of the node if we assume it's all laid out on one line.
+    val widthGuess: Int
+
+    fun Printer.printImpl()
+}
+
+fun TreeView.print(): String {
+    val printer = Printer()
+    printer.print(this)
+    return printer.getResult()
+}
+
+class NamedBranchingNode(val name: String, val args: List<TreeView>) : TreeView {
+    constructor(name: String, vararg args: TreeView) : this(name, args.toList())
+
+    // Characters for parentheses
+    private val fixedExtraWidth = 2
+
+    // Characters for comma and space
+    private val perArgumentExtraWidth = 2
+
+    // We overcount by 2 since we assume there's a comma and space after the last character as well; it's probably not
+    // worth fixing at this point.
+    override val widthGuess: Int = name.length + fixedExtraWidth + args.map { it.widthGuess + perArgumentExtraWidth }.sum()
+
+    override fun Printer.printImpl() {
+        val splitOverLines = availableSpace <= widthGuess
+        print(name)
+        print("(")
+        if (splitOverLines) {
+            newLine()
+            indent()
+            for (arg in args) {
+                print(arg)
+                print(",")
+                newLine()
+            }
+            unindent()
+        } else if (args.isNotEmpty()) {
+            for (arg in args.take(args.size - 1)) {
+                print(arg)
+                print(", ")
+            }
+            print(args.last())
+        } // No else; if the args are empty, we don't need to do anything.
+        print(")")
+    }
+}
+
+class PlaintextLeaf(val text: String) : TreeView {
+    override val widthGuess: Int
+        get() = text.length
+
+    override fun Printer.printImpl() {
+        print(text)
+    }
+}
+
+/**
+ * Node with a label that refers to its purpose.
+ *
+ * `LabeledNode` would also be an appropriate name, but we already use the term "label" frequently.
+ */
+class DesignatedNode(val label: String, val node: TreeView) : TreeView {
+    // Characters for equals sign separator.
+    private val fixedExtraWidth = 3
+
+    override val widthGuess: Int = label.length + fixedExtraWidth + node.widthGuess
+
+    override fun Printer.printImpl() {
+        print(label)
+        print(" = ")
+        print(node)
+    }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/Utils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/Utils.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.expression.debug
+
+import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
+import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
+import org.jetbrains.kotlin.formver.viper.ast.Label
+
+val Label.debugTreeView: TreeView
+    get() = PlaintextLeaf(name.mangled)
+val NamedFunctionSignature.nameAsDebugTreeView: TreeView
+    get() = PlaintextLeaf(name.mangled)
+val FieldEmbedding.debugTreeView: TreeView
+    get() = NamedBranchingNode("Field", PlaintextLeaf(name.mangled))
+
+fun TreeView.withDesignation(name: String) = DesignatedNode(name, this)


### PR DESCRIPTION
Sending this over FYI; the first commit is https://github.com/jesyspa/kotlin/pull/163 , so we should resolve that first.