### PR TITLE
Fix `VIPER_CONSISTENCY_ERROR` positioning.

### DIFF
--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.warning1
 
 object PluginErrors {
-    val VIPER_CONSISTENCY_ERROR by warning1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
+    val VIPER_CONSISTENCY_ERROR by warning1<PsiElement, String>()
     val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val INTERNAL_ERROR by error1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)


### PR DESCRIPTION
This error may be raised with a position other than the declaration.