### PR TITLE
Add warning message for possible index-out-of-bound errors

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -24,8 +24,16 @@ fun NamedFunctionSignature.stdLibPreConditions(): List<ExpEmbedding> =
                 val receiver = receiver!!
                 val indexArg = formalArgs[1]
                 return listOf(
-                    GeCmp(indexArg, IntLit(0), SourceRole.ListElementAccessCheck),
-                    GtCmp(FieldAccess(receiver, ListSizeFieldEmbedding), indexArg, SourceRole.ListElementAccessCheck),
+                    GeCmp(
+                        indexArg,
+                        IntLit(0),
+                        SourceRole.ListElementAccessCheck(SourceRole.ListElementAccessCheck.AccessCheckType.LESS_THAN_ZERO)
+                    ),
+                    GtCmp(
+                        FieldAccess(receiver, ListSizeFieldEmbedding),
+                        indexArg,
+                        SourceRole.ListElementAccessCheck(SourceRole.ListElementAccessCheck.AccessCheckType.GREATER_THAN_LIST_SIZE)
+                    ),
                 )
             }
             ifFunctionName("subList") {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.formver.embeddings.ListSizeFieldEmbedding
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.names.NameMatcher
@@ -23,8 +24,8 @@ fun NamedFunctionSignature.stdLibPreConditions(): List<ExpEmbedding> =
                 val receiver = receiver!!
                 val indexArg = formalArgs[1]
                 return listOf(
-                    GeCmp(indexArg, IntLit(0)),
-                    GtCmp(FieldAccess(receiver, ListSizeFieldEmbedding), indexArg),
+                    GeCmp(indexArg, IntLit(0), SourceRole.ListElementAccessCheck),
+                    GtCmp(FieldAccess(receiver, ListSizeFieldEmbedding), indexArg, SourceRole.ListElementAccessCheck),
                 )
             }
             ifFunctionName("subList") {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.viper.ast.Info
 
 sealed interface SourceRole {
+    data object ListElementAccessCheck : SourceRole
     data object ParamFunctionLeakageCheck : SourceRole
     data class CallsInPlaceEffect(val paramSymbol: FirBasedSymbol<*>, val kind: EventOccurrencesRange) : SourceRole
     data class ConditionalEffect(val effect: ReturnsEffect, val condition: Condition) : SourceRole

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -11,8 +11,15 @@ import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.viper.ast.Info
 
 sealed interface SourceRole {
-    data object ListElementAccessCheck : SourceRole
     data object ParamFunctionLeakageCheck : SourceRole
+
+    data class ListElementAccessCheck(val accessType: AccessCheckType) : SourceRole {
+        enum class AccessCheckType {
+            LESS_THAN_ZERO,
+            GREATER_THAN_LIST_SIZE
+        }
+    }
+
     data class CallsInPlaceEffect(val paramSymbol: FirBasedSymbol<*>, val kind: EventOccurrencesRange) : SourceRole
     data class ConditionalEffect(val effect: ReturnsEffect, val condition: Condition) : SourceRole
     data class FirSymbolHolder(val firSymbol: FirBasedSymbol<*>) : SourceRole, Condition

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
@@ -45,8 +45,10 @@ data class GtCmp(
 data class GeCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
+    override val sourceRole: SourceRole? = null,
 ) : ComparisonExpression {
-    override fun toViper(ctx: LinearizationContext) = Exp.GeCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition)
+    override fun toViper(ctx: LinearizationContext) =
+        Exp.GeCmp(left.toViper(ctx), right.toViper(ctx), ctx.source.asPosition, sourceRole.asInfo)
 }
 
 data class EqCmp(

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -61,5 +61,10 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
             CommonRenderers.STRING
         )
+        put(
+            PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
+            "Index potentially out of bound for list ''{0}''.",
+            FirDiagnosticRenderers.DECLARATION_NAME
+        )
     }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -63,8 +63,9 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
         )
         put(
             PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
-            "Index potentially out of bound for list ''{0}''.",
-            FirDiagnosticRenderers.DECLARATION_NAME
+            "Invalid index for {0}, the index may be {1}.",
+            CommonRenderers.STRING,
+            CommonRenderers.STRING
         )
     }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -20,6 +20,7 @@ object PluginErrors {
     val INVALID_INVOCATION_TYPE by warning2<PsiElement, FirBasedSymbol<*>, String>()
     val LAMBDA_MAY_LEAK by warning1<PsiElement, FirBasedSymbol<*>>()
     val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
+    val POSSIBLE_INDEX_OUT_OF_BOUND by warning1<PsiElement, FirBasedSymbol<*>>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(FormalVerificationPluginErrorMessages)

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -20,7 +20,7 @@ object PluginErrors {
     val INVALID_INVOCATION_TYPE by warning2<PsiElement, FirBasedSymbol<*>, String>()
     val LAMBDA_MAY_LEAK by warning1<PsiElement, FirBasedSymbol<*>>()
     val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
-    val POSSIBLE_INDEX_OUT_OF_BOUND by warning1<PsiElement, FirBasedSymbol<*>>()
+    val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(FormalVerificationPluginErrorMessages)

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
@@ -10,10 +10,12 @@ import org.jetbrains.kotlin.contracts.description.EventOccurrencesRange
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers
 import org.jetbrains.kotlin.formver.PluginErrors
 import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.viper.ast.info
 import org.jetbrains.kotlin.formver.viper.ast.unwrap
+import org.jetbrains.kotlin.formver.viper.ast.unwrapOr
 import org.jetbrains.kotlin.formver.viper.errors.VerificationError
 
 sealed interface FormattedError {
@@ -80,11 +82,30 @@ class DefaultError(private val error: VerificationError) : FormattedError {
     }
 }
 
-class IndexOutOfBoundError(private val error: VerificationError) : FormattedError {
+class IndexOutOfBoundError(private val error: VerificationError, private val sourceRole: SourceRole.ListElementAccessCheck) :
+    FormattedError {
+
+    private val SourceRole.ListElementAccessCheck.AccessCheckType.asUserFriendlyMessage: String
+        get() = when (this) {
+            SourceRole.ListElementAccessCheck.AccessCheckType.LESS_THAN_ZERO -> "less than zero"
+            SourceRole.ListElementAccessCheck.AccessCheckType.GREATER_THAN_LIST_SIZE -> "greater than the list's size"
+        }
+
     override fun report(reporter: DiagnosticReporter, source: KtSourceElement?, context: CheckerContext) {
+        /**
+         * When we are dealing with inlined expressions returning a list, we do not have access to any list symbol.
+         * Therefore, we do not report any name since the compiler would highlight the sub-expression causing the problem.
+         */
         val targetListInfo = error.locationNode.asCallable().arg(0).info
-        val targetList = targetListInfo.unwrap<SourceRole.FirSymbolHolder>().firSymbol
-        reporter.reportOn(source, PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND, targetList, context)
+        val targetList = targetListInfo.unwrapOr<SourceRole.FirSymbolHolder> { null }
+        val listMsg = when (targetList) {
+            null -> "the following list sub-expression"
+            else -> {
+                val listName = FirDiagnosticRenderers.DECLARATION_NAME.render(targetList.firSymbol)
+                "list '${listName}'"
+            }
+        }
+        reporter.reportOn(source, PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND, listMsg, sourceRole.accessType.asUserFriendlyMessage, context)
     }
 }
 
@@ -94,7 +115,7 @@ fun VerificationError.formatUserFriendly(): FormattedError? =
         is SourceRole.CallsInPlaceEffect -> CallsInPlaceError(sourceRole)
         is SourceRole.ConditionalEffect -> ConditionalEffectError(sourceRole)
         is SourceRole.ParamFunctionLeakageCheck -> LeakingLambdaError(this)
-        is SourceRole.ListElementAccessCheck -> IndexOutOfBoundError(this)
+        is SourceRole.ListElementAccessCheck -> IndexOutOfBoundError(this, sourceRole)
         else -> null
     }
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
@@ -80,6 +80,13 @@ class DefaultError(private val error: VerificationError) : FormattedError {
     }
 }
 
+class IndexOutOfBoundError(private val error: VerificationError) : FormattedError {
+    override fun report(reporter: DiagnosticReporter, source: KtSourceElement?, context: CheckerContext) {
+        val targetList: FirBasedSymbol<*> = error.fetchOutOfBoundsIndexList()
+        reporter.reportOn(source, PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND, targetList, context)
+    }
+}
+
 fun VerificationError.formatUserFriendly(): FormattedError? =
     when (val sourceRole = lookupSourceRole()) {
         is SourceRole.ReturnsEffect -> ReturnsEffectError(sourceRole)

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
@@ -90,7 +90,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   ensures ret.special$size == local$toIndex - local$fromIndex
 
 
-/binary_search.kt:(305,313): warning: Index potentially out of bound for list 'arr'.
+/binary_search.kt:(305,313): warning: Invalid index for list 'arr', the index may be greater than the list's size.
 
 /binary_search.kt:(511,531): info: Generated Viper text for mid_decreased_by_one:
 field special$size: Int
@@ -184,7 +184,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   ensures ret.special$size == local$toIndex - local$fromIndex
 
 
-/binary_search.kt:(726,734): warning: Index potentially out of bound for list 'arr'.
+/binary_search.kt:(726,734): warning: Invalid index for list 'arr', the index may be less than zero.
 
 /binary_search.kt:(932,964): info: Generated Viper text for mid_decreased_by_one_in_rec_call:
 field special$size: Int
@@ -331,4 +331,4 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   ensures this.special$size == old(this.special$size)
 
 
-/binary_search.kt:(1608,1616): warning: Index potentially out of bound for list 'arr'.
+/binary_search.kt:(1608,1616): warning: Invalid index for list 'arr', the index may be less than zero.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
@@ -90,7 +90,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   ensures ret.special$size == local$toIndex - local$fromIndex
 
 
-/binary_search.kt:(305,313): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local$arr.special$size > local0$mid might not hold.
+/binary_search.kt:(305,313): warning: Index potentially out of bound for list 'arr'.
 
 /binary_search.kt:(511,531): info: Generated Viper text for mid_decreased_by_one:
 field special$size: Int
@@ -184,7 +184,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   ensures ret.special$size == local$toIndex - local$fromIndex
 
 
-/binary_search.kt:(726,734): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local0$mid >= 0 might not hold.
+/binary_search.kt:(726,734): warning: Index potentially out of bound for list 'arr'.
 
 /binary_search.kt:(932,964): info: Generated Viper text for mid_decreased_by_one_in_rec_call:
 field special$size: Int
@@ -331,4 +331,4 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   ensures this.special$size == old(this.special$size)
 
 
-/binary_search.kt:(1608,1616): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local0$mid >= 0 might not hold.
+/binary_search.kt:(1608,1616): warning: Index potentially out of bound for list 'arr'.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.kt
@@ -8,7 +8,7 @@ fun <!VIPER_TEXT!>mid_increased_by_one<!>(arr: List<Int>, target: Int): Boolean 
     val mid = arr.size / 2 + 1 // if arr.size == 1, mid is out of bounds
     return when {
         arr.isEmpty() -> false
-        <!VIPER_VERIFICATION_ERROR!>arr[mid]<!> == target -> true
+        <!POSSIBLE_INDEX_OUT_OF_BOUND!>arr[mid]<!> == target -> true
         arr[mid] < target -> mid_increased_by_one(arr.subList(mid + 1, size), target)
         else -> mid_increased_by_one(arr.subList(0, mid), target)
     }
@@ -20,7 +20,7 @@ fun <!VIPER_TEXT!>mid_decreased_by_one<!>(arr: List<Int>, target: Int): Boolean 
     val mid = arr.size / 2 - 1 // if arr.size == 1, mid is out of bounds
     return when {
         arr.isEmpty() -> false
-        <!VIPER_VERIFICATION_ERROR!>arr[mid]<!> == target -> true
+        <!POSSIBLE_INDEX_OUT_OF_BOUND!>arr[mid]<!> == target -> true
         arr[mid] < target -> mid_decreased_by_one(arr.subList(mid + 1, size), target)
         else -> mid_decreased_by_one(arr.subList(0, mid), target)
     }
@@ -48,7 +48,7 @@ fun <!VIPER_TEXT!>unsafe_binary_search<!>(arr: List<Int>, target: Int, left: Int
     val mid = left + (right - left) / 2
 
     return when {
-        <!VIPER_VERIFICATION_ERROR!>arr[mid]<!> == target -> true
+        <!POSSIBLE_INDEX_OUT_OF_BOUND!>arr[mid]<!> == target -> true
         arr[mid] < target -> unsafe_binary_search(arr, target, mid + 1, right)
         else -> unsafe_binary_search(arr, target, left, mid - 1)
     }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -32,7 +32,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures ret.special$size == 0
 
 
-/list.kt:(162,171): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local0$myList.special$size > 0 might not hold.
+/list.kt:(162,171): warning: Index potentially out of bound for list 'myList'.
 
 /list.kt:(193,204): info: Generated Viper text for unsafe_last:
 field special$size: Int
@@ -63,7 +63,7 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   ensures this.special$size == old(this.special$size)
 
 
-/list.kt:(238,251): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int might not hold. Assertion local$l.special$size - 1 >= 0 might not hold.
+/list.kt:(238,251): warning: Index potentially out of bound for list 'l'.
 
 /list.kt:(273,280): info: Generated Viper text for add_get:
 field special$size: Int
@@ -107,4 +107,4 @@ method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kot
   ensures this.special$size == old(this.special$size)
 
 
-/list.kt:(329,333): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$T_Int$return$T_Int might not hold. Assertion local$l.special$size > 1 might not hold.
+/list.kt:(329,333): warning: Index potentially out of bound for list 'l'.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -1,4 +1,40 @@
-/list.kt:(91,105): info: Generated Viper text for empty_list_get:
+/list.kt:(91,110): info: Generated Viper text for empty_list_expr_get:
+field special$size: Int
+
+method global$fun_empty_list_expr_get$fun_take$$return$T_Unit()
+  returns (ret$0: dom$Unit)
+{
+  var local0$s: Int
+  var anonymous$0: Ref
+  anonymous$0 := pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
+  local0$s := pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(anonymous$0,
+    0)
+  label label$ret$0
+}
+
+method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$return$T_Int(this: Ref,
+  local$index: Int)
+  returns (ret: Int)
+  requires acc(this.special$size, write)
+  requires this.special$size >= 0
+  requires local$index >= 0
+  requires this.special$size > local$index
+  ensures acc(this.special$size, write)
+  ensures this.special$size >= 0
+  ensures this.special$size == old(this.special$size)
+
+
+method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
+  ensures acc(ret.special$size, write)
+  ensures ret.special$size >= 0
+  ensures ret.special$size == 0
+
+
+/list.kt:(127,146): warning: Invalid index for the following list sub-expression, the index may be greater than the list's size.
+
+/list.kt:(168,182): info: Generated Viper text for empty_list_get:
 field special$size: Int
 
 method global$fun_empty_list_get$fun_take$$return$T_Unit()
@@ -32,9 +68,9 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures ret.special$size == 0
 
 
-/list.kt:(162,171): warning: Index potentially out of bound for list 'myList'.
+/list.kt:(239,248): warning: Invalid index for list 'myList', the index may be greater than the list's size.
 
-/list.kt:(193,204): info: Generated Viper text for unsafe_last:
+/list.kt:(270,281): info: Generated Viper text for unsafe_last:
 field special$size: Int
 
 method global$fun_unsafe_last$fun_take$T_class_pkg$kotlin$collections$global$class_List$return$T_Int(local$l: Ref)
@@ -63,9 +99,9 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   ensures this.special$size == old(this.special$size)
 
 
-/list.kt:(238,251): warning: Index potentially out of bound for list 'l'.
+/list.kt:(315,328): warning: Invalid index for list 'l', the index may be less than zero.
 
-/list.kt:(273,280): info: Generated Viper text for add_get:
+/list.kt:(350,357): info: Generated Viper text for add_get:
 field special$size: Int
 
 method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$return$T_Unit(local$l: Ref)
@@ -107,4 +143,4 @@ method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kot
   ensures this.special$size == old(this.special$size)
 
 
-/list.kt:(329,333): warning: Index potentially out of bound for list 'l'.
+/list.kt:(406,410): warning: Invalid index for list 'l', the index may be greater than the list's size.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
@@ -5,16 +5,16 @@ import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
 @AlwaysVerify
 fun <!VIPER_TEXT!>empty_list_get<!>() {
     val myList: List<Int> = emptyList()
-    val s = <!VIPER_VERIFICATION_ERROR!>myList[0]<!>
+    val s = <!POSSIBLE_INDEX_OUT_OF_BOUND!>myList[0]<!>
 }
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>unsafe_last<!>(l: List<Int>) : Int {
-    return <!VIPER_VERIFICATION_ERROR!>l[l.size - 1]<!>
+    return <!POSSIBLE_INDEX_OUT_OF_BOUND!>l[l.size - 1]<!>
 }
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>add_get<!>(l: MutableList<Int>) {
     l.add(1)
-    val n = <!VIPER_VERIFICATION_ERROR!>l[1]<!>
+    val n = <!POSSIBLE_INDEX_OUT_OF_BOUND!>l[1]<!>
 }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
@@ -3,6 +3,11 @@
 import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
 
 @AlwaysVerify
+fun <!VIPER_TEXT!>empty_list_expr_get<!>() {
+    val s = <!POSSIBLE_INDEX_OUT_OF_BOUND!>emptyList<Int>()[0]<!>
+}
+
+@AlwaysVerify
 fun <!VIPER_TEXT!>empty_list_get<!>() {
     val myList: List<Int> = emptyList()
     val s = <!POSSIBLE_INDEX_OUT_OF_BOUND!>myList[0]<!>


### PR DESCRIPTION
This PR adds a new warning message for possible out-of-bound list element access.

Some notes:
* Viper raises a pre-condition error on the method representing the list access function. So, a new source role called `ListElementAccessCheck` is embedded in the precondition that may fail (specifically on in-ranges checks: `index >= 0` and `index < list.size`).
* Add a new extension function on Viper's AST node: `extraInfoFromCallableArgument`. This function extracts information metadata from a "callable" node (function application and method call). It wasn't possible to reference the argument list in the function since Viper does not implement or define any "Callable" interface, that's why an inline function returning a sequence of expression is used.