### PR TITLE
Add new `SourceRole`s for `callsInPlace` effects

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -130,30 +130,36 @@ class ContractDescriptionConversionVisitor(
     ): ExpEmbedding {
         val param = callsEffect.valueParameterReference.accept(this, data)
         val callsFieldAccess = FieldAccess(param, SpecialFields.FunctionObjectCallCounterField)
+        val sourceRole = SourceRole.CallsInPlaceEffect(callsEffect.kind)
         return when (callsEffect.kind) {
             // NOTE: case not supported for contracts
             EventOccurrencesRange.ZERO -> EqCmp(
                 callsFieldAccess,
                 Old(callsFieldAccess),
+                sourceRole
             )
             EventOccurrencesRange.AT_MOST_ONCE -> LeCmp(
                 callsFieldAccess,
                 Add(Old(callsFieldAccess), IntLit(1)),
+                sourceRole
             )
             EventOccurrencesRange.EXACTLY_ONCE -> EqCmp(
                 callsFieldAccess,
                 Add(Old(callsFieldAccess), IntLit(1)),
+                sourceRole
             )
             EventOccurrencesRange.AT_LEAST_ONCE -> GtCmp(
                 callsFieldAccess,
                 Old(callsFieldAccess),
+                sourceRole
             )
             // NOTE: case not supported for contracts
             EventOccurrencesRange.MORE_THAN_ONCE -> GtCmp(
                 callsFieldAccess,
                 Add(Old(callsFieldAccess), IntLit(1)),
+                sourceRole
             )
-            EventOccurrencesRange.UNKNOWN -> BooleanLit(true)
+            EventOccurrencesRange.UNKNOWN -> BooleanLit(true, sourceRole)
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.embeddings
 
+import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
 import org.jetbrains.kotlin.formver.viper.ast.Info
 
 sealed interface SourceRole {
@@ -13,6 +14,7 @@ sealed interface SourceRole {
     data object ReturnsFalseEffect : SourceRole
     data object ReturnsNullEffect : SourceRole
     data object ReturnsNotNullEffect : SourceRole
+    data class CallsInPlaceEffect(val kind: EventOccurrencesRange = EventOccurrencesRange.UNKNOWN) : SourceRole
 }
 
 val SourceRole?.asInfo: Info

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
@@ -27,15 +27,19 @@ data class LtCmp(
 data class LeCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
+    override val sourceRole: SourceRole? = null,
 ) : ComparisonExpression {
-    override fun toViper(ctx: LinearizationContext) = Exp.LeCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition)
+    override fun toViper(ctx: LinearizationContext) =
+        Exp.LeCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition, sourceRole.asInfo)
 }
 
 data class GtCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
+    override val sourceRole: SourceRole? = null,
 ) : ComparisonExpression {
-    override fun toViper(ctx: LinearizationContext) = Exp.GtCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition)
+    override fun toViper(ctx: LinearizationContext) =
+        Exp.GtCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition, sourceRole.asInfo)
 }
 
 data class GeCmp(


### PR DESCRIPTION
This PR adds new source roles for `callsInPlace` effect. I have defined two new roles to be interpreted later during the error reporting phase.

1. `SourceRole.CallsInPlaceEffect` indicates that the Viper's AST node is the result of verifying calls in place. The role has only field (`EventOccurrencesRange`) that will be used to generate user-friendly warnings
2. `SourceRole.ParamFunctionLeakageCheck` indicates that the generated Viper's AST node is used to check if a function parameter may leak from a `callsInPlace` contract. The role is always embedded in the calls of `duplicable` function (see `DuplicableCall`).