### PR TITLE
add warning message for sub-list function

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -41,9 +41,9 @@ fun NamedFunctionSignature.stdLibPreConditions(): List<ExpEmbedding> =
                 val fromIndexArg = formalArgs[1]
                 val toIndexArg = formalArgs[2]
                 return listOf(
-                    LeCmp(fromIndexArg, toIndexArg, SourceRole.SubListCreation()),
-                    GeCmp(fromIndexArg, IntLit(0), SourceRole.SubListCreation(true)),
-                    LeCmp(toIndexArg, FieldAccess(receiver, ListSizeFieldEmbedding), SourceRole.SubListCreation())
+                    LeCmp(fromIndexArg, toIndexArg, SourceRole.SubListCreation.CheckInSize),
+                    GeCmp(fromIndexArg, IntLit(0), SourceRole.SubListCreation.CheckNegativeIndices),
+                    LeCmp(toIndexArg, FieldAccess(receiver, ListSizeFieldEmbedding), SourceRole.SubListCreation.CheckInSize)
                 )
             }
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -41,9 +41,9 @@ fun NamedFunctionSignature.stdLibPreConditions(): List<ExpEmbedding> =
                 val fromIndexArg = formalArgs[1]
                 val toIndexArg = formalArgs[2]
                 return listOf(
-                    LeCmp(fromIndexArg, toIndexArg),
-                    GeCmp(fromIndexArg, IntLit(0)),
-                    LeCmp(toIndexArg, FieldAccess(receiver, ListSizeFieldEmbedding))
+                    LeCmp(fromIndexArg, toIndexArg, SourceRole.SubListCreation()),
+                    GeCmp(fromIndexArg, IntLit(0), SourceRole.SubListCreation(true)),
+                    LeCmp(toIndexArg, FieldAccess(receiver, ListSizeFieldEmbedding), SourceRole.SubListCreation())
                 )
             }
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.formver.viper.ast.Info
 
 sealed interface SourceRole {
     data object ParamFunctionLeakageCheck : SourceRole
-    data class SubListCreation(val mayBeNegative: Boolean = false) : SourceRole
 
     data class ListElementAccessCheck(val accessType: AccessCheckType) : SourceRole {
         enum class AccessCheckType {
@@ -24,6 +23,11 @@ sealed interface SourceRole {
     data class CallsInPlaceEffect(val paramSymbol: FirBasedSymbol<*>, val kind: EventOccurrencesRange) : SourceRole
     data class ConditionalEffect(val effect: ReturnsEffect, val condition: Condition) : SourceRole
     data class FirSymbolHolder(val firSymbol: FirBasedSymbol<*>) : SourceRole, Condition
+
+    sealed interface SubListCreation : SourceRole {
+        data object CheckInSize : SubListCreation
+        data object CheckNegativeIndices : SubListCreation
+    }
 
     sealed interface ReturnsEffect : SourceRole {
         data object Wildcard : ReturnsEffect

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Info
 
 sealed interface SourceRole {
     data object ParamFunctionLeakageCheck : SourceRole
+    data class SubListCreation(val mayBeNegative: Boolean = false) : SourceRole
 
     data class ListElementAccessCheck(val accessType: AccessCheckType) : SourceRole {
         enum class AccessCheckType {

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -67,5 +67,11 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
             CommonRenderers.STRING
         )
+        put(
+            PluginErrors.INVALID_SUBLIST_RANGE,
+            "Invalid sub-list range for {0}, the range may be {1}.",
+            CommonRenderers.STRING,
+            CommonRenderers.STRING
+        )
     }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -21,6 +21,7 @@ object PluginErrors {
     val LAMBDA_MAY_LEAK by warning1<PsiElement, FirBasedSymbol<*>>()
     val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
     val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
+    val INVALID_SUBLIST_RANGE by warning2<PsiElement, String, String>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(FormalVerificationPluginErrorMessages)

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
@@ -98,14 +98,33 @@ class IndexOutOfBoundError(private val error: VerificationError, private val sou
          */
         val targetListInfo = error.locationNode.asCallable().arg(0).info
         val targetList = targetListInfo.unwrapOr<SourceRole.FirSymbolHolder> { null }
-        val listMsg = when (targetList) {
-            null -> "the following list sub-expression"
-            else -> {
-                val listName = FirDiagnosticRenderers.DECLARATION_NAME.render(targetList.firSymbol)
-                "list '${listName}'"
-            }
+        reporter.reportOn(
+            source,
+            PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
+            targetList.formatListMessage(),
+            sourceRole.accessType.asUserFriendlyMessage,
+            context
+        )
+    }
+}
+
+class InvalidSubListRangeError(private val error: VerificationError, private val sourceRole: SourceRole.SubListCreation) : FormattedError {
+    private val SourceRole.SubListCreation.asUserFriendlyMessage: String
+        get() = when (mayBeNegative) {
+            true -> "including negative indices"
+            false -> "greater than the list's size"
         }
-        reporter.reportOn(source, PluginErrors.POSSIBLE_INDEX_OUT_OF_BOUND, listMsg, sourceRole.accessType.asUserFriendlyMessage, context)
+
+    override fun report(reporter: DiagnosticReporter, source: KtSourceElement?, context: CheckerContext) {
+        val targetListInfo = error.locationNode.asCallable().arg(0).info
+        val targetList = targetListInfo.unwrapOr<SourceRole.FirSymbolHolder> { null }
+        reporter.reportOn(
+            source,
+            PluginErrors.INVALID_SUBLIST_RANGE,
+            targetList.formatListMessage(),
+            sourceRole.asUserFriendlyMessage,
+            context
+        )
     }
 }
 
@@ -116,6 +135,7 @@ fun VerificationError.formatUserFriendly(): FormattedError? =
         is SourceRole.ConditionalEffect -> ConditionalEffectError(sourceRole)
         is SourceRole.ParamFunctionLeakageCheck -> LeakingLambdaError(this)
         is SourceRole.ListElementAccessCheck -> IndexOutOfBoundError(this, sourceRole)
+        is SourceRole.SubListCreation -> InvalidSubListRangeError(this, sourceRole)
         else -> null
     }
 
@@ -134,5 +154,13 @@ private fun VerificationError.lookupSourceRole(): SourceRole? {
     return when (val locationNodeRole = locationNode.getInfoOrNull<SourceRole>()) {
         null -> unverifiableProposition.getInfoOrNull<SourceRole>()
         else -> locationNodeRole
+    }
+}
+
+private fun SourceRole.FirSymbolHolder?.formatListMessage(): String = when (this) {
+    null -> "the following list sub-expression"
+    else -> {
+        val listName = FirDiagnosticRenderers.DECLARATION_NAME.render(firSymbol)
+        "list '${listName}'"
     }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/FormattedError.kt
@@ -110,9 +110,9 @@ class IndexOutOfBoundError(private val error: VerificationError, private val sou
 
 class InvalidSubListRangeError(private val error: VerificationError, private val sourceRole: SourceRole.SubListCreation) : FormattedError {
     private val SourceRole.SubListCreation.asUserFriendlyMessage: String
-        get() = when (mayBeNegative) {
-            true -> "including negative indices"
-            false -> "greater than the list's size"
+        get() = when (this) {
+            is SourceRole.SubListCreation.CheckNegativeIndices -> "including negative indices"
+            is SourceRole.SubListCreation.CheckInSize -> "greater than the list's size"
         }
 
     override fun report(reporter: DiagnosticReporter, source: KtSourceElement?, context: CheckerContext) {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
@@ -276,7 +276,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   ensures ret.special$size == local$toIndex - local$fromIndex
 
 
-/binary_search.kt:(1345,1368): warning: Viper verification error: The precondition of method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$T_Int$return$T_class_pkg$kotlin$collections$global$class_List might not hold. Assertion 0 <= local0$mid - 1 might not hold.
+/binary_search.kt:(1345,1368): warning: Invalid sub-list range for list 'arr', the range may be greater than the list's size.
 
 /binary_search.kt:(1405,1425): info: Generated Viper text for unsafe_binary_search:
 field special$size: Int

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.kt
@@ -35,7 +35,7 @@ fun <!VIPER_TEXT!>mid_decreased_by_one_in_rec_call<!>(arr: List<Int>, target: In
         arr[mid] == target -> true
         arr[mid] < target -> mid_decreased_by_one_in_rec_call(arr.subList(mid + 1, size), target)
         // if arr.size == 1, arr.subList(0, -1) is called
-        else -> mid_decreased_by_one_in_rec_call(<!VIPER_VERIFICATION_ERROR!>arr.subList(0, mid - 1)<!>, target)
+        else -> mid_decreased_by_one_in_rec_call(<!INVALID_SUBLIST_RANGE!>arr.subList(0, mid - 1)<!>, target)
     }
 }
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -144,3 +144,85 @@ method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kot
 
 
 /list.kt:(406,410): warning: Invalid index for list 'l', the index may be greater than the list's size.
+
+/list.kt:(432,446): info: Generated Viper text for empty_list_sub:
+field special$size: Int
+
+method global$fun_empty_list_sub$fun_take$$return$T_Unit()
+  returns (ret$0: dom$Unit)
+{
+  var local0$l: Ref
+  var anonymous$0: Ref
+  anonymous$0 := pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
+  local0$l := pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$T_Int$return$T_class_pkg$kotlin$collections$global$class_List(anonymous$0,
+    0, 1)
+  label label$ret$0
+}
+
+method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$T_Int$return$T_class_pkg$kotlin$collections$global$class_List(this: Ref,
+  local$fromIndex: Int, local$toIndex: Int)
+  returns (ret: Ref)
+  requires acc(this.special$size, write)
+  requires this.special$size >= 0
+  requires local$fromIndex <= local$toIndex
+  requires local$fromIndex >= 0
+  requires local$toIndex <= this.special$size
+  ensures acc(this.special$size, write)
+  ensures this.special$size >= 0
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
+  ensures acc(ret.special$size, write)
+  ensures ret.special$size >= 0
+  ensures this.special$size == old(this.special$size)
+  ensures ret.special$size == local$toIndex - local$fromIndex
+
+
+method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
+  ensures acc(ret.special$size, write)
+  ensures ret.special$size >= 0
+  ensures ret.special$size == 0
+
+
+/list.kt:(463,493): warning: Invalid sub-list range for the following list sub-expression, the range may be greater than the list's size.
+
+/list.kt:(515,538): info: Generated Viper text for empty_list_sub_negative:
+field special$size: Int
+
+method global$fun_empty_list_sub_negative$fun_take$$return$T_Unit()
+  returns (ret$0: dom$Unit)
+{
+  var local0$l: Ref
+  var anonymous$0: Ref
+  anonymous$0 := pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
+  local0$l := pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$T_Int$return$T_class_pkg$kotlin$collections$global$class_List(anonymous$0,
+    -1, 1)
+  label label$ret$0
+}
+
+method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin$collections$global$class_List$T_Int$T_Int$return$T_class_pkg$kotlin$collections$global$class_List(this: Ref,
+  local$fromIndex: Int, local$toIndex: Int)
+  returns (ret: Ref)
+  requires acc(this.special$size, write)
+  requires this.special$size >= 0
+  requires local$fromIndex <= local$toIndex
+  requires local$fromIndex >= 0
+  requires local$toIndex <= this.special$size
+  ensures acc(this.special$size, write)
+  ensures this.special$size >= 0
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
+  ensures acc(ret.special$size, write)
+  ensures ret.special$size >= 0
+  ensures this.special$size == old(this.special$size)
+  ensures ret.special$size == local$toIndex - local$fromIndex
+
+
+method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$kotlin$collections$global$class_List()
+  returns (ret: Ref)
+  ensures dom$Type$isSubtype((dom$TypeOf$typeOf(ret): dom$Type), dom$Type$pkg$kotlin$collections$global$class_List())
+  ensures acc(ret.special$size, write)
+  ensures ret.special$size >= 0
+  ensures ret.special$size == 0
+
+
+/list.kt:(555,586): warning: Invalid sub-list range for the following list sub-expression, the range may be including negative indices.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.kt
@@ -23,3 +23,13 @@ fun <!VIPER_TEXT!>add_get<!>(l: MutableList<Int>) {
     l.add(1)
     val n = <!POSSIBLE_INDEX_OUT_OF_BOUND!>l[1]<!>
 }
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>empty_list_sub<!>() {
+    val l = <!INVALID_SUBLIST_RANGE!>emptyList<Int>().subList(0, 1)<!>
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>empty_list_sub_negative<!>() {
+    val l = <!INVALID_SUBLIST_RANGE!>emptyList<Int>().subList(-1, 1)<!>
+}


### PR DESCRIPTION
I've added a new warning message for the `subList` function. Two new test functions were added for negative indices and for the case of a sub-expression returning a list.