### PR TITLE
Add `error_style` option

### DIFF
--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -79,6 +79,7 @@ dist/kotlinc/bin/kotlinc -language-version 2.0 -Xplugin=dist/kotlinc/lib/formver
 
 The plugin accepts a number of command line options which can be passed via `-P plugin:org.jetbrains.kotlin.formver:OPTION=SETTING`:
 - Option `log_level`: permitted values `only_warnings`, `short_viper_dump`, `full_viper_dump` (default: `only_warnings`).
+- Option `error_style`: permitted values `user_friendly`, `original_viper` and `both` (default: `user_friendly`).
 - Options `conversion_targets_selection` and `verification_targets_selection`: permitted values `no_targets`, `targets_with_contract`, `all_targets` (default: `targets_with_contract`).
 - Option `unsupported_feature_behaviour`: permitted values `throw_exception`, `assume_unreachable` (default: `throw_exception`).
 

--- a/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationCommandLineProcessor.kt
+++ b/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationCommandLineProcessor.kt
@@ -12,10 +12,12 @@ import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.CONVERSION_TARGETS_SELECTION
+import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.ERROR_STYLE
 import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.LOG_LEVEL
 import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.UNSUPPORTED_FEATURE_BEHAVIOUR
 import org.jetbrains.kotlin.formver.FormalVerificationConfigurationKeys.VERIFICATION_TARGETS_SELECTION
 import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.CONVERSION_TARGETS_SELECTION_OPTION_NAME
+import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.ERROR_STYLE_NAME
 import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.LOG_LEVEL_OPTION_NAME
 import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME
 import org.jetbrains.kotlin.formver.FormalVerificationPluginNames.VERIFICATION_TARGETS_SELECTION_OPTION_NAME
@@ -23,6 +25,7 @@ import org.jetbrains.kotlin.util.capitalizeDecapitalize.toUpperCaseAsciiOnly
 
 object FormalVerificationConfigurationKeys {
     val LOG_LEVEL: CompilerConfigurationKey<LogLevel> = CompilerConfigurationKey.create("viper log level")
+    val ERROR_STYLE: CompilerConfigurationKey<ErrorStyle> = CompilerConfigurationKey.create("error style")
     val UNSUPPORTED_FEATURE_BEHAVIOUR: CompilerConfigurationKey<UnsupportedFeatureBehaviour> =
         CompilerConfigurationKey.create("unsupported feature behaviour")
     val CONVERSION_TARGETS_SELECTION: CompilerConfigurationKey<TargetsSelection> =
@@ -35,6 +38,10 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
     companion object {
         val LOG_LEVEL_OPTION = CliOption(
             LOG_LEVEL_OPTION_NAME, "<log_level>", "Viper log level",
+            required = false, allowMultipleOccurrences = false
+        )
+        val ERROR_STYLE_OPTION = CliOption(
+            ERROR_STYLE_NAME, "<error_style>", "Style of error messages",
             required = false, allowMultipleOccurrences = false
         )
         val UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION = CliOption(
@@ -63,6 +70,7 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = FormalVerificationPluginNames.PLUGIN_ID
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
         LOG_LEVEL_OPTION,
+        ERROR_STYLE_OPTION,
         UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION,
         CONVERSION_TARGETS_SELECTION_OPTION,
         VERIFICATION_TARGETS_SELECTION_OPTION
@@ -72,6 +80,8 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
         try {
             when (option) {
                 LOG_LEVEL_OPTION -> configuration.put(LOG_LEVEL, LogLevel.valueOf(value.toUpperCaseAsciiOnly()))
+                ERROR_STYLE_OPTION ->
+                    configuration.put(ERROR_STYLE, ErrorStyle.valueOf(value.toUpperCaseAsciiOnly()))
                 UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION ->
                     configuration.put(UNSUPPORTED_FEATURE_BEHAVIOUR, UnsupportedFeatureBehaviour.valueOf(value.toUpperCaseAsciiOnly()))
                 CONVERSION_TARGETS_SELECTION_OPTION ->

--- a/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationPluginComponentRegistrar.kt
+++ b/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationPluginComponentRegistrar.kt
@@ -19,6 +19,10 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
             FormalVerificationConfigurationKeys.UNSUPPORTED_FEATURE_BEHAVIOUR,
             UnsupportedFeatureBehaviour.defaultBehaviour()
         )
+        val errorStyle = configuration.get(
+            FormalVerificationConfigurationKeys.ERROR_STYLE,
+            ErrorStyle.defaultBehaviour()
+        )
         val conversionSelection = configuration.get(
             FormalVerificationConfigurationKeys.CONVERSION_TARGETS_SELECTION,
             TargetsSelection.defaultBehaviour()
@@ -27,7 +31,7 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
             FormalVerificationConfigurationKeys.VERIFICATION_TARGETS_SELECTION,
             TargetsSelection.defaultBehaviour()
         )
-        val config = PluginConfiguration(logLevel, behaviour, conversionSelection, verificationSelection)
+        val config = PluginConfiguration(logLevel, errorStyle, behaviour, conversionSelection, verificationSelection)
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
     }
 }

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/ErrorStyle.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/ErrorStyle.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver
+
+enum class ErrorStyle {
+    USER_FRIENDLY,
+    ORIGINAL_VIPER,
+    BOTH;
+
+    companion object {
+        @JvmStatic
+        fun defaultBehaviour(): ErrorStyle = USER_FRIENDLY
+    }
+}

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/FormalVerificationPluginNames.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/FormalVerificationPluginNames.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver
 object FormalVerificationPluginNames {
     const val PLUGIN_ID = "org.jetbrains.kotlin.formver"
     const val LOG_LEVEL_OPTION_NAME = "log_level"
+    const val ERROR_STYLE_NAME = "error_style"
     const val UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME = "unsupported_feature_behaviour"
     const val CONVERSION_TARGETS_SELECTION_OPTION_NAME = "conversion_targets_selection"
     const val VERIFICATION_TARGETS_SELECTION_OPTION_NAME = "verification_targets_selection"

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver
 
 class PluginConfiguration(
     val logLevel: LogLevel,
+    val errorStyle: ErrorStyle,
     val behaviour: UnsupportedFeatureBehaviour,
     val conversionSelection: TargetsSelection,
     val verificationSelection: TargetsSelection,

--- a/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -20,12 +20,14 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
             module.files.any { it.name.contains("predicates") } -> LogLevel.SHORT_VIPER_DUMP_WITH_PREDICATES
             else -> LogLevel.SHORT_VIPER_DUMP
         }
+        val errorStyle = ErrorStyle.USER_FRIENDLY
         val verificationSelection =
             if (module.files.any { it.name.contains("always_validate") }) TargetsSelection.ALL_TARGETS
             else if (module.files.any {it.name.contains("no_contracts") }) TargetsSelection.NO_TARGETS
             else TargetsSelection.TARGETS_WITH_CONTRACT
         val config = PluginConfiguration(
             logLevel,
+            errorStyle,
             UnsupportedFeatureBehaviour.THROW_EXCEPTION,
             conversionSelection = TargetsSelection.ALL_TARGETS,
             verificationSelection = verificationSelection


### PR DESCRIPTION
This new option will allow us to customize the style of error messages:
* `user_friendly` will output nice messages for users.
* `original_viper` will output Viper's original error message (mainly used for debug)
* `both` will output the previous two styles together