### PR TITLE
Add special `verify` builtin function

### DIFF
--- a/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.formver.plugin
 
 /**
- * Built-in function used to verify a given boolean predicate with Viper.
+ * Built-in function used to mark a boolean predicate to be verified in Viper.
+ * This function hooks-in in the `formver` plugin, its invocation in a Kotlin
+ * program does not do anything.
  */
-fun verify(predicate: Boolean): Unit = Unit
+fun verify(@Suppress("UNUSED_PARAMETER") predicate: Boolean) = Unit

--- a/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.plugin
+
+/**
+ * Built-in function used to verify a given boolean predicate with Viper.
+ */
+fun verify(predicate: Boolean): Unit = Unit

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -147,7 +147,6 @@ object SpecialVerifyFunction : SpecialKotlinFunction {
     override val name: String = "verify"
 
     override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding {
-        // Function calls to the `verify` function will be replaced with an assert statement.
         return Assert(args[0])
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -139,8 +139,26 @@ object KotlinRunSpecialFunction : SpecialKotlinFunction {
     }
 }
 
+/**
+ * Represents the `verify` function defined in `org.jetbrains.kotlin.formver.plugin`.
+ */
+object SpecialVerifyFunction : SpecialKotlinFunction {
+    override val packageName: List<String> = listOf("org", "jetbrains", "kotlin", "formver", "plugin")
+    override val name: String = "verify"
+
+    override fun insertCallImpl(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding {
+        // Function calls to the `verify` function will be replaced with an assert statement.
+        return Assert(args[0])
+    }
+
+    override val receiverType: TypeEmbedding? = null
+    override val paramTypes: List<TypeEmbedding> = listOf(BooleanTypeEmbedding)
+    override val returnType: TypeEmbedding = UnitTypeEmbedding
+}
+
 object SpecialKotlinFunctions {
     val byName = listOf(
+        SpecialVerifyFunction,
         KotlinContractFunction,
         KotlinIntPlusFunctionImplementation,
         KotlinIntMinusFunctionImplementation,

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/viper_verify.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/viper_verify.fir.diag.txt
@@ -1,0 +1,24 @@
+/viper_verify.kt:(125,137): info: Generated Viper text for verify_false:
+method global$fun_verify_false$fun_take$$return$T_Unit()
+  returns (ret$0: dom$Unit)
+{
+  assert false
+  label label$ret$0
+}
+
+/viper_verify.kt:(153,158): warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/viper_verify.kt:(181,196): info: Generated Viper text for verify_compound:
+method global$fun_verify_compound$fun_take$$return$T_Unit()
+  returns (ret$0: dom$Unit)
+{
+  var anonymous$0: Bool
+  if (true) {
+    anonymous$0 := false
+  } else {
+    anonymous$0 := false}
+  assert anonymous$0
+  label label$ret$0
+}
+
+/viper_verify.kt:(212,225): warning: Viper verification error: Assert might fail. Assertion anonymous$0 might not hold.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/viper_verify.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/viper_verify.kt
@@ -1,0 +1,12 @@
+import org.jetbrains.kotlin.formver.plugin.verify
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>verify_false<!>() {
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>verify_compound<!>() {
+    verify(<!VIPER_VERIFICATION_ERROR!>true && false<!>)
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -104,6 +104,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         public void testReturns_null() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.kt");
         }
+
+        @Test
+        @TestMetadata("viper_verify.kt")
+        public void testViper_verify() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/viper_verify.kt");
+        }
     }
 
     @Nested


### PR DESCRIPTION
This PR adds a new special builtin function to generate Viper's assert statements. 

Small note: at the moment, I do not like how the `VIPER_VERIFICATION_ERROR` annotation doesn't wrap the entire function call.