### PR TITLE
Refactor the code with more Kotlin idioms

### DIFF
--- a/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationCommandLineProcessor.kt
+++ b/plugins/formal-verification/formver.cli/src/org/jetbrains/kotlin/formver/FormalVerificationCommandLineProcessor.kt
@@ -91,6 +91,6 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
                 else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
             }
         } catch (e: IllegalArgumentException) {
-            throw CliOptionProcessingException("Value $value is not a valid argument for option ${option.optionName}.")
+            throw CliOptionProcessingException("Value $value is not a valid argument for option ${option.optionName}.", e)
         }
 }

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/PluginConfiguration.kt
@@ -13,8 +13,8 @@ class PluginConfiguration(
     val verificationSelection: TargetsSelection,
 ) {
     init {
-        if (conversionSelection < verificationSelection) {
-            throw IllegalArgumentException("Conversion options may not be stricter than verification options; converting $conversionSelection but verifying $verificationSelection.")
+        require(conversionSelection >= verificationSelection) {
+            "Conversion options may not be stricter than verification options; converting $conversionSelection but verifying $verificationSelection."
         }
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -122,7 +122,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     }
 
     override fun embedType(type: ConeKotlinType): TypeEmbedding = when {
-        type is ConeErrorType -> throw IllegalArgumentException("Encountered an erroneous type: $type")
+        type is ConeErrorType -> error("Encountered an erroneous type: $type")
         type is ConeTypeParameterType -> NullableTypeEmbedding(AnyTypeEmbedding)
         type.isUnit -> UnitTypeEmbedding
         type.isInt -> IntTypeEmbedding
@@ -159,7 +159,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     } else {
         // Ensure that the class has been processed.
         embedType(symbol.dispatchReceiverType!!)
-        properties[symbol.callableId.embedMemberPropertyName()] ?: throw IllegalStateException("Unknown property ${symbol.callableId}")
+        properties[symbol.callableId.embedMemberPropertyName()] ?: error("Unknown property ${symbol.callableId}")
     }
 
     override fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -125,8 +125,8 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         equalityOperatorCall: FirEqualityOperatorCall,
         data: StmtConversionContext,
     ): ExpEmbedding {
-        if (equalityOperatorCall.arguments.size != 2) {
-            throw IllegalArgumentException("Invalid equality comparison $equalityOperatorCall, can only compare 2 elements.")
+        require(equalityOperatorCall.arguments.size == 2) {
+            "Invalid equality comparison $equalityOperatorCall, can only compare 2 elements."
         }
         val left = data.convert(equalityOperatorCall.arguments[0])
         val right = data.convert(equalityOperatorCall.arguments[1])
@@ -173,13 +173,11 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         comparisonExpression: FirComparisonExpression,
         data: StmtConversionContext,
     ): ExpEmbedding {
-        val dispatchReceiver = comparisonExpression.compareToCall.dispatchReceiver
-        val arg = comparisonExpression.compareToCall.argumentList.arguments.firstOrNull()
-        if (dispatchReceiver == null) {
-            throw IllegalArgumentException("found compareTo call with null receiver")
+        val dispatchReceiver = checkNotNull(comparisonExpression.compareToCall.dispatchReceiver) {
+            "found 'compareTo' call with null receiver"
         }
-        if (arg == null) {
-            throw IllegalArgumentException("found compareTo call with no argument at position 0")
+        val arg = checkNotNull(comparisonExpression.compareToCall.argumentList.arguments.firstOrNull()) {
+            "found `compareTo` call with no argument at position 0"
         }
         val left = data.convert(dispatchReceiver)
         val right = data.convert(arg)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PropertyAccessEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PropertyAccessEmbedding.kt
@@ -20,7 +20,7 @@ fun ExpEmbedding.asPropertyAccess() = when (this) {
             this@asPropertyAccess
 
         override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
-            throw IllegalStateException("Property does not have a settable value")
+            error("Property does not have a settable value")
         }
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -235,25 +235,25 @@ data class FunctionTypeEmbedding(val signature: CallableSignatureData) : Unspeci
 data class ClassTypeEmbedding(val className: ScopedKotlinName) : TypeEmbedding {
     private var _superTypes: List<TypeEmbedding>? = null
     val superTypes: List<TypeEmbedding>
-        get() = _superTypes ?: throw IllegalStateException("Super types of $className have not been initialised yet.")
+        get() = _superTypes ?: error("Super types of $className have not been initialised yet.")
 
     private val classSuperTypes: List<ClassTypeEmbedding>
         get() = superTypes.filterIsInstance<ClassTypeEmbedding>()
 
     fun initSuperTypes(newSuperTypes: List<TypeEmbedding>) {
-        if (_superTypes != null) throw IllegalStateException("Super types of $className are already initialised.")
+        check(_superTypes == null) { "Super types of $className are already initialised." }
         _superTypes = newSuperTypes
     }
 
     private var _fields: Map<SimpleKotlinName, FieldEmbedding>? = null
     private var _predicate: Predicate? = null
     val fields: Map<SimpleKotlinName, FieldEmbedding>
-        get() = _fields ?: throw IllegalStateException("Fields of $className have not been initialised yet.")
+        get() = _fields ?: error("Fields of $className have not been initialised yet.")
     val predicate: Predicate
-        get() = _predicate ?: throw IllegalStateException("Predicate of $className has not been initialised yet.")
+        get() = _predicate ?: error("Predicate of $className has not been initialised yet.")
 
     fun initFields(newFields: Map<SimpleKotlinName, FieldEmbedding>) {
-        if (_fields != null) throw IllegalStateException("Fields of $className are already initialised.")
+        check(_fields == null) { "Fields of $className are already initialised." }
         _fields = newFields
         _predicate = initPredicate()
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -132,7 +132,7 @@ object KotlinRunSpecialFunction : SpecialKotlinFunction {
     ): ExpEmbedding {
         val lambda = when (val arg = args[0].ignoringCastsAndMetaNodes()) {
             is LambdaExp -> arg
-            else -> throw IllegalStateException("kotlin.run must be called with a lambda argument at the moment")
+            else -> error("kotlin.run must be called with a lambda argument at the moment")
         }
 
         return lambda.insertCallImpl(listOf(), ctx)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
@@ -42,7 +42,7 @@ fun CallableId.embedFunctionName(type: TypeEmbedding): ScopedKotlinName =
 fun CallableId.embedPropertyName(scope: Int): ScopedKotlinName = when {
     isLocal -> ScopedKotlinName(LocalScope(scope), SimpleKotlinName(callableName))
     className != null -> embedMemberPropertyName()
-    else -> throw IllegalStateException("Name is neither local nor bound to a class; we do not know how to handle this.")
+    else -> error("Name is neither local nor bound to a class; we do not know how to handle this.")
 }
 
 fun FirValueParameterSymbol.embedName(): ScopedKotlinName = ScopedKotlinName(ParameterScope, SimpleKotlinName(name))
@@ -50,12 +50,12 @@ fun FirPropertyAccessorSymbol.embedName(ctx: ProgramConversionContext): ScopedKo
     true -> when {
         isGetter -> propertySymbol.callableId.embedExtensionGetterName(ctx.embedType(this))
         isSetter -> propertySymbol.callableId.embedExtensionSetterName(ctx.embedType(this))
-        else -> throw IllegalStateException("An extension property must be a setter or a getter!")
+        else -> error("An extension property must be a setter or a getter!")
     }
     false -> when {
         isGetter -> propertySymbol.callableId.embedGetterName()
         isSetter -> propertySymbol.callableId.embedSetterName()
-        else -> throw IllegalStateException("A property accessor must be a setter or a getter!")
+        else -> error("A property accessor must be a setter or a getter!")
     }
 }
 


### PR DESCRIPTION
These changes modify some statements that could have been written into a more idiomatic way. Those issues have been spot using `detekt`. Here is a small guideline:

1. `throw IllegalStateException`: we use the function `check` with a lazy message.
2. `throw IllegalArgumentException`: we use the function `require` with a lazy message.
3. throwing an `IllegalStateException` as return value: we use the function `error`.
4. Naming a lambda parameter as `it` is a *bad practice*.
5. Creating a new value possible null: we use the function `checkNotNull` that returns a non-nullable value or throw with an input message (check `StmtConversionVisitor::visitComparisonExpression`).
6. Avoid swallowed exceptions. When an exception is thrown and in the catch block we are throwing a new exception, we must pass the old one as a cause (this allows us to track down what went wrong in a deeper level).