### PR TITLE
Allow setting `error_style` flag by Gradle's build script

### DIFF
--- a/ReadMe-FormVer.md
+++ b/ReadMe-FormVer.md
@@ -49,7 +49,7 @@ Plugin options can be enabled using the `formver` configuration block:
 
 ```kotlin
 formver {
-    setLogLevel("full_viper_dump")
+    logLevel("full_viper_dump")
 }
 ```
 

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
@@ -5,14 +5,20 @@
 
 package org.jetbrains.kotlin.formver.gradle
 
+
 open class FormVerExtension {
     internal var myLogLevel: String? = null
+    internal var myErrorStyle: String? = null
     internal var myUnsupportedFeatureBehaviour: String? = null
     internal var myConversionTargetsSelection: String? = null
     internal var myVerificationTargetsSelection: String? = null
 
     open fun logLevel(logLevel: String) {
         myLogLevel = logLevel
+    }
+
+    open fun errorStyle(style: String) {
+        myErrorStyle = style
     }
 
     open fun unsupportedFeatureBehaviour(behaviour: String) {

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
@@ -41,7 +41,7 @@ class FormVerGradleSubplugin
             }
 
             formVerExtension.myErrorStyle?.let {
-                options += SubpluginOption(FormalVerificationPluginNames.ERRRO_STYLE_NAME, it)
+                options += SubpluginOption(FormalVerificationPluginNames.ERROR_STYLE_NAME, it)
             }
 
             formVerExtension.myUnsupportedFeatureBehaviour?.let {

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
@@ -40,6 +40,10 @@ class FormVerGradleSubplugin
                 options += SubpluginOption(FormalVerificationPluginNames.LOG_LEVEL_OPTION_NAME, it)
             }
 
+            formVerExtension.myErrorStyle?.let {
+                options += SubpluginOption(FormalVerificationPluginNames.ERRRO_STYLE_NAME, it)
+            }
+
             formVerExtension.myUnsupportedFeatureBehaviour?.let {
                 options += SubpluginOption(FormalVerificationPluginNames.UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME, it)
             }

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
@@ -21,6 +21,7 @@ class FormVerModelBuilder : ToolingModelBuilder {
         return FormVerImpl(
             project.name,
             extension.myLogLevel,
+            extension.myErrorStyle,
             extension.myUnsupportedFeatureBehaviour,
             extension.myConversionTargetsSelection,
             extension.myVerificationTargetsSelection

--- a/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
+++ b/libraries/tools/kotlin-formver/src/common/kotlin/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
@@ -14,6 +14,7 @@ import java.io.Serializable
 data class FormVerImpl(
     override val name: String,
     override val logLevel: String?,
+    override val errorStyle: String?,
     override val unsupportedFeatureBehaviour: String?,
     override val conversionTargetsSelection: String?,
     override val verificationTargetsSelection: String?,

--- a/libraries/tools/kotlin-gradle-plugin-model/src/common/kotlin/org/jetbrains/kotlin/gradle/model/FormVer.kt
+++ b/libraries/tools/kotlin-gradle-plugin-model/src/common/kotlin/org/jetbrains/kotlin/gradle/model/FormVer.kt
@@ -29,6 +29,13 @@ interface FormVer {
     val logLevel: String?
 
     /**
+     * Return the desired style for error messages.
+     *
+     * @return the error style
+     */
+    val errorStyle: String?
+
+    /**
      * Returns the desired behaviour when encountering unsupported Kotlin features.
      *
      * @return the behaviour for unsupported features


### PR DESCRIPTION
Additional:
* Update `ReadMe-FormVer.md` section on setting the plugin's options from Gradle