### PR TITLE
Unify logic for extracting information during error reporting

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.viper.ast.Info
 import org.jetbrains.kotlin.formver.viper.ast.unwrap
-import org.jetbrains.kotlin.formver.viper.errors.VerificationError
+import org.jetbrains.kotlin.formver.viper.errors.ErrorReason
 import org.jetbrains.kotlin.formver.viper.errors.extractInfoFromFunctionArgument
 
 sealed interface SourceRole {
@@ -19,10 +19,8 @@ sealed interface SourceRole {
          * Retrieves the leaking function parameter symbol from an error reason.
          * This method is specifically used for identifying the function parameter that violates the `callsInPlace` contract.
          */
-        fun VerificationError.fetchLeakingFunction(): FirBasedSymbol<*> {
-            // The leaking function can be found on the reason's offending node as first argument.
-            return extractInfoFromFunctionArgument(argIndex = 0, isFromReason = true).unwrap<FirSymbolHolder>().firSymbol
-        }
+        fun ErrorReason.fetchLeakingFunction(): FirBasedSymbol<*> =
+            extractInfoFromFunctionArgument(0).unwrap<FirSymbolHolder>().firSymbol
     }
 
     data class CallsInPlaceEffect(val paramSymbol: FirBasedSymbol<*>, val kind: EventOccurrencesRange) : SourceRole

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/SourceRoleConditionPrettyPrinter.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/SourceRoleConditionPrettyPrinter.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.fir.types.renderReadable
 import org.jetbrains.kotlin.formver.embeddings.SourceRole
 
 object SourceRoleConditionPrettyPrinter {
-
     private fun FirBasedSymbol<*>.showFirSymbol(): String =
         FirDiagnosticRenderers.DECLARATION_NAME.render(this)
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/VerifierErrorInterpreter.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/VerifierErrorInterpreter.kt
@@ -13,45 +13,22 @@ import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.formver.ErrorStyle
 import org.jetbrains.kotlin.formver.PluginErrors
-import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.viper.errors.ConsistencyError
 import org.jetbrains.kotlin.formver.viper.errors.VerificationError
 import org.jetbrains.kotlin.formver.viper.errors.VerifierError
-import org.jetbrains.kotlin.formver.viper.errors.getInfoOrNull
 
-private fun fetchVerificationErrorReporter(error: VerificationError): ErrorReporter =
-    when (val sourceRole = error.getInfoOrNull<SourceRole>()) {
-        is SourceRole.ReturnsEffect -> ReturnsEffectReporter(sourceRole)
-        is SourceRole.CallsInPlaceEffect -> CallsInPlaceReporter(sourceRole)
-        is SourceRole.ParamFunctionLeakageCheck -> LeakingLambdaReporter(error)
-        is SourceRole.ConditionalEffect -> ConditionalEffectReporter(sourceRole)
-        else -> DefaultErrorReporter(error)
-    }
+private fun VerificationError.formatByErrorStyle(errorStyle: ErrorStyle): List<FormattedError> = when (errorStyle) {
+    ErrorStyle.USER_FRIENDLY -> listOf(formatUserFriendly() ?: DefaultError(this))
+    ErrorStyle.ORIGINAL_VIPER -> listOf(DefaultError(this))
+    ErrorStyle.BOTH -> listOfNotNull(formatUserFriendly(), DefaultError(this))
+}
 
 private fun DiagnosticReporter.reportVerificationError(
     source: KtSourceElement?,
     error: VerificationError,
     errorStyle: ErrorStyle,
     context: CheckerContext,
-) {
-    when (errorStyle) {
-        ErrorStyle.USER_FRIENDLY -> {
-            val reporter = fetchVerificationErrorReporter(error)
-            reporter.report(this, source, context)
-        }
-        ErrorStyle.ORIGINAL_VIPER -> {
-            DefaultErrorReporter(error).report(this, source, context)
-        }
-        ErrorStyle.BOTH -> {
-            val reporter = fetchVerificationErrorReporter(error)
-            reporter.report(this, source, context)
-            // Avoid duplicate warnings if we do not have a specific reporter for the error.
-            if (reporter !is DefaultErrorReporter) {
-                DefaultErrorReporter(error).report(this, source, context)
-            }
-        }
-    }
-}
+) = error.formatByErrorStyle(errorStyle).forEach { it.report(this, source, context) }
 
 private fun DiagnosticReporter.reportConsistencyError(source: KtSourceElement?, error: ConsistencyError, context: CheckerContext) {
     val sourceIsFunctionDeclaration = source?.elementType?.let { it == KtNodeTypes.FUN } ?: false


### PR DESCRIPTION
I defined a new interface `SourceRolePrettyPrinter<T: SourceRole>` that extends a given source role of type `T` with a new extension function `prettyPrint`. Additionally, new objects inheriting this interface are defined: `ReturnsEffectPrinter`, `CallsInPlacePrinter` and `ConditionalEffectPrinter`. 

Note: I couldn't implement the interfaces `SourceRolePrettyPrinter<ReturnsEffect>` and `SourceRolePrettyPrinter<Condition>` in `ConditionalEffectPrinter` because of type erasure, that's why there are two inner objects (`ConditionalEffectPrinter.ReturnsEffect` and `ConditionalEffectPrinter.Condition`).

See comment: https://github.com/jesyspa/kotlin/pull/193#discussion_r1406006230