### PR TITLE
Add error warning messages for lambdas that may leak from the `callsInPlace` effect.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
-import org.jetbrains.kotlin.formver.viper.ast.Info
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.viper.ast.Position
 
 val FirElement.calleeSymbol: FirBasedSymbol<*>
@@ -32,8 +32,5 @@ val KtSourceElement?.asPosition: Position
         null -> Position.NoPosition
         else -> Position.Wrapped(this)
     }
-val FirBasedSymbol<*>?.asInfo: Info
-    get() = when (this) {
-        null -> Info.NoInfo
-        else -> Info.Wrapped(this)
-    }
+val FirBasedSymbol<*>.asSourceRole: SourceRole
+    get() = SourceRole.FirSymbolHolder(this)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.formver.viper.ast.Info
 import org.jetbrains.kotlin.formver.viper.ast.Position
 
 val FirElement.calleeSymbol: FirBasedSymbol<*>
@@ -30,4 +31,9 @@ val KtSourceElement?.asPosition: Position
     get() = when (this) {
         null -> Position.NoPosition
         else -> Position.Wrapped(this)
+    }
+val FirBasedSymbol<*>?.asInfo: Info
+    get() = when (this) {
+        null -> Info.NoInfo
+        else -> Info.Wrapped(this)
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -8,6 +8,9 @@ package org.jetbrains.kotlin.formver.embeddings
 import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.formver.viper.ast.Info
+import org.jetbrains.kotlin.formver.viper.ast.unwrap
+import org.jetbrains.kotlin.formver.viper.errors.ErrorReason
+import org.jetbrains.kotlin.formver.viper.errors.extractInfoFromFunctionArgument
 
 sealed interface SourceRole {
     data object ReturnsEffect : SourceRole
@@ -16,11 +19,14 @@ sealed interface SourceRole {
     data object ReturnsNullEffect : SourceRole
     data object ReturnsNotNullEffect : SourceRole
     data class CallsInPlaceEffect(val paramSymbol: FirBasedSymbol<*>, val kind: EventOccurrencesRange) : SourceRole
+    data class FirSymbolHolder(val firSymbol: FirBasedSymbol<*>) : SourceRole
     data object ParamFunctionLeakageCheck : SourceRole {
         /**
-         * The index field is used to fetch the missing function parameter symbol during error reporting.
+         * Retrieves the leaking function parameter symbol from an error reason.
+         * This method is specifically used for identifying the function parameter that violates the `callsInPlace` contract.
          */
-        const val INDEX: Int = 0
+        fun ErrorReason.fetchLeakingFunction(): FirBasedSymbol<*> =
+            extractInfoFromFunctionArgument(0).unwrap<FirSymbolHolder>().firSymbol
     }
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -16,6 +16,12 @@ sealed interface SourceRole {
     data object ReturnsNullEffect : SourceRole
     data object ReturnsNotNullEffect : SourceRole
     data class CallsInPlaceEffect(val paramSymbol: FirBasedSymbol<*>, val kind: EventOccurrencesRange) : SourceRole
+    data object ParamFunctionLeakageCheck : SourceRole {
+        /**
+         * The index field is used to fetch the missing function parameter symbol during error reporting.
+         */
+        const val INDEX: Int = 0
+    }
 }
 
 val SourceRole?.asInfo: Info

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Invariant.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Invariant.kt
@@ -7,7 +7,9 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.embeddings.BooleanTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.asInfo
 import org.jetbrains.kotlin.formver.embeddings.callables.DuplicableFunction
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -19,6 +21,7 @@ data class Old(override val inner: ExpEmbedding) : UnaryDirectResultExpEmbedding
 
 data class DuplicableCall(override val inner: ExpEmbedding) : UnaryDirectResultExpEmbedding {
     override val type: TypeEmbedding = BooleanTypeEmbedding
-    override fun toViper(ctx: LinearizationContext): Exp = DuplicableFunction.toFuncApp(listOf(inner.toViper(ctx)), ctx.source.asPosition)
+    override fun toViper(ctx: LinearizationContext): Exp =
+        DuplicableFunction.toFuncApp(listOf(inner.toViper(ctx)), ctx.source.asPosition, SourceRole.ParamFunctionLeakageCheck.asInfo)
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.formver.asInfo
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.PropertyAccessEmbedding
@@ -66,7 +67,9 @@ class AnonymousVariableEmbedding(n: Int, override val type: TypeEmbedding) : Var
  * Embedding of a variable that comes from some FIR element.
  */
 class FirVariableEmbedding(override val name: MangledName, override val type: TypeEmbedding, val symbol: FirBasedSymbol<*>) :
-    VariableEmbedding
+    VariableEmbedding {
+    override fun toViper(source: KtSourceElement?): Exp.LocalVar = Exp.LocalVar(name, type.viperType, source.asPosition, symbol.asInfo)
+}
 
 /**
  * Variable embedding generated at linearization phase.

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -7,15 +7,13 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
-import org.jetbrains.kotlin.formver.asInfo
 import org.jetbrains.kotlin.formver.asPosition
+import org.jetbrains.kotlin.formver.asSourceRole
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.embeddings.PropertyAccessEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.NamedBranchingNode
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
-import org.jetbrains.kotlin.formver.embeddings.fillHoles
 import org.jetbrains.kotlin.formver.names.AnonymousName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.*
@@ -36,7 +34,7 @@ sealed interface VariableEmbedding : PureExpEmbedding, PropertyAccessEmbedding {
         trafos: Trafos = Trafos.NoTrafos,
     ): Exp.LocalVar = Exp.LocalVar(name, type.viperType, pos, info, trafos)
 
-    override fun toViper(source: KtSourceElement?): Exp.LocalVar = Exp.LocalVar(name, type.viperType, source.asPosition)
+    override fun toViper(source: KtSourceElement?): Exp.LocalVar = Exp.LocalVar(name, type.viperType, source.asPosition, sourceRole.asInfo)
 
     override fun getValue(ctx: StmtConversionContext): ExpEmbedding = this
     override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding = Assign(this, value)
@@ -68,7 +66,8 @@ class AnonymousVariableEmbedding(n: Int, override val type: TypeEmbedding) : Var
  */
 class FirVariableEmbedding(override val name: MangledName, override val type: TypeEmbedding, val symbol: FirBasedSymbol<*>) :
     VariableEmbedding {
-    override fun toViper(source: KtSourceElement?): Exp.LocalVar = Exp.LocalVar(name, type.viperType, source.asPosition, symbol.asInfo)
+    override val sourceRole: SourceRole
+        get() = symbol.asSourceRole
 }
 
 /**

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -44,5 +44,10 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             FirDiagnosticRenderers.SYMBOL,
             CommonRenderers.STRING
         )
+        put(
+            PluginErrors.LAMBDA_MAY_LEAK,
+            "Function ''{0}'' may leak from its in-place contract.",
+            FirDiagnosticRenderers.SYMBOL,
+        )
     }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -17,6 +17,7 @@ object PluginErrors {
     val MINOR_INTERNAL_ERROR by error1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val UNEXPECTED_RETURNED_VALUE by warning1<PsiElement, String>()
     val INVALID_INVOCATION_TYPE by warning2<PsiElement, FirBasedSymbol<*>, String>()
+    val LAMBDA_MAY_LEAK by warning1<PsiElement, FirBasedSymbol<*>>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(FormalVerificationPluginErrorMessages)

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/VerifierErrorInterpreter.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/VerifierErrorInterpreter.kt
@@ -39,6 +39,12 @@ class VerifierErrorInterpreter {
                 reportOn(source, PluginErrors.UNEXPECTED_RETURNED_VALUE, "null", context)
             is SourceRole.CallsInPlaceEffect ->
                 reportOn(source, PluginErrors.INVALID_INVOCATION_TYPE, role.paramSymbol, role.kind.asUserFriendlyMessage, context)
+            is SourceRole.ParamFunctionLeakageCheck -> {
+                val paramSymbol = error.extractInfoFromFunctionArgument(role.INDEX).unwrapOr<FirBasedSymbol<*>> {
+                    error("The function symbol is missing.")
+                }
+                reportOn(source, PluginErrors.LAMBDA_MAY_LEAK, paramSymbol!!, context)
+            }
             else -> reportVerificationErrorOriginalViper(source, error, context)
         }
     }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/VerifierErrorInterpreter.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/VerifierErrorInterpreter.kt
@@ -39,11 +39,8 @@ class VerifierErrorInterpreter {
                 reportOn(source, PluginErrors.UNEXPECTED_RETURNED_VALUE, "null", context)
             is SourceRole.CallsInPlaceEffect ->
                 reportOn(source, PluginErrors.INVALID_INVOCATION_TYPE, role.paramSymbol, role.kind.asUserFriendlyMessage, context)
-            is SourceRole.ParamFunctionLeakageCheck -> {
-                val paramSymbol = error.extractInfoFromFunctionArgument(role.INDEX).unwrapOr<FirBasedSymbol<*>> {
-                    error("The function symbol is missing.")
-                }
-                reportOn(source, PluginErrors.LAMBDA_MAY_LEAK, paramSymbol!!, context)
+            is SourceRole.ParamFunctionLeakageCheck -> with(role) {
+                reportOn(source, PluginErrors.LAMBDA_MAY_LEAK, error.reason.fetchLeakingFunction(), context)
             }
             else -> reportVerificationErrorOriginalViper(source, error, context)
         }

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.formver.viper
 
 import org.jetbrains.kotlin.formver.viper.ast.Program
 import org.jetbrains.kotlin.formver.viper.errors.ConsistencyError
-import org.jetbrains.kotlin.formver.viper.errors.ErrorAdapter
 import org.jetbrains.kotlin.formver.viper.errors.GenericConsistencyError
 import org.jetbrains.kotlin.formver.viper.errors.VerificationError
 import viper.silicon.Config
@@ -59,7 +58,7 @@ class Verifier {
 
         for (result in results) {
             if (result.isFatal) {
-                onFailure(ErrorAdapter.translate(result))
+                onFailure(VerificationError.fromSilver(result))
             }
         }
     }

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Info.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Info.kt
@@ -40,5 +40,13 @@ inline fun <I> Info.unwrapOr(orBlock: () -> I?): I? = when (this) {
     else -> orBlock()
 }
 
+inline fun <reified I> Info.unwrap(): I = when (this) {
+    is Info.Wrapped -> {
+        check(info is I) { "The wrapped info is not of type ${I::class}." }
+        info
+    }
+    else -> error("The metadata does not contain an information of type ${I::class}.")
+}
+
 val viper.silver.ast.Node.info: viper.silver.ast.Info
     get() = prettyMetadata._2()

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.fir.diag.txt
@@ -1,11 +1,11 @@
 /calls_in_place_leak.kt:(607,629): info: Generated Viper text for invalid_calls_in_place:
-method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
+method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$h: Ref)
   returns (ret: dom$Unit)
-  requires acc(local$f.special$function_object_call_counter, write)
-  requires special$duplicable(local$f)
-  ensures acc(local$f.special$function_object_call_counter, write)
-  ensures old(local$f.special$function_object_call_counter) <=
-    local$f.special$function_object_call_counter
+  requires acc(local$h.special$function_object_call_counter, write)
+  requires special$duplicable(local$h)
+  ensures acc(local$h.special$function_object_call_counter, write)
+  ensures old(local$h.special$function_object_call_counter) <=
+    local$h.special$function_object_call_counter
 
 
 method global$fun_invalid_calls_in_place$fun_take$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref)
@@ -22,7 +22,7 @@ method global$fun_invalid_calls_in_place$fun_take$fun_take$$return$T_Unit$return
   label label$ret$0
 }
 
-/calls_in_place_leak.kt:(697,706): warning: Viper verification error: The precondition of method global$fun_escape$fun_take$fun_take$$return$T_Unit$return$T_Unit might not hold. Assertion special$duplicable(local$f) might not hold.
+/calls_in_place_leak.kt:(697,706): warning: Function 'f: () -> Unit' may leak from its in-place contract.
 
 /calls_in_place_leak.kt:(787,807): info: Generated Viper text for function_object_call:
 method global$fun_function_object_call$fun_take$fun_take$fun_take$$return$T_Unit$return$T_Unit$fun_take$$return$T_Unit$return$T_Unit(local$f: Ref,
@@ -49,4 +49,4 @@ method global$fun_function_object_call$fun_take$fun_take$fun_take$$return$T_Unit
   label label$ret$0
 }
 
-/calls_in_place_leak.kt:(906,910): warning: Viper verification error: Assert might fail. Assertion special$duplicable(local$g) might not hold.
+/calls_in_place_leak.kt:(906,910): warning: Function 'g: () -> Unit' may leak from its in-place contract.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place_leak.kt
@@ -7,9 +7,9 @@ import kotlin.contracts.contract
 // This will be fixed in the next pull-request.
 
 @NeverConvert
-fun escape(f : () -> Unit) {
+fun escape(h : () -> Unit) {
     // No contract means that we assume this function may leak the function object passed to it.
-    f()
+    h()
 }
 
 @Suppress("LEAKED_IN_PLACE_LAMBDA")
@@ -18,7 +18,7 @@ fun <!VIPER_TEXT!>invalid_calls_in_place<!>(f : () -> Unit) {
     contract {
         callsInPlace(f)
     }
-    <!VIPER_VERIFICATION_ERROR!>escape(f)<!>
+    <!LAMBDA_MAY_LEAK!>escape(f)<!>
 }
 
 @Suppress("LEAKED_IN_PLACE_LAMBDA")
@@ -27,5 +27,5 @@ fun <!VIPER_TEXT!>function_object_call<!>(f: (() -> Unit) -> Unit, g: () -> Unit
     contract {
         callsInPlace(g)
     }
-    return <!VIPER_VERIFICATION_ERROR!>f(g)<!>
+    return <!LAMBDA_MAY_LEAK!>f(g)<!>
 }


### PR DESCRIPTION
The commit introduces a new `SourceRole` called `ParamFunctionLeakageCheck` that is embedded as info metadata in `special$duplicable` function calls. When a `PreconditionInCallFalse` or `AssertFailed` error is raised by Viper, and it contains the new defined role, then we are dealing with a possible lambda leakage. In addition, to output the parameter is leaking, now the `FirVariableEmbedding`, when converted into Viper's code, it embeds the symbol as info metadata. Therefore, during error reporting, we are now able to output a user-friendly warning message.

> Note: in the next PR I will refactor the code of `VerifierErrorInterpreter` since the cyclomatic complexity of `reportVerificationErrorUserFriendly` is growing.