### PR TITLE
Make type invariants first-class.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -376,7 +376,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext<Re
                     val invariants = if (argument.type.isNullable) {
                         resultCtx.resultVar.accessInvariants()
                     } else {
-                        conversionType.accessInvariants(Cast(resultExp, conversionType).pureToViper())
+                        conversionType.accessInvariants().fillHoles(Cast(resultExp, conversionType))
                     }
 
                     for (invariant in invariants) {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
@@ -23,7 +23,7 @@ abstract class BackingFieldAccess(val field: FieldEmbedding) {
         source: KtSourceElement?,
         action: StmtConversionContext<RTC>.(access: FieldAccess) -> Unit,
     ) {
-        val invariant = field.accessInvariantForAccess(receiver.pureToViper())
+        val invariant = field.accessInvariantForAccess()?.fillHole(receiver)
         invariant?.let {
             ctx.addStatement(Stmt.Inhale(it.pureToViper(), source.asPosition))
         }
@@ -43,7 +43,7 @@ class BackingFieldGetter(field: FieldEmbedding) : BackingFieldAccess(field), Get
         ctx.withResult(field.type) {
             access(receiver, this, source) {
                 addStatement(Stmt.assign(resultExp.pureToViper(), it.pureToViper(), source.asPosition))
-                field.type.provenInvariants(resultExp.pureToViper()).forEach { inv ->
+                field.type.provenInvariants().fillHoles(resultExp).forEach { inv ->
                     addStatement(Stmt.Inhale(inv.pureToViper(), source.asPosition))
                 }
             }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeInvariantEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeInvariantEmbedding.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.embeddings.expression.*
+import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.formver.viper.ast.PermExp
+
+/**
+ * An invariant for a type.
+ *
+ * These are different from invariants in general because they are parametrised by a variable of this type,
+ * i.e. they can be seen as an `ExpEmbedding` with a hole.
+ */
+interface TypeInvariantEmbedding {
+    fun fillHole(exp: ExpEmbedding): ExpEmbedding
+}
+
+fun List<TypeInvariantEmbedding>.fillHoles(exp: ExpEmbedding): List<ExpEmbedding> = map { it.fillHole(exp) }
+
+data object FalseTypeInvariant : TypeInvariantEmbedding {
+    override fun fillHole(exp: ExpEmbedding): ExpEmbedding = BooleanLit(false)
+}
+
+data class SubTypeInvariantEmbedding(val type: TypeEmbedding) : TypeInvariantEmbedding {
+    override fun fillHole(exp: ExpEmbedding): ExpEmbedding = Is(exp, type)
+}
+
+data class IfNonNullInvariant(val invariant: TypeInvariantEmbedding) : TypeInvariantEmbedding {
+    override fun fillHole(exp: ExpEmbedding): ExpEmbedding =
+        Implies(NeCmp(exp, exp.type.getNullable().nullVal), invariant.fillHole(exp.withType(exp.type.getNonNullable())))
+}
+
+data class FieldAccessTypeInvariantEmbedding(val field: FieldEmbedding, val perm: PermExp) : TypeInvariantEmbedding {
+    override fun fillHole(exp: ExpEmbedding): ExpEmbedding = FieldAccessPermissions(exp, field, perm)
+}
+
+// Note that at present, the predicate name and class name are the same.
+// We may want to mangle it better down the line.
+data class PredicateAccessTypeInvariantEmbedding(val predicateName: MangledName) : TypeInvariantEmbedding {
+    override fun fillHole(exp: ExpEmbedding): ExpEmbedding = PredicateAccessPermissions(predicateName, listOf(exp))
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.formver.conversion.ResultTrackingContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.PropertyAccessEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.fillHoles
 import org.jetbrains.kotlin.formver.linearization.pureToViper
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.*
@@ -46,8 +47,8 @@ class VariableEmbedding(val name: MangledName, override val type: TypeEmbedding)
         ctx.addStatement(Stmt.LocalVarAssign(toLocalVarUse(), value.withType(type).pureToViper(), source.asPosition))
     }
 
-    fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants(toLocalVarUse())
-    fun provenInvariants(): List<ExpEmbedding> = type.provenInvariants(toLocalVarUse())
-    fun accessInvariants(): List<ExpEmbedding> = type.accessInvariants(toLocalVarUse())
-    fun dynamicInvariants(): List<ExpEmbedding> = type.dynamicInvariants(toLocalVarUse())
+    fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants().fillHoles(this)
+    fun provenInvariants(): List<ExpEmbedding> = type.provenInvariants().fillHoles(this)
+    fun accessInvariants(): List<ExpEmbedding> = type.accessInvariants().fillHoles(this)
+    fun dynamicInvariants(): List<ExpEmbedding> = type.dynamicInvariants().fillHoles(this)
 }


### PR DESCRIPTION
Instead of constructing the expressions directly, build type invariants using dedicated types for it and then fill in the holes at the use-site.