### PR TITLE
Add dump diagnostic for `ExpEmbedding`s

### DIFF
--- a/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
+++ b/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
@@ -8,3 +8,4 @@ package org.jetbrains.kotlin.formver.plugin
 annotation class NeverConvert
 annotation class NeverVerify
 annotation class AlwaysVerify
+annotation class DumpExpEmbeddings

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -42,6 +42,14 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     private val classes: MutableMap<MangledName, ClassTypeEmbedding> = mutableMapOf()
     private val properties: MutableMap<MangledName, PropertyEmbedding> = mutableMapOf()
 
+    // Cast is valid since we check that values are not null. We specify the type for `filterValues` explicitly to ensure there's no
+    // loss of type information earlier.
+    @Suppress("UNCHECKED_CAST")
+    val debugExpEmbeddings: Map<MangledName, ExpEmbedding>
+        get() = methods
+            .mapValues { (it.value as? UserFunctionEmbedding)?.body?.debugExpEmbedding }
+            .filterValues { value: ExpEmbedding? -> value != null } as Map<MangledName, ExpEmbedding>
+
     override val whileIndexProducer = indexProducer()
     override val catchLabelNameProducer = simpleFreshEntityProducer { CatchLabelName(it) }
     override val tryExitLabelNameProducer = simpleFreshEntityProducer { TryExitLabelName(it) }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -19,6 +19,12 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
         )
         put(
+            PluginErrors.EXP_EMBEDDING,
+            "Generated ExpEmbedding for {0}:\n{1}",
+            CommonRenderers.STRING,
+            CommonRenderers.STRING,
+        )
+        put(
             PluginErrors.VIPER_VERIFICATION_ERROR,
             "Viper verification error: {0}",
             CommonRenderers.STRING,

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 object PluginErrors {
     val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
+    val EXP_EMBEDDING by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val INTERNAL_ERROR by error1<PsiElement, String>()
     val MINOR_INTERNAL_ERROR by error1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val UNEXPECTED_RETURNED_VALUE by warning1<PsiElement, String>()

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.fir.declarations.FirContractDescriptionOwner
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.formver.conversion.ProgramConverter
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.print
 import org.jetbrains.kotlin.formver.reporting.VerifierErrorInterpreter
 import org.jetbrains.kotlin.formver.viper.Verifier
 import org.jetbrains.kotlin.formver.viper.ast.Program
@@ -49,6 +50,18 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
 
             getProgramForLogging(program)?.let {
                 reporter.reportOn(declaration.source, PluginErrors.VIPER_TEXT, declaration.name.asString(), it.toDebugOutput(), context)
+            }
+
+            if (shouldDumpExpEmbeddings(declaration)) {
+                for ((name, embedding) in programConversionContext.debugExpEmbeddings) {
+                    reporter.reportOn(
+                        declaration.source,
+                        PluginErrors.EXP_EMBEDDING,
+                        name.mangled,
+                        embedding.debugTreeView.print(),
+                        context
+                    )
+                }
             }
 
             val verifier = Verifier()
@@ -87,6 +100,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
     private val neverConvertId: ClassId = getAnnotationId("NeverConvert")
     private val neverVerifyId: ClassId = getAnnotationId("NeverVerify")
     private val alwaysVerifyId: ClassId = getAnnotationId("AlwaysVerify")
+    private val dumpExpEmbeddingsId: ClassId = getAnnotationId("DumpExpEmbeddings")
 
     private fun PluginConfiguration.shouldConvert(declaration: FirSimpleFunction): Boolean = when {
         declaration.hasAnnotation(neverConvertId, session) -> false
@@ -99,4 +113,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
         declaration.hasAnnotation(alwaysVerifyId, session) -> true
         else -> verificationSelection.applicable(declaration)
     }
+
+    private fun shouldDumpExpEmbeddings(declaration: FirSimpleFunction): Boolean =
+        declaration.hasAnnotation(dumpExpEmbeddingsId, session)
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -1,4 +1,4 @@
-/full_viper_dump.kt:(54,55): info: Generated Viper text for f:
+/full_viper_dump.kt:(134,135): info: Generated Viper text for f:
 domain dom$Any  {
 
 
@@ -325,3 +325,16 @@ method special$invoke_function_object(anonymous$0: Ref)
   ensures old(anonymous$0.special$function_object_call_counter) + 1 ==
     anonymous$0.special$function_object_call_counter
 
+
+/full_viper_dump.kt:(134,135): info: Generated ExpEmbedding for global$fun_f$fun_take$$return$T_Unit:
+Function(
+    name = global$fun_f$fun_take$$return$T_Unit,
+    {
+        Declare(
+            Var(local0$foo),
+            T_class_global$class_Foo,
+            MethodCall(callee = class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo, Int(0)),
+        );
+    },
+    return = label$ret$0,
+)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.kt
@@ -1,6 +1,8 @@
+import org.jetbrains.kotlin.formver.plugin.DumpExpEmbeddings
 // Check class generation.
 class Foo(val x: Int)
 
-fun <!VIPER_TEXT!>f<!>() {
+@DumpExpEmbeddings
+fun <!EXP_EMBEDDING, VIPER_TEXT!>f<!>() {
     val foo = Foo(0)
 }


### PR DESCRIPTION
Annotate a function with `@DumpExpEmbeddings` to dump the `ExpEmbedding` generated for it.

This is intended only as a debug tool.