### PR TITLE
Add `SourceRole` to `ExpEmbedding` interface.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.viper.ast.Info
+
+sealed interface SourceRole {
+    data object ReturnsEffect : SourceRole
+    data object ReturnsTrueEffect : SourceRole
+    data object ReturnsFalseEffect : SourceRole
+    data object ReturnsNullEffect : SourceRole
+    data object ReturnsNotNullEffect : SourceRole
+}
+
+val SourceRole?.asInfo: Info
+    get() = when (this) {
+        null -> Info.NoInfo
+        else -> Info.Wrapped(this)
+    }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.embeddings.BooleanTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
+import org.jetbrains.kotlin.formver.embeddings.asInfo
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
@@ -48,14 +50,18 @@ data class GeCmp(
 data class EqCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
+    override val sourceRole: SourceRole? = null,
 ) : ComparisonExpression {
-    override fun toViper(ctx: LinearizationContext) = Exp.EqCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition)
+    override fun toViper(ctx: LinearizationContext) =
+        Exp.EqCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition, sourceRole.asInfo)
 }
 
 data class NeCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
+    override val sourceRole: SourceRole? = null,
 ) : ComparisonExpression {
-    override fun toViper(ctx: LinearizationContext) = Exp.NeCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition)
+    override fun toViper(ctx: LinearizationContext) =
+        Exp.NeCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition, sourceRole.asInfo)
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -20,6 +20,12 @@ sealed interface ExpEmbedding {
     val type: TypeEmbedding
 
     /**
+     * The original Kotlin source's role for the generated expression embedding.
+     */
+    val sourceRole: SourceRole?
+        get() = null
+
+    /**
      * Convert this `ExpEmbedding` into a Viper `Exp`, using the provided context for auxiliary statements and declarations.
      *
      * The `Exp` returned contains the result of the expression.

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
@@ -8,10 +8,7 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.NullableDomain
-import org.jetbrains.kotlin.formver.embeddings.BooleanTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.IntTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.NullableTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
@@ -26,10 +23,10 @@ data class IntLit(val value: Int) : PureExpEmbedding {
     override fun toViper(source: KtSourceElement?): Exp = Exp.IntLit(value, source.asPosition)
 }
 
-data class BooleanLit(val value: Boolean) : PureExpEmbedding {
+data class BooleanLit(val value: Boolean, override val sourceRole: SourceRole? = null) : PureExpEmbedding {
     override val type = BooleanTypeEmbedding
 
-    override fun toViper(source: KtSourceElement?): Exp = Exp.BoolLit(value, source.asPosition)
+    override fun toViper(source: KtSourceElement?): Exp = Exp.BoolLit(value, source.asPosition, sourceRole.asInfo)
 }
 
 data class NullLit(val elemType: TypeEmbedding) : PureExpEmbedding {

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Info.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Info.kt
@@ -6,10 +6,36 @@
 package org.jetbrains.kotlin.formver.viper.ast
 
 import org.jetbrains.kotlin.formver.viper.IntoSilver
+import scala.collection.JavaConverters
+import scala.collection.immutable.Seq
 import viper.silver.ast.`NoInfo$`
 
 sealed class Info : IntoSilver<viper.silver.ast.Info> {
+    internal class Wrapper(val wrappedValue: Any) : viper.silver.ast.Info {
+        override fun toString(): String = "<wrapped info value>"
+        override fun comment(): Seq<String> = JavaConverters.asScala(emptyList<String>()).toSeq()
+        override fun isCached(): Boolean = false
+    }
+
+    companion object {
+        fun fromSilver(info: viper.silver.ast.Info): Info = when (info) {
+            `NoInfo$`.`MODULE$` -> NoInfo
+            is Wrapper -> Wrapped(info.wrappedValue)
+            else -> TODO("Unreachable")
+        }
+    }
+
     data object NoInfo : Info() {
         override fun toSilver(): viper.silver.ast.Info = `NoInfo$`.`MODULE$`
     }
+
+    class Wrapped(val info: Any) : Info() {
+        override fun toSilver(): viper.silver.ast.Info = Wrapper(info)
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+inline fun <I> Info.unwrapOr(orBlock: () -> I?): I? = when (this) {
+    is Info.Wrapped -> info as I
+    else -> orBlock()
 }


### PR DESCRIPTION
For the moment only `EqCmp`, `NeCmp` and `BoolLit` override the default value with one passed from the constructor. This will become useful later when implementing error reporting.