### PR TITLE
Immutable class predicates

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -64,7 +64,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             domains = listOf(RuntimeTypeDomain(classes.values.toList())),
             fields = SpecialFields.all.map { it.toViper() } +
                     classes.values.flatMap { it.flatMapUniqueFields { _, field -> listOf(field.toViper()) } }.distinctBy { it.name },
-            functions = SpecialFunctions.all + classes.values.flatMap { it.getterFunctions() }.distinctBy { it.name },
+            functions = SpecialFunctions.all,
             methods = SpecialMethods.all + methods.values.mapNotNull { it.viperMethod }.toList(),
             predicates = classes.values.map { it.predicate }
         )
@@ -199,7 +199,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         }
     }
 
-    private val FirRegularClassSymbol.propertySymbols : List<FirPropertySymbol>
+    private val FirRegularClassSymbol.propertySymbols: List<FirPropertySymbol>
         get() = this.declarationSymbols.filterIsInstance<FirPropertySymbol>()
 
     private fun embedFullSignature(symbol: FirFunctionSymbol<*>): FullNamedFunctionSignature {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -232,7 +232,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                 params.mapNotNull { param ->
                     constructorParamSymbolsToFields[param.symbol]?.let { field ->
                         (field.accessPolicy == AccessPolicy.ALWAYS_READABLE).ifTrue {
-                            EqCmp(FieldAccess(returnVariable, field), param)
+                            EqCmp(PrimitiveFieldAccess(returnVariable, field), param)
                         }
                     }
                 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyGetter
@@ -107,7 +108,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                 // `ProgramConverter`.
 
                 // Phase 1
-                val newEmbedding = ClassTypeEmbedding(className)
+                val newEmbedding = ClassTypeEmbedding(className, symbol.classKind == ClassKind.INTERFACE)
                 classes[className] = newEmbedding
 
                 // Phase 2

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -255,6 +255,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         return if (exp.type.getNonNullable() == newType) {
             exp.withType(newType)
         } else {
+            // TODO: when there is a cast from B to A, only inhale invariants of A - invariants of B
             exp.withType(newType).withAccessInvariants()
         }
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -255,7 +255,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         return if (exp.type.getNonNullable() == newType) {
             exp.withType(newType)
         } else {
-            exp.withType(newType).withAccessAndProvenInvariants()
+            exp.withType(newType).withAccessInvariants()
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -251,7 +251,12 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     ): ExpEmbedding {
         val exp = data.convert(smartCastExpression.originalExpression)
         val newType = data.embedType(smartCastExpression.smartcastType.coneType)
-        return exp.withType(newType)
+        // If the smart-cast is from A? to A, then is not necessary to inhale invariants
+        return if (exp.type.getNonNullable() == newType) {
+            exp.withType(newType)
+        } else {
+            exp.withType(newType).withAccessAndProvenInvariants()
+        }
     }
 
     override fun visitBinaryLogicExpression(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
@@ -5,12 +5,19 @@
 
 package org.jetbrains.kotlin.formver.embeddings
 
+import org.jetbrains.kotlin.formver.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 
 class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding =
-        FieldAccess(receiver, field).withAccessAndProvenInvariants()
+    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
+        return if (field.accessPolicy == AccessPolicy.ALWAYS_READABLE) {
+            FieldAccess(receiver, field)
+        } else {
+            FieldAccess(receiver, field).withAccessAndProvenInvariants()
+        }
+    }
+
 }
 
 class BackingFieldSetter(val field: FieldEmbedding) : SetterEmbedding {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -21,6 +21,8 @@ interface FieldEmbedding {
     val type: TypeEmbedding
     val viperType: Type
     val accessPolicy: AccessPolicy
+
+    // If true, it is necessary to unfold the predicate of the receiver before accessing the field
     val unfoldToAccess: Boolean
         get() = false
     val includeInShortDump: Boolean

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -67,7 +67,7 @@ interface TypeEmbedding {
     fun accessInvariants(): List<TypeInvariantEmbedding> = emptyList()
 
     // Note: this function will replace accessInvariants when nested unfold will be implemented
-    fun predicateAccessInvariants(): List<TypeInvariantEmbedding> = emptyList()
+    fun predicateAccessInvariant(): TypeInvariantEmbedding? = null
 
     /**
      * A list of invariants that are already known to be true based on the Kotlin code being well-formed.
@@ -176,8 +176,8 @@ data class NullableTypeEmbedding(val elementType: TypeEmbedding) : TypeEmbedding
     override fun accessInvariants(): List<TypeInvariantEmbedding> = elementType.accessInvariants().map { IfNonNullInvariant(it) }
 
     // Note: this function will replace accessInvariants when nested unfold will be implemented
-    override fun predicateAccessInvariants(): List<TypeInvariantEmbedding> =
-        elementType.predicateAccessInvariants().map { IfNonNullInvariant(it) }
+    override fun predicateAccessInvariant(): TypeInvariantEmbedding? =
+        elementType.predicateAccessInvariant()?.let { IfNonNullInvariant(it) }
 
     override fun getNullable(): NullableTypeEmbedding = this
     override fun getNonNullable(): TypeEmbedding = elementType
@@ -218,7 +218,7 @@ data class FunctionTypeEmbedding(val signature: CallableSignatureData) : Unspeci
     }
 }
 
-data class ClassTypeEmbedding(val className: ScopedKotlinName) : TypeEmbedding {
+data class ClassTypeEmbedding(val className: ScopedKotlinName, val isInterface: Boolean) : TypeEmbedding {
     private var _superTypes: List<TypeEmbedding>? = null
     val superTypes: List<TypeEmbedding>
         get() = _superTypes ?: error("Super types of $className have not been initialised yet.")
@@ -247,6 +247,7 @@ data class ClassTypeEmbedding(val className: ScopedKotlinName) : TypeEmbedding {
     private fun initPredicate(): Predicate {
         val subjectEmbedding = PlaceholderVariableEmbedding(ClassPredicateSubjectName, this)
         val accessFields = fields.values
+            .filter { it.accessPolicy == AccessPolicy.ALWAYS_READABLE }
             .flatMap { it.accessInvariantsForParameter().fillHoles(subjectEmbedding) }
 
         // For the moment ALWAYS_WRITEABLE fields with some class type do not exist.
@@ -254,11 +255,11 @@ data class ClassTypeEmbedding(val className: ScopedKotlinName) : TypeEmbedding {
         // We need to pass in the field access since the predicates are simply the ones for the type.
         val accessFieldPredicates = fields.values
             .filter { it.accessPolicy == AccessPolicy.ALWAYS_READABLE }
-            .flatMap { it.type.predicateAccessInvariants().fillHoles(FieldAccess(subjectEmbedding, it)) }
+            .mapNotNull { it.type.predicateAccessInvariant()?.fillHole(FieldAccess(subjectEmbedding, it)) }
 
         val accessSuperTypesPredicates = superTypes
             .filterIsInstance<ClassTypeEmbedding>()
-            .map { PredicateAccessTypeInvariantEmbedding(it.name).fillHole(subjectEmbedding) }
+            .map { PredicateAccessTypeInvariantEmbedding(it.name, PermExp.WildcardPerm()).fillHole(subjectEmbedding) }
 
         val body = (accessFields + accessFieldPredicates + accessSuperTypesPredicates).toConjunction()
         return Predicate(name, listOf(subjectEmbedding.toLocalVarDecl()), body.pureToViper(toBuiltin = true))
@@ -268,11 +269,11 @@ data class ClassTypeEmbedding(val className: ScopedKotlinName) : TypeEmbedding {
     fun getterFunctions(): List<FieldAccessFunction> {
         val receiver = PlaceholderVariableEmbedding(GetterFunctionSubjectName, this)
         val getPropertyFunctions = fields.values
-            .filter { field -> field.accessPolicy != AccessPolicy.ALWAYS_INHALE_EXHALE }
+            .filter { field -> field.accessPolicy == AccessPolicy.ALWAYS_READABLE }
             .map { field -> FieldAccessFunction(name, field, FieldAccess(receiver, field).pureToViper(toBuiltin = false)) }
         val getSuperPropertyFunctions = classSuperTypes.flatMap {
             it.flatMapUniqueFields { _, field ->
-                if (field.accessPolicy != AccessPolicy.ALWAYS_INHALE_EXHALE) {
+                if (field.accessPolicy == AccessPolicy.ALWAYS_READABLE) {
                     val unfoldingBody =
                         Exp.FuncApp(GetterFunctionName(it.name, field.name), listOf(receiver.toLocalVarUse()), Type.Ref)
                     listOf(FieldAccessFunction(name, field, unfoldingBody))
@@ -305,8 +306,26 @@ data class ClassTypeEmbedding(val className: ScopedKotlinName) : TypeEmbedding {
         flatMapUniqueFields { _, field -> field.accessInvariantsForParameter() }
 
     // Note: this function will replace accessInvariants when nested unfold will be implemented
-    override fun predicateAccessInvariants(): List<TypeInvariantEmbedding> = listOf(PredicateAccessTypeInvariantEmbedding(name))
+    override fun predicateAccessInvariant() =
+        PredicateAccessTypeInvariantEmbedding(name, PermExp.WildcardPerm())
 
+    // Returns the list of classes in a hierarchy that need to be unfolded in order to access the given field
+    fun hierarchyUnfoldPath(fieldName: ScopedKotlinName): List<ClassTypeEmbedding> {
+        return if (fieldName.scope is ClassScope) {
+            if (fieldName.scope.className == className.name) {
+                listOf(this)
+            } else {
+                val sup = superTypes.firstOrNull { it is ClassTypeEmbedding && !it.isInterface }
+                if (sup is ClassTypeEmbedding) {
+                    listOf(this) + sup.hierarchyUnfoldPath(fieldName)
+                } else {
+                    throw IllegalArgumentException("Reached top of the hierarchy without finding the field")
+                }
+            }
+        } else {
+            throw IllegalArgumentException("Cannot find hierarchy unfold path of a field with no class scope")
+        }
+    }
 }
 
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeInvariantEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeInvariantEmbedding.kt
@@ -40,6 +40,6 @@ data class FieldAccessTypeInvariantEmbedding(val field: FieldEmbedding, val perm
 
 // Note that at present, the predicate name and class name are the same.
 // We may want to mangle it better down the line.
-data class PredicateAccessTypeInvariantEmbedding(val predicateName: MangledName) : TypeInvariantEmbedding {
-    override fun fillHole(exp: ExpEmbedding): ExpEmbedding = PredicateAccessPermissions(predicateName, listOf(exp))
+data class PredicateAccessTypeInvariantEmbedding(val predicateName: MangledName, val perm: PermExp) : TypeInvariantEmbedding {
+    override fun fillHole(exp: ExpEmbedding): ExpEmbedding = PredicateAccessPermissions(predicateName, listOf(exp), perm)
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialFunctions.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialFunctions.kt
@@ -40,7 +40,7 @@ class FieldAccessFunction(
 ) : Function {
     override val name = GetterFunctionName(className, field.name)
     private val subject = Exp.LocalVar(GetterFunctionSubjectName, Type.Ref)
-    private val subjectAccess = Exp.PredicateAccess(className, listOf(subject))
+    private val subjectAccess = Exp.PredicateAccess(className, listOf(subject), PermExp.WildcardPerm())
     override val retType: Type = Type.Ref
     override val includeInDumpPolicy: IncludeInDumpPolicy = IncludeInDumpPolicy.PREDICATE_DUMP
     override val formalArgs: List<Declaration.LocalVarDecl> = listOf(Declaration.LocalVarDecl(GetterFunctionSubjectName, Type.Ref))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialFunctions.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialFunctions.kt
@@ -7,46 +7,8 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.domains.FunctionBuilder
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain.Companion.boolType
-import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain.Companion.isOf
-import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
-import org.jetbrains.kotlin.formver.names.GetterFunctionName
-import org.jetbrains.kotlin.formver.names.GetterFunctionSubjectName
-import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.*
-import org.jetbrains.kotlin.formver.viper.ast.Function
 
-/**
- * Function used to unfold a class predicate in order to get the value of a field.
- * The function looks like:
- * ```
- *  function className$get$fieldName(this: Ref): fieldType
- *      requires acc(className(this), write)
- *  {
- *      unfolding acc(className(this), write) in unfoldingBody
- *  }
- *  ```
- * @param unfoldingBody should be one of:
- * - a field access if the field we want to access is declared in the class;
- * - a call to another FieldAccessFunction if the field we want to access is declared in a superclass.
- */
-class FieldAccessFunction(
-    className: MangledName,
-    field: FieldEmbedding,
-    unfoldingBody: Exp,
-    override val pos: Position = Position.NoPosition,
-    override val info: Info = Info.NoInfo,
-    override val trafos: Trafos = Trafos.NoTrafos,
-) : Function {
-    override val name = GetterFunctionName(className, field.name)
-    private val subject = Exp.LocalVar(GetterFunctionSubjectName, Type.Ref)
-    private val subjectAccess = Exp.PredicateAccess(className, listOf(subject), PermExp.WildcardPerm())
-    override val retType: Type = Type.Ref
-    override val includeInDumpPolicy: IncludeInDumpPolicy = IncludeInDumpPolicy.PREDICATE_DUMP
-    override val formalArgs: List<Declaration.LocalVarDecl> = listOf(Declaration.LocalVarDecl(GetterFunctionSubjectName, Type.Ref))
-    override val pres: List<Exp> = listOf(subjectAccess)
-    override val body: Exp = Exp.Unfolding(subjectAccess, unfoldingBody)
-}
 
 object SpecialFunctions {
     val duplicableFunction = FunctionBuilder.build("duplicable") {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -42,7 +42,7 @@ object KotlinContractFunction : SpecialKotlinFunction {
     override val name: String = "contract"
 
     private val contractBuilderType =
-        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(listOf("ContractBuilder"))))
+        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(listOf("ContractBuilder"))), true)
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -42,7 +42,7 @@ object KotlinContractFunction : SpecialKotlinFunction {
     override val name: String = "contract"
 
     private val contractBuilderType =
-        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(listOf("ContractBuilder"))), true)
+        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(listOf("ContractBuilder"))), isInterface = true)
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -373,10 +373,10 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
 
     private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
         val hierarchyPath = (receiver.type as? ClassTypeEmbedding)?.hierarchyUnfoldPath(field.name)
-        hierarchyPath?.forEach {
-            val predAcc = it.predicateAccessInvariant().fillHole(receiverWrapper)
+        hierarchyPath?.forEach { classType ->
+            val predAcc = classType.predicateAccessInvariant().fillHole(receiverWrapper)
                 .pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess
-            predAcc?.let { x -> ctx.addStatement(Stmt.Unfold(x)) }
+            predAcc?.let { ctx.addStatement(Stmt.Unfold(it)) }
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
@@ -116,7 +116,7 @@ fun ExpEmbedding.withProvenInvariants(): ExpEmbedding = InhaleProven(this).simpl
 
 class InhaleAccess(exp: ExpEmbedding) : InhaleInvariants(exp) {
     override val invariants: List<TypeInvariantEmbedding>
-        get() = type.accessInvariants()
+        get() = type.accessInvariants() + listOfNotNull(type.predicateAccessInvariant())
 }
 
 fun ExpEmbedding.withAccessInvariants(): ExpEmbedding = InhaleAccess(this).simplified

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
@@ -123,7 +123,7 @@ fun ExpEmbedding.withAccessInvariants(): ExpEmbedding = InhaleAccess(this).simpl
 
 class InhaleAccessAndProven(exp: ExpEmbedding) : InhaleInvariants(exp) {
     override val invariants: List<TypeInvariantEmbedding>
-        get() = type.accessInvariants() + type.provenInvariants()
+        get() = type.accessInvariants() + type.provenInvariants() + listOfNotNull(type.predicateAccessInvariant())
 }
 
 fun ExpEmbedding.withAccessAndProvenInvariants(): ExpEmbedding = InhaleAccessAndProven(this).simplified

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -42,8 +42,6 @@ sealed interface VariableEmbedding : PureExpEmbedding, PropertyAccessEmbedding {
     fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants().fillHoles(this)
     fun provenInvariants(): List<ExpEmbedding> = type.provenInvariants().fillHoles(this)
     fun accessInvariants(): List<ExpEmbedding> = type.accessInvariants()
-        .filter { !(it is FieldAccessTypeInvariantEmbedding && it.perm == PermExp.WildcardPerm()) }
-        .filter { !(it is IfNonNullInvariant && it.invariant is FieldAccessTypeInvariantEmbedding && it.invariant.perm == PermExp.WildcardPerm()) }
         .fillHoles(this) + listOfNotNull(type.predicateAccessInvariant()?.fillHole(this))
 
     fun dynamicInvariants(): List<ExpEmbedding> = type.dynamicInvariants().fillHoles(this)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -41,7 +41,11 @@ sealed interface VariableEmbedding : PureExpEmbedding, PropertyAccessEmbedding {
 
     fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants().fillHoles(this)
     fun provenInvariants(): List<ExpEmbedding> = type.provenInvariants().fillHoles(this)
-    fun accessInvariants(): List<ExpEmbedding> = type.accessInvariants().fillHoles(this)
+    fun accessInvariants(): List<ExpEmbedding> = type.accessInvariants()
+        .filter { !(it is FieldAccessTypeInvariantEmbedding && it.perm == PermExp.WildcardPerm()) }
+        .filter { !(it is IfNonNullInvariant && it.invariant is FieldAccessTypeInvariantEmbedding && it.invariant.perm == PermExp.WildcardPerm()) }
+        .fillHoles(this) + listOfNotNull(type.predicateAccessInvariant()?.fillHole(this))
+
     fun dynamicInvariants(): List<ExpEmbedding> = type.dynamicInvariants().fillHoles(this)
 
     override val debugTreeView: TreeView

--- a/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/plugins/formal-verification/formver.viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -373,6 +373,7 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     data class PredicateAccess(
         val predicateName: MangledName,
         val formalArgs: List<Exp>,
+        val perm: PermExp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
@@ -392,7 +393,7 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             )
             return PredicateAccessPredicate(
                 predicateAccess,
-                PermExp.FullPerm().toSilver(),
+                perm.toSilver(),
                 pos.toSilver(),
                 info.toSilver(),
                 trafos.toSilver()

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
@@ -13,13 +13,13 @@ method global$fun_getX$fun_take$T_Any$return$NT_Int(local$a: Ref)
     anonymous$0 := local$a
   } else {
     anonymous$0 := dom$RuntimeType$nullValue()}
-  inhale anonymous$0 != dom$RuntimeType$nullValue() ==>
-    acc(anonymous$0.class_IntHolder$member_x, wildcard)
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_IntHolder()))
+  inhale anonymous$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_IntHolder(anonymous$0), wildcard)
   if (anonymous$0 != dom$RuntimeType$nullValue()) {
     var anonymous$1: Ref
+    unfold acc(T_class_global$class_IntHolder(anonymous$0), wildcard)
     anonymous$1 := anonymous$0.class_IntHolder$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
     ret$0 := anonymous$1
   } else {
     ret$0 := dom$RuntimeType$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
@@ -6,8 +6,10 @@ method global$fun_mid_increased_by_one$fun_take$T_class_pkg$kotlin$collections$g
   returns (ret$0: Ref)
   requires acc(local$arr.special$size, write)
   requires dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures acc(local$arr.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var local0$size: Ref
@@ -62,11 +64,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -76,8 +80,10 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -92,6 +98,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$fromIndex) <=
     dom$RuntimeType$intFromRef(local$toIndex)
   requires dom$RuntimeType$intFromRef(local$fromIndex) >= 0
@@ -99,9 +106,11 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
   ensures dom$RuntimeType$intFromRef(ret.special$size) ==
@@ -119,8 +128,10 @@ method global$fun_mid_decreased_by_one$fun_take$T_class_pkg$kotlin$collections$g
   returns (ret$0: Ref)
   requires acc(local$arr.special$size, write)
   requires dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures acc(local$arr.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var local0$size: Ref
@@ -175,11 +186,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -189,8 +202,10 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -205,6 +220,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$fromIndex) <=
     dom$RuntimeType$intFromRef(local$toIndex)
   requires dom$RuntimeType$intFromRef(local$fromIndex) >= 0
@@ -212,9 +228,11 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
   ensures dom$RuntimeType$intFromRef(ret.special$size) ==
@@ -232,8 +250,10 @@ method global$fun_mid_decreased_by_one_in_rec_call$fun_take$T_class_pkg$kotlin$c
   returns (ret$0: Ref)
   requires acc(local$arr.special$size, write)
   requires dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures acc(local$arr.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var local0$size: Ref
@@ -286,11 +306,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -300,8 +322,10 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -316,6 +340,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$fromIndex) <=
     dom$RuntimeType$intFromRef(local$toIndex)
   requires dom$RuntimeType$intFromRef(local$fromIndex) >= 0
@@ -323,9 +348,11 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
   ensures dom$RuntimeType$intFromRef(ret.special$size) ==
@@ -343,8 +370,10 @@ method global$fun_unsafe_binary_search$fun_take$T_class_pkg$kotlin$collections$g
   returns (ret$0: Ref)
   requires acc(local$arr.special$size, write)
   requires dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures acc(local$arr.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var local0$mid: Ref
@@ -389,11 +418,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -134,6 +134,8 @@ method global$fun_incorrect_exactly_once_with_catch$fun_take$fun_take$$return$T_
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -186,6 +188,8 @@ method global$fun_incorrect_exactly_once_with_call_in_catch$fun_take$fun_take$$r
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
@@ -44,6 +44,10 @@ method global$fun_mayReturnNull$fun_take$NT_Any$return$NT_Any(local$x: Ref)
 /cond_effects.kt:(723,741): info: Generated Viper text for isNullOrEmptyWrong:
 method global$fun_isNullOrEmptyWrong$fun_take$NT_class_pkg$kotlin$global$class_CharSequence$return$T_Boolean(local$seq: Ref)
   returns (ret$0: Ref)
+  requires local$seq != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$global$class_CharSequence(local$seq), wildcard)
+  ensures local$seq != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$global$class_CharSequence(local$seq), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$boolFromRef(ret$0) == false ==>
     local$seq != dom$RuntimeType$nullValue()
@@ -62,6 +66,8 @@ method global$fun_isNullOrEmptyWrong$fun_take$NT_class_pkg$kotlin$global$class_C
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -91,6 +97,8 @@ method global$fun_recursiveContract$fun_take$T_Int$NT_Any$return$T_Boolean(local
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -16,6 +16,8 @@ method global$fun_unverifiableTypeCheck$fun_take$NT_Int$return$T_Boolean(local$x
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -19,11 +19,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -34,6 +36,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(ret.special$size) == 0
 
 
@@ -60,11 +63,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -75,6 +80,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(ret.special$size) == 0
 
 
@@ -87,8 +93,10 @@ method global$fun_unsafe_last$fun_take$T_class_pkg$kotlin$collections$global$cla
   returns (ret$0: Ref)
   requires acc(local$l.special$size, write)
   requires dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures acc(local$l.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   var anonymous$0: Ref
@@ -106,11 +114,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -125,8 +135,10 @@ method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_M
   returns (ret$0: Ref)
   requires acc(local$l.special$size, write)
   requires dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(local$l), wildcard)
   ensures acc(local$l.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var anonymous$0: Ref
@@ -145,8 +157,10 @@ method pkg$kotlin$collections$class_MutableList$fun_add$fun_take$T_class_pkg$kot
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size)) + 1
@@ -157,11 +171,13 @@ method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kot
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -190,6 +206,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$fromIndex) <=
     dom$RuntimeType$intFromRef(local$toIndex)
   requires dom$RuntimeType$intFromRef(local$fromIndex) >= 0
@@ -197,9 +214,11 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
   ensures dom$RuntimeType$intFromRef(ret.special$size) ==
@@ -212,6 +231,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(ret.special$size) == 0
 
 
@@ -238,6 +258,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$fromIndex) <=
     dom$RuntimeType$intFromRef(local$toIndex)
   requires dom$RuntimeType$intFromRef(local$fromIndex) >= 0
@@ -245,9 +266,11 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
   ensures dom$RuntimeType$intFromRef(ret.special$size) ==
@@ -260,6 +283,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(ret.special$size) == 0
 
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
@@ -1,13 +1,17 @@
 /as_type_contract.kt:(152,162): info: Generated Viper text for asOperator:
 method global$fun_asOperator$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$foo: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Bar())
+  ensures acc(T_class_global$class_Bar(ret$0), wildcard)
   ensures true ==>
     dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Bar())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
   ret$0 := local$foo
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Bar())
+  inhale acc(T_class_global$class_Bar(ret$0), wildcard)
   goto label$ret$0
   label label$ret$0
 }
@@ -15,13 +19,19 @@ method global$fun_asOperator$fun_take$T_class_global$class_Foo$return$T_class_gl
 /as_type_contract.kt:(307,321): info: Generated Viper text for safeAsOperator:
 method global$fun_safeAsOperator$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Bar(local$foo: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
   ensures ret$0 != dom$RuntimeType$nullValue() ==>
     dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Bar())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
   ret$0 := local$foo
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  inhale ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
   goto label$ret$0
   label label$ret$0
 }
@@ -43,13 +53,13 @@ method global$fun_getX$fun_take$T_Any$return$NT_Int(local$a: Ref)
     anonymous$0 := local$a
   } else {
     anonymous$0 := dom$RuntimeType$nullValue()}
-  inhale anonymous$0 != dom$RuntimeType$nullValue() ==>
-    acc(anonymous$0.class_IntHolder$member_x, wildcard)
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_IntHolder()))
+  inhale anonymous$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_IntHolder(anonymous$0), wildcard)
   if (anonymous$0 != dom$RuntimeType$nullValue()) {
     var anonymous$1: Ref
+    unfold acc(T_class_global$class_IntHolder(anonymous$0), wildcard)
     anonymous$1 := anonymous$0.class_IntHolder$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
     ret$0 := anonymous$1
   } else {
     ret$0 := dom$RuntimeType$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -5,18 +5,18 @@ field class_Y$member_z: Ref
 
 method global$fun_cascadeGet$fun_take$T_class_global$class_X$return$T_class_global$class_Z(local$x: Ref)
   returns (ret$0: Ref)
-  requires acc(local$x.class_X$member_y, wildcard)
-  ensures acc(local$x.class_X$member_y, wildcard)
+  requires acc(T_class_global$class_X(local$x), wildcard)
+  ensures acc(T_class_global$class_X(local$x), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Z())
+  ensures acc(T_class_global$class_Z(ret$0), wildcard)
   ensures true
 {
   var anonymous$0: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_X())
+  unfold acc(T_class_global$class_X(local$x), wildcard)
   anonymous$0 := local$x.class_X$member_y
-  inhale acc(anonymous$0.class_Y$member_z, wildcard)
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_Y())
+  unfold acc(T_class_global$class_Y(anonymous$0), wildcard)
   ret$0 := anonymous$0.class_Y$member_z
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Z())
   goto label$ret$0
   label label$ret$0
 }
@@ -29,9 +29,9 @@ field class_Y$member_z: Ref
 method global$fun_receiverNotNullProved$fun_take$NT_class_global$class_X$return$T_Boolean(local$x: Ref)
   returns (ret$0: Ref)
   requires local$x != dom$RuntimeType$nullValue() ==>
-    acc(local$x.class_X$member_y, wildcard)
+    acc(T_class_global$class_X(local$x), wildcard)
   ensures local$x != dom$RuntimeType$nullValue() ==>
-    acc(local$x.class_X$member_y, wildcard)
+    acc(T_class_global$class_X(local$x), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$boolFromRef(ret$0) == true ==>
     local$x != dom$RuntimeType$nullValue()
@@ -40,9 +40,8 @@ method global$fun_receiverNotNullProved$fun_take$NT_class_global$class_X$return$
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_X()))
   if (local$x != dom$RuntimeType$nullValue()) {
     var anonymous$1: Ref
+    unfold acc(T_class_global$class_X(local$x), wildcard)
     anonymous$1 := local$x.class_X$member_y
-    inhale acc(anonymous$1.class_Y$member_z, wildcard)
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$T_class_global$class_Y())
     anonymous$0 := anonymous$1
   } else {
     anonymous$0 := dom$RuntimeType$nullValue()}
@@ -60,25 +59,25 @@ field class_NullableY$member_z: Ref
 method global$fun_cascadeNullableGet$fun_take$NT_class_global$class_NullableX$return$NT_class_global$class_Z(local$x: Ref)
   returns (ret$0: Ref)
   requires local$x != dom$RuntimeType$nullValue() ==>
-    acc(local$x.class_NullableX$member_y, wildcard)
+    acc(T_class_global$class_NullableX(local$x), wildcard)
   ensures local$x != dom$RuntimeType$nullValue() ==>
-    acc(local$x.class_NullableX$member_y, wildcard)
+    acc(T_class_global$class_NullableX(local$x), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Z()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Z(ret$0), wildcard)
   ensures ret$0 != dom$RuntimeType$nullValue() ==>
     local$x != dom$RuntimeType$nullValue()
 {
   var anonymous$0: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_NullableX()))
   if (local$x != dom$RuntimeType$nullValue()) {
+    unfold acc(T_class_global$class_NullableX(local$x), wildcard)
     anonymous$0 := local$x.class_NullableX$member_y
-    inhale anonymous$0 != dom$RuntimeType$nullValue() ==>
-      acc(anonymous$0.class_NullableY$member_z, wildcard)
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_NullableY()))
   } else {
     anonymous$0 := dom$RuntimeType$nullValue()}
   if (anonymous$0 != dom$RuntimeType$nullValue()) {
+    unfold acc(T_class_global$class_NullableY(anonymous$0), wildcard)
     ret$0 := anonymous$0.class_NullableY$member_z
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Z()))
   } else {
     ret$0 := dom$RuntimeType$nullValue()}
   goto label$ret$0
@@ -93,10 +92,12 @@ field class_NullableY$member_z: Ref
 method global$fun_cascadeNullableSmartcastGet$fun_take$NT_class_global$class_NullableX$return$NT_class_global$class_Z(local$x: Ref)
   returns (ret$0: Ref)
   requires local$x != dom$RuntimeType$nullValue() ==>
-    acc(local$x.class_NullableX$member_y, wildcard)
+    acc(T_class_global$class_NullableX(local$x), wildcard)
   ensures local$x != dom$RuntimeType$nullValue() ==>
-    acc(local$x.class_NullableX$member_y, wildcard)
+    acc(T_class_global$class_NullableX(local$x), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Z()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Z(ret$0), wildcard)
   ensures ret$0 != dom$RuntimeType$nullValue() ==>
     local$x != dom$RuntimeType$nullValue()
 {
@@ -107,23 +108,18 @@ method global$fun_cascadeNullableSmartcastGet$fun_take$NT_class_global$class_Nul
     ret$0 := anonymous$0
   } else {
     var anonymous$1: Ref
+    unfold acc(T_class_global$class_NullableX(local$x), wildcard)
     anonymous$1 := local$x.class_NullableX$member_y
-    inhale anonymous$1 != dom$RuntimeType$nullValue() ==>
-      acc(anonymous$1.class_NullableY$member_z, wildcard)
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_NullableY()))
     if (anonymous$1 == dom$RuntimeType$nullValue()) {
       var anonymous$2: Ref
       anonymous$2 := dom$RuntimeType$nullValue()
       ret$0 := anonymous$2
     } else {
       var anonymous$3: Ref
+      unfold acc(T_class_global$class_NullableX(local$x), wildcard)
       anonymous$3 := local$x.class_NullableX$member_y
-      inhale anonymous$3 != dom$RuntimeType$nullValue() ==>
-        acc(anonymous$3.class_NullableY$member_z, wildcard)
-      inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$3),
-        dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_NullableY()))
+      unfold acc(T_class_global$class_NullableY(anonymous$3), wildcard)
       ret$0 := anonymous$3.class_NullableY$member_z
-      inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Z()))
     }
   }
   goto label$ret$0
@@ -136,7 +132,7 @@ field class_Baz$member_x: Ref
 method class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
-  ensures acc(ret.class_Baz$member_x, wildcard)
+  ensures acc(T_class_global$class_Baz(ret), wildcard)
 
 
 method global$fun_nullableReceiverNotNullSafeGet$fun_take$$return$T_Boolean()
@@ -151,8 +147,8 @@ method global$fun_nullableReceiverNotNullSafeGet$fun_take$$return$T_Boolean()
   local0$f := anonymous$0
   if (local0$f != dom$RuntimeType$nullValue()) {
     var anonymous$2: Ref
+    unfold acc(T_class_global$class_Baz(local0$f), wildcard)
     anonymous$2 := local0$f.class_Baz$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$2), dom$RuntimeType$intType())
     anonymous$1 := anonymous$2
   } else {
     anonymous$1 := dom$RuntimeType$nullValue()}
@@ -175,8 +171,8 @@ method global$fun_nullableReceiverNullSafeGet$fun_take$$return$T_Boolean()
   local0$f := dom$RuntimeType$nullValue()
   if (local0$f != dom$RuntimeType$nullValue()) {
     var anonymous$1: Ref
+    unfold acc(T_class_global$class_Baz(local0$f), wildcard)
     anonymous$1 := local0$f.class_Baz$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
     anonymous$0 := anonymous$1
   } else {
     anonymous$0 := dom$RuntimeType$nullValue()}
@@ -192,7 +188,7 @@ field class_Baz$member_x: Ref
 method class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
-  ensures acc(ret.class_Baz$member_x, wildcard)
+  ensures acc(T_class_global$class_Baz(ret), wildcard)
 
 
 method global$fun_nonNullableReceiverSafeGet$fun_take$$return$T_Boolean()
@@ -205,8 +201,8 @@ method global$fun_nonNullableReceiverSafeGet$fun_take$$return$T_Boolean()
   local0$f := class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   if (local0$f != dom$RuntimeType$nullValue()) {
     var anonymous$1: Ref
+    unfold acc(T_class_global$class_Baz(local0$f), wildcard)
     anonymous$1 := local0$f.class_Baz$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
     anonymous$0 := anonymous$1
   } else {
     anonymous$0 := dom$RuntimeType$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/binary_search.fir.diag.txt
@@ -6,8 +6,10 @@ method global$fun_safe_binary_search$fun_take$T_class_pkg$kotlin$collections$glo
   returns (ret$0: Ref)
   requires acc(local$arr.special$size, write)
   requires dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures acc(local$arr.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var local0$size: Ref
@@ -60,11 +62,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -74,8 +78,10 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -90,6 +96,7 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$fromIndex) <=
     dom$RuntimeType$intFromRef(local$toIndex)
   requires dom$RuntimeType$intFromRef(local$fromIndex) >= 0
@@ -97,9 +104,11 @@ method pkg$kotlin$collections$class_List$fun_subList$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
   ensures dom$RuntimeType$intFromRef(ret.special$size) ==
@@ -115,8 +124,10 @@ method global$fun_unsafe_binary_search_fixed$fun_take$T_class_pkg$kotlin$collect
   returns (ret$0: Ref)
   requires acc(local$arr.special$size, write)
   requires dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures acc(local$arr.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$arr.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$arr), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var anonymous$0: Ref
@@ -175,11 +186,14 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
+

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -16,6 +16,8 @@ method global$fun_isString$fun_take$NT_Any$return$T_Boolean(local$x: Ref)
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -37,6 +39,8 @@ method global$fun_isString$fun_take$T_Any$return$T_Boolean(local$obj: Ref)
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -58,7 +62,7 @@ field class_Foo$member_bar: Ref
 method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_bar, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_constructorReturnType$fun_take$$return$T_Boolean()
@@ -79,8 +83,8 @@ field class_Foo$member_bar: Ref
 
 method global$fun_subtypeSuperType$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Foo$member_bar, wildcard)
-  ensures acc(local$bar.class_Foo$member_bar, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
   ensures true ==>
     dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Foo())
@@ -95,16 +99,15 @@ field class_Foo$member_bar: Ref
 
 method global$fun_typeOfField$fun_take$T_class_global$class_Foo$return$T_Boolean(local$foo: Ref)
   returns (ret$0: Ref)
-  requires acc(local$foo.class_Foo$member_bar, wildcard)
-  ensures acc(local$foo.class_Foo$member_bar, wildcard)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$boolFromRef(ret$0) == true
 {
   var anonymous$0: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
+  unfold acc(T_class_global$class_Foo(local$foo), wildcard)
   anonymous$0 := local$foo.class_Foo$member_bar
-  inhale acc(anonymous$0.class_Foo$member_bar, wildcard)
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_Bar())
   if (dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_Bar())) {
     ret$0 := dom$RuntimeType$boolToRef(true)
     goto label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -19,8 +19,10 @@ method global$fun_initialization$fun_take$T_class_pkg$kotlin$collections$global$
   returns (ret$0: Ref)
   requires acc(local$l.special$size, write)
   requires dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures acc(local$l.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var local0$myList: Ref
@@ -37,6 +39,7 @@ method pkg$kotlin$collections$global$fun_emptyList$fun_take$$return$T_class_pkg$
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_List())
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(ret), wildcard)
   ensures dom$RuntimeType$intFromRef(ret.special$size) == 0
 
 
@@ -47,8 +50,10 @@ method global$fun_add_get$fun_take$T_class_pkg$kotlin$collections$global$class_M
   returns (ret$0: Ref)
   requires acc(local$l.special$size, write)
   requires dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(local$l), wildcard)
   ensures acc(local$l.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var anonymous$0: Ref
@@ -67,8 +72,10 @@ method pkg$kotlin$collections$class_MutableList$fun_add$fun_take$T_class_pkg$kot
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size)) + 1
@@ -79,11 +86,13 @@ method pkg$kotlin$collections$class_MutableList$fun_get$fun_take$T_class_pkg$kot
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -96,8 +105,10 @@ method global$fun_last_or_null$fun_take$T_class_pkg$kotlin$collections$global$cl
   returns (ret$0: Ref)
   requires acc(local$l.special$size, write)
   requires dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures acc(local$l.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$intType()))
 {
   var local0$size: Ref
@@ -122,11 +133,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -139,8 +152,10 @@ method global$fun_is_empty$fun_take$T_class_pkg$kotlin$collections$global$class_
   returns (ret$0: Ref)
   requires acc(local$l.special$size, write)
   requires dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures acc(local$l.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   var anonymous$0: Ref
@@ -160,11 +175,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -174,8 +191,10 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -194,10 +213,14 @@ method global$fun_nullable_list$fun_take$NT_class_pkg$kotlin$collections$global$
     acc(local$l.special$size, write)
   requires local$l != dom$RuntimeType$nullValue() ==>
     dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  requires local$l != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures local$l != dom$RuntimeType$nullValue() ==>
     acc(local$l.special$size, write)
   ensures local$l != dom$RuntimeType$nullValue() ==>
     dom$RuntimeType$intFromRef(local$l.special$size) >= 0
+  ensures local$l != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$collections$global$class_List(local$l), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var anonymous$0: Ref
@@ -225,11 +248,13 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   requires dom$RuntimeType$intFromRef(local$index) >= 0
   requires dom$RuntimeType$intFromRef(this.special$size) >
     dom$RuntimeType$intFromRef(local$index)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -239,8 +264,10 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_List(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -248,3 +275,4 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size) == 0
   ensures !dom$RuntimeType$boolFromRef(ret) ==>
     dom$RuntimeType$intFromRef(this.special$size) > 0
+

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -106,10 +106,14 @@ method global$fun_isNullOrEmpty$fun_take$NT_class_pkg$kotlin$collections$global$
     acc(local$collection.special$size, write)
   requires local$collection != dom$RuntimeType$nullValue() ==>
     dom$RuntimeType$intFromRef(local$collection.special$size) >= 0
+  requires local$collection != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$collections$global$class_Collection(local$collection), wildcard)
   ensures local$collection != dom$RuntimeType$nullValue() ==>
     acc(local$collection.special$size, write)
   ensures local$collection != dom$RuntimeType$nullValue() ==>
     dom$RuntimeType$intFromRef(local$collection.special$size) >= 0
+  ensures local$collection != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$collections$global$class_Collection(local$collection), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$boolFromRef(ret$0) == false ==>
     local$collection != dom$RuntimeType$nullValue()
@@ -128,8 +132,10 @@ method pkg$kotlin$collections$class_Collection$fun_isEmpty$fun_take$T_class_pkg$
   returns (ret: Ref)
   requires acc(this.special$size, write)
   requires dom$RuntimeType$intFromRef(this.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_Collection(this), wildcard)
   ensures acc(this.special$size, write)
   ensures dom$RuntimeType$intFromRef(this.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_Collection(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
@@ -137,3 +143,4 @@ method pkg$kotlin$collections$class_Collection$fun_isEmpty$fun_take$T_class_pkg$
     dom$RuntimeType$intFromRef(this.special$size) == 0
   ensures !dom$RuntimeType$boolFromRef(ret) ==>
     dom$RuntimeType$intFromRef(this.special$size) > 0
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/as_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/as_operator.fir.diag.txt
@@ -1,11 +1,15 @@
 /as_operator.kt:(38,44): info: Generated Viper text for testAs:
 method global$fun_testAs$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$foo: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Bar())
+  ensures acc(T_class_global$class_Bar(ret$0), wildcard)
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
   ret$0 := local$foo
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Bar())
+  inhale acc(T_class_global$class_Bar(ret$0), wildcard)
   goto label$ret$0
   label label$ret$0
 }
@@ -13,11 +17,19 @@ method global$fun_testAs$fun_take$T_class_global$class_Foo$return$T_class_global
 /as_operator.kt:(78,92): info: Generated Viper text for testNullableAs:
 method global$fun_testNullableAs$fun_take$NT_class_global$class_Foo$return$NT_class_global$class_Bar(local$foo: Ref)
   returns (ret$0: Ref)
+  requires local$foo != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures local$foo != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Foo()))
   ret$0 := local$foo
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  inhale ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
   goto label$ret$0
   label label$ret$0
 }
@@ -25,7 +37,11 @@ method global$fun_testNullableAs$fun_take$NT_class_global$class_Foo$return$NT_cl
 /as_operator.kt:(129,139): info: Generated Viper text for testSafeAs:
 method global$fun_testSafeAs$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Bar(local$foo: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
   if (dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Bar())) {
@@ -33,6 +49,8 @@ method global$fun_testSafeAs$fun_take$T_class_global$class_Foo$return$NT_class_g
   } else {
     ret$0 := dom$RuntimeType$nullValue()}
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  inhale ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
   goto label$ret$0
   label label$ret$0
 }
@@ -40,7 +58,13 @@ method global$fun_testSafeAs$fun_take$T_class_global$class_Foo$return$NT_class_g
 /as_operator.kt:(175,193): info: Generated Viper text for testNullableSafeAs:
 method global$fun_testNullableSafeAs$fun_take$NT_class_global$class_Foo$return$NT_class_global$class_Bar(local$foo: Ref)
   returns (ret$0: Ref)
+  requires local$foo != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures local$foo != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Foo()))
   if (dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Bar())) {
@@ -48,6 +72,8 @@ method global$fun_testNullableSafeAs$fun_take$NT_class_global$class_Foo$return$N
   } else {
     ret$0 := dom$RuntimeType$nullValue()}
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Bar()))
+  inhale ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_Bar(ret$0), wildcard)
   goto label$ret$0
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
@@ -4,20 +4,20 @@ field class_Foo$member_a: Ref
 method class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(local$b: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_a, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$x1: Ref,
   local$x2: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_a, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$n: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_a, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
@@ -32,17 +32,15 @@ method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
   var local0$test: Ref
   ret$0 := dom$RuntimeType$unitValue()
   local0$f1 := class_Foo$constructor$fun_take$T_Boolean$return$T_class_global$class_Foo(dom$RuntimeType$boolToRef(true))
+  unfold acc(T_class_global$class_Foo(local0$f1), wildcard)
   local0$shouldBeOne := local0$f1.class_Foo$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$shouldBeOne),
-    dom$RuntimeType$intType())
   local0$f2 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(dom$RuntimeType$intToRef(42))
+  unfold acc(T_class_global$class_Foo(local0$f2), wildcard)
   local0$shouldBeAnswer := local0$f2.class_Foo$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$shouldBeAnswer),
-    dom$RuntimeType$intType())
   local0$f3 := class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(dom$RuntimeType$intToRef(10),
     dom$RuntimeType$intToRef(32))
+  unfold acc(T_class_global$class_Foo(local0$f3), wildcard)
   local0$test := local0$f3.class_Foo$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$test), dom$RuntimeType$intType())
   label label$ret$0
 }
 
@@ -52,13 +50,13 @@ field class_Bar$member_a: Ref
 method class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(local$b: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
-  ensures acc(ret.class_Bar$member_a, wildcard)
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
 
 
 method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
-  ensures acc(ret.class_Bar$member_a, wildcard)
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
   ensures ret.class_Bar$member_a == local$a
 
 
@@ -72,12 +70,10 @@ method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()
   var local0$shouldBeAnswer: Ref
   ret$0 := dom$RuntimeType$unitValue()
   local0$b1 := class_Bar$constructor$fun_take$T_Boolean$return$T_class_global$class_Bar(dom$RuntimeType$boolToRef(false))
+  unfold acc(T_class_global$class_Bar(local0$b1), wildcard)
   local0$shouldBeZero := local0$b1.class_Bar$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$shouldBeZero),
-    dom$RuntimeType$intType())
   local0$b2 := class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(dom$RuntimeType$intToRef(42))
+  unfold acc(T_class_global$class_Bar(local0$b2), wildcard)
   local0$shouldBeAnswer := local0$b2.class_Bar$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$shouldBeAnswer),
-    dom$RuntimeType$intType())
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -7,8 +7,7 @@ method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Fo
   local$b: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_a, wildcard)
-  ensures acc(ret.class_Foo$member_b, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
   ensures ret.class_Foo$member_a == local$a
   ensures ret.class_Foo$member_b == local$b
 
@@ -16,18 +15,17 @@ method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Fo
 method global$fun_createFoo$fun_take$$return$T_class_global$class_Foo()
   returns (ret$0: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret$0.class_Foo$member_a, wildcard)
-  ensures acc(ret$0.class_Foo$member_b, wildcard)
+  ensures acc(T_class_global$class_Foo(ret$0), wildcard)
 {
   var local0$f: Ref
   var local0$fa: Ref
   var local0$fb: Ref
   local0$f := class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(dom$RuntimeType$intToRef(10),
     dom$RuntimeType$intToRef(20))
+  unfold acc(T_class_global$class_Foo(local0$f), wildcard)
   local0$fa := local0$f.class_Foo$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$fa), dom$RuntimeType$intType())
+  unfold acc(T_class_global$class_Foo(local0$f), wildcard)
   local0$fb := local0$f.class_Foo$member_b
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$fb), dom$RuntimeType$intType())
   ret$0 := local0$f
   goto label$ret$0
   label label$ret$0
@@ -39,11 +37,11 @@ field class_Bar$member_a: Ref
 method class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_global$class_Bar(local$a: Ref)
   returns (ret: Ref)
   requires local$a != dom$RuntimeType$nullValue() ==>
-    acc(local$a.class_Bar$member_a, wildcard)
+    acc(T_class_global$class_Bar(local$a), wildcard)
   ensures local$a != dom$RuntimeType$nullValue() ==>
-    acc(local$a.class_Bar$member_a, wildcard)
+    acc(T_class_global$class_Bar(local$a), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
-  ensures acc(ret.class_Bar$member_a, wildcard)
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
   ensures ret.class_Bar$member_a == local$a
 
 
@@ -64,8 +62,7 @@ field class_Baz$member_c: Ref
 method class_Baz$constructor$fun_take$T_Int$return$T_class_global$class_Baz(local$c: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
-  ensures acc(ret.class_Baz$member_c, wildcard)
-  ensures acc(ret.class_Baz$member_a, wildcard)
+  ensures acc(T_class_global$class_Baz(ret), wildcard)
   ensures ret.class_Baz$member_c == local$c
 
 
@@ -77,9 +74,9 @@ method global$fun_createBaz$fun_take$$return$T_Unit() returns (ret$0: Ref)
   var local0$bc: Ref
   ret$0 := dom$RuntimeType$unitValue()
   local0$b := class_Baz$constructor$fun_take$T_Int$return$T_class_global$class_Baz(dom$RuntimeType$intToRef(10))
+  unfold acc(T_class_global$class_Baz(local0$b), wildcard)
   local0$ba := local0$b.class_Baz$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$ba), dom$RuntimeType$intType())
+  unfold acc(T_class_global$class_Baz(local0$b), wildcard)
   local0$bc := local0$b.class_Baz$member_c
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$bc), dom$RuntimeType$intType())
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -4,13 +4,13 @@ field class_IntWrapper$member_n: Ref
 method class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_IntWrapper())
-  ensures acc(ret.class_IntWrapper$member_n, wildcard)
+  ensures acc(T_class_global$class_IntWrapper(ret), wildcard)
   ensures ret.class_IntWrapper$member_n == local$n
 
 
 method class_IntWrapper$getter_succ(this: Ref) returns (ret: Ref)
-  requires acc(this.class_IntWrapper$member_n, wildcard)
-  ensures acc(this.class_IntWrapper$member_n, wildcard)
+  requires acc(T_class_global$class_IntWrapper(this), wildcard)
+  ensures acc(T_class_global$class_IntWrapper(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -34,12 +34,10 @@ field class_Foo$member_b: Ref
 
 method class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local$f: Ref)
   returns (ret: Ref)
-  requires acc(local$f.class_Foo$member_a, wildcard)
-  requires acc(local$f.class_Foo$member_b, wildcard)
-  ensures acc(local$f.class_Foo$member_a, wildcard)
-  ensures acc(local$f.class_Foo$member_b, wildcard)
+  requires acc(T_class_global$class_Foo(local$f), wildcard)
+  ensures acc(T_class_global$class_Foo(local$f), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
-  ensures acc(ret.class_Bar$member_f, wildcard)
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
   ensures ret.class_Bar$member_f == local$f
 
 
@@ -47,8 +45,7 @@ method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Fo
   local$b: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_a, wildcard)
-  ensures acc(ret.class_Foo$member_b, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
   ensures ret.class_Foo$member_a == local$a
   ensures ret.class_Foo$member_b == local$b
 
@@ -67,18 +64,14 @@ method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
   local0$foo := class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(dom$RuntimeType$intToRef(10),
     dom$RuntimeType$intToRef(20))
   local0$bar := class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_global$class_Bar(local0$foo)
+  unfold acc(T_class_global$class_Bar(local0$bar), wildcard)
   anonymous$0 := local0$bar.class_Bar$member_f
-  inhale acc(anonymous$0.class_Foo$member_a, wildcard)
-  inhale acc(anonymous$0.class_Foo$member_b, wildcard)
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_Foo())
+  unfold acc(T_class_global$class_Foo(anonymous$0), wildcard)
   local0$bfa := anonymous$0.class_Foo$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$bfa), dom$RuntimeType$intType())
+  unfold acc(T_class_global$class_Bar(local0$bar), wildcard)
   anonymous$1 := local0$bar.class_Bar$member_f
-  inhale acc(anonymous$1.class_Foo$member_a, wildcard)
-  inhale acc(anonymous$1.class_Foo$member_b, wildcard)
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$T_class_global$class_Foo())
+  unfold acc(T_class_global$class_Foo(anonymous$1), wildcard)
   local0$bfb := anonymous$1.class_Foo$member_b
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$bfb), dom$RuntimeType$intType())
   label label$ret$0
 }
 
@@ -90,22 +83,22 @@ field class_IntWrapperContainer$member_i: Ref
 method class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(local$n: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_IntWrapper())
-  ensures acc(ret.class_IntWrapper$member_n, wildcard)
+  ensures acc(T_class_global$class_IntWrapper(ret), wildcard)
   ensures ret.class_IntWrapper$member_n == local$n
 
 
 method class_IntWrapper$getter_succ(this: Ref) returns (ret: Ref)
-  requires acc(this.class_IntWrapper$member_n, wildcard)
-  ensures acc(this.class_IntWrapper$member_n, wildcard)
+  requires acc(T_class_global$class_IntWrapper(this), wildcard)
+  ensures acc(T_class_global$class_IntWrapper(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(local$i: Ref)
   returns (ret: Ref)
-  requires acc(local$i.class_IntWrapper$member_n, wildcard)
-  ensures acc(local$i.class_IntWrapper$member_n, wildcard)
+  requires acc(T_class_global$class_IntWrapper(local$i), wildcard)
+  ensures acc(T_class_global$class_IntWrapper(local$i), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_IntWrapperContainer())
-  ensures acc(ret.class_IntWrapperContainer$member_i, wildcard)
+  ensures acc(T_class_global$class_IntWrapperContainer(ret), wildcard)
   ensures ret.class_IntWrapperContainer$member_i == local$i
 
 
@@ -120,9 +113,8 @@ method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()
   ret$0 := dom$RuntimeType$unitValue()
   anonymous$0 := class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_IntWrapper(dom$RuntimeType$intToRef(42))
   local0$wrapper := class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWrapper$return$T_class_global$class_IntWrapperContainer(anonymous$0)
+  unfold acc(T_class_global$class_IntWrapperContainer(local0$wrapper), wildcard)
   anonymous$1 := local0$wrapper.class_IntWrapperContainer$member_i
-  inhale acc(anonymous$1.class_IntWrapper$member_n, wildcard)
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$T_class_global$class_IntWrapper())
   local0$succ := class_IntWrapper$getter_succ(anonymous$1)
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_setters.fir.diag.txt
@@ -6,14 +6,19 @@ field class_AlwaysPlusOne$member_num: Ref
 method class_AlwaysPlusOne$constructor$fun_take$$return$T_class_global$class_AlwaysPlusOne()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_AlwaysPlusOne())
+  ensures acc(T_class_global$class_AlwaysPlusOne(ret), wildcard)
 
 
 method class_AlwaysPlusOne$getter_num(this: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_AlwaysPlusOne(this), wildcard)
+  ensures acc(T_class_global$class_AlwaysPlusOne(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_AlwaysPlusOne$setter_num(this: Ref, local$value: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_AlwaysPlusOne(this), wildcard)
+  ensures acc(T_class_global$class_AlwaysPlusOne(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
@@ -38,6 +43,7 @@ field class_Person$member_age: Ref
 method class_Person$constructor$fun_take$T_Int$return$T_class_global$class_Person(local$age: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Person())
+  ensures acc(T_class_global$class_Person(ret), wildcard)
 
 
 method global$fun_testSetter$fun_take$$return$T_Unit() returns (ret$0: Ref)
@@ -65,11 +71,15 @@ field class_Foo$member_b: Ref
 method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
 
 
 method class_Foo$constructor$fun_take$T_class_global$class_Bar$return$T_class_global$class_Foo(local$b: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_Bar(local$b), wildcard)
+  ensures acc(T_class_global$class_Bar(local$b), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_testSetterCascade$fun_take$$return$T_Unit()
@@ -86,6 +96,7 @@ method global$fun_testSetterCascade$fun_take$$return$T_Unit()
   anonymous$1 := local0$f.class_Foo$member_b
   exhale acc(local0$f.class_Foo$member_b, write)
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$T_class_global$class_Bar())
+  inhale acc(T_class_global$class_Bar(anonymous$1), wildcard)
   inhale acc(anonymous$1.class_Bar$member_a, write)
   anonymous$1.class_Bar$member_a := dom$RuntimeType$intToRef(42)
   exhale acc(anonymous$1.class_Bar$member_a, write)
@@ -98,13 +109,18 @@ field class_Baz$member__a: Ref
 method class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
+  ensures acc(T_class_global$class_Baz(ret), wildcard)
 
 
 method class_Baz$getter_a(this: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_Baz(this), wildcard)
+  ensures acc(T_class_global$class_Baz(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_Baz$setter_a(this: Ref, local$value: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_Baz(this), wildcard)
+  ensures acc(T_class_global$class_Baz(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
@@ -126,6 +142,7 @@ field class_Bar$member_a: Ref
 method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(local$a: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
 
 
 method global$fun_testSetterLambda$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/exp_side_effects.fir.diag.txt
@@ -4,11 +4,13 @@ field class_Foo$member_x: Ref
 method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   returns (ret$0: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_Foo())
+  ensures acc(T_class_global$class_Foo(ret$0), wildcard)
 {
   ret$0 := class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(dom$RuntimeType$intToRef(0))
   goto label$ret$0
@@ -30,6 +32,7 @@ field class_Foo$member_x: Ref
 method global$fun_get_foo$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_side_effect$fun_take$$return$T_Int() returns (ret: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -47,14 +47,14 @@ field class_Foo$member_x: Ref
 method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_x, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
   ensures ret.class_Foo$member_x == local$x
 
 
 method global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -76,22 +76,22 @@ field class_Foo$member_x: Ref
 method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_x, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
   ensures ret.class_Foo$member_x == local$x
 
 
 method global$ext_getter_strange$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method global$ext_setter_strange$fun_take$T_class_global$class_Foo$T_Int$return$T_Unit(this: Ref,
   local$v: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -202,13 +202,6 @@ field class_Foo$member_x: Ref
 
 field special$function_object_call_counter: Int
 
-function T_class_global$class_Foo$get$class_Foo$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_Foo(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_Foo(special$get$function$subject), write) in
-    special$get$function$subject.class_Foo$member_x)
-}
-
 function special$andBools(arg1: Ref, arg2: Ref): Ref
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(result), dom$RuntimeType$boolType())
   ensures dom$RuntimeType$boolFromRef(result) ==
@@ -294,13 +287,15 @@ function special$timesInts(arg1: Ref, arg2: Ref): Ref
 
 
 predicate T_class_global$class_Foo(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.class_Foo$member_x, wildcard)
+  acc(special$class$predicate$subject.class_Foo$member_x, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_Foo$member_x),
+  dom$RuntimeType$intType())
 }
 
 method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_x, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
   ensures ret.class_Foo$member_x == local$x
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -2,6 +2,10 @@
 method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$f: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Bar(this), wildcard)
+  requires acc(T_class_global$class_Foo(local$f), wildcard)
+  ensures acc(T_class_global$class_Bar(this), wildcard)
+  ensures acc(T_class_global$class_Foo(local$f), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_Bar())
@@ -14,6 +18,10 @@ method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_
 method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
   local$b: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Bar(this), wildcard)
+  requires acc(T_class_global$class_Bar(local$b), wildcard)
+  ensures acc(T_class_global$class_Bar(this), wildcard)
+  ensures acc(T_class_global$class_Bar(local$b), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_Bar())
@@ -25,6 +33,8 @@ method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_
 /function_overloading.kt:(79,88): info: Generated Viper text for fakePrint:
 method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Bar(local$b), wildcard)
+  ensures acc(T_class_global$class_Bar(local$b), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$b), dom$RuntimeType$T_class_global$class_Bar())
@@ -35,6 +45,8 @@ method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(loca
 /function_overloading.kt:(106,115): info: Generated Viper text for fakePrint:
 method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$f), wildcard)
+  ensures acc(T_class_global$class_Foo(local$f), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$f), dom$RuntimeType$T_class_global$class_Foo())
@@ -66,11 +78,13 @@ method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Ref)
 method class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
 
 
 method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Ref)
@@ -85,11 +99,15 @@ method global$fun_fakePrint$fun_take$T_Int$return$T_Unit(local$value: Ref)
 
 method global$fun_fakePrint$fun_take$T_class_global$class_Bar$return$T_Unit(local$b: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_Bar(local$b), wildcard)
+  ensures acc(T_class_global$class_Bar(local$b), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
 method global$fun_fakePrint$fun_take$T_class_global$class_Foo$return$T_Unit(local$f: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_Foo(local$f), wildcard)
+  ensures acc(T_class_global$class_Foo(local$f), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
@@ -117,23 +135,33 @@ method global$fun_testGlobalScopeOverloading$fun_take$$return$T_Unit()
 method class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
+  ensures acc(T_class_global$class_Bar(ret), wildcard)
 
 
 method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
   local$b: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_Bar(this), wildcard)
+  requires acc(T_class_global$class_Bar(local$b), wildcard)
+  ensures acc(T_class_global$class_Bar(this), wildcard)
+  ensures acc(T_class_global$class_Bar(local$b), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
 method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$f: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_Bar(this), wildcard)
+  requires acc(T_class_global$class_Foo(local$f), wildcard)
+  ensures acc(T_class_global$class_Bar(this), wildcard)
+  ensures acc(T_class_global$class_Foo(local$f), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
 method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_testClassFunctionOverloading$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/generics.fir.diag.txt
@@ -4,6 +4,8 @@ field class_Box$member_t: Ref
 method class_Box$fun_genericMethod$fun_take$T_class_global$class_Box$NT_Any$return$NT_Any(this: Ref,
   local$x: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Box(this), wildcard)
+  ensures acc(T_class_global$class_Box(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$anyType()))
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_Box())
@@ -19,6 +21,7 @@ field class_Box$member_t: Ref
 method class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Box())
+  ensures acc(T_class_global$class_Box(ret), wildcard)
 
 
 method global$fun_createBox$fun_take$$return$T_Int() returns (ret$0: Ref)
@@ -51,6 +54,7 @@ field class_Box$member_t: Ref
 method class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(local$t: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Box())
+  ensures acc(T_class_global$class_Box(ret), wildcard)
 
 
 method global$fun_setGenericField$fun_take$$return$T_Unit()
@@ -100,6 +104,8 @@ field class_Box$member_t: Ref
 
 method global$fun_genericAsIfCondition$fun_take$T_class_global$class_Box$return$T_Int(local$box: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Box(local$box), wildcard)
+  ensures acc(T_class_global$class_Box(local$box), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   var anonymous$0: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance.fir.diag.txt
@@ -7,15 +7,13 @@ field class_Foo$member_y: Ref
 
 method class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret$0: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  requires acc(this.class_Foo$member_y, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_y, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_Foo())
+  unfold acc(T_class_global$class_Foo(this), wildcard)
   ret$0 := this.class_Foo$member_y
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
   goto label$ret$0
   label label$ret$0
 }
@@ -31,21 +29,18 @@ field class_Foo$member_y: Ref
 
 method class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret$0: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  requires acc(this.class_Foo$member_y, wildcard)
-  requires acc(this.class_Bar$member_z, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_y, wildcard)
-  ensures acc(this.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(this), wildcard)
+  ensures acc(T_class_global$class_Bar(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   var anonymous$0: Ref
   var anonymous$1: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_Bar())
+  unfold acc(T_class_global$class_Bar(this), wildcard)
+  unfold acc(T_class_global$class_Foo(this), wildcard)
   anonymous$0 := this.class_Foo$member_x
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$intType())
+  unfold acc(T_class_global$class_Bar(this), wildcard)
   anonymous$1 := this.class_Bar$member_z
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
   ret$0 := special$plusInts(anonymous$0, anonymous$1)
   goto label$ret$0
   label label$ret$0
@@ -62,21 +57,15 @@ field class_Foo$member_y: Ref
 
 method class_Foo$fun_getY$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  requires acc(this.class_Foo$member_y, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_y, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method global$fun_callSuperMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Bar())
@@ -96,12 +85,8 @@ field class_Foo$member_y: Ref
 
 method global$fun_accessSuperField$fun_take$T_class_global$class_Bar$return$T_Boolean(local$bar: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Bar())
@@ -124,17 +109,13 @@ field class_Foo$member_y: Ref
 
 method global$fun_accessNewField$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Bar())
+  unfold acc(T_class_global$class_Bar(local$bar), wildcard)
   ret$0 := local$bar.class_Bar$member_z
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
   goto label$ret$0
   label label$ret$0
 }
@@ -150,23 +131,15 @@ field class_Foo$member_y: Ref
 
 method class_Bar$fun_sum$fun_take$T_class_global$class_Bar$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  requires acc(this.class_Foo$member_y, wildcard)
-  requires acc(this.class_Bar$member_z, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_y, wildcard)
-  ensures acc(this.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(this), wildcard)
+  ensures acc(T_class_global$class_Bar(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method global$fun_callNewMethod$fun_take$T_class_global$class_Bar$return$T_Int(local$bar: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Bar())
@@ -186,12 +159,8 @@ field class_Foo$member_y: Ref
 
 method global$fun_setSuperField$fun_take$T_class_global$class_Bar$return$T_Unit(local$bar: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Foo$member_x, wildcard)
-  requires acc(local$bar.class_Foo$member_y, wildcard)
-  requires acc(local$bar.class_Bar$member_z, wildcard)
-  ensures acc(local$bar.class_Foo$member_x, wildcard)
-  ensures acc(local$bar.class_Foo$member_y, wildcard)
-  ensures acc(local$bar.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Bar())
@@ -213,17 +182,15 @@ field class_Foo$member_y: Ref
 
 method global$fun_accessSuperSuperField$fun_take$T_class_global$class_Baz$return$T_Int(local$baz: Ref)
   returns (ret$0: Ref)
-  requires acc(local$baz.class_Foo$member_x, wildcard)
-  requires acc(local$baz.class_Foo$member_y, wildcard)
-  requires acc(local$baz.class_Bar$member_z, wildcard)
-  ensures acc(local$baz.class_Foo$member_x, wildcard)
-  ensures acc(local$baz.class_Foo$member_y, wildcard)
-  ensures acc(local$baz.class_Bar$member_z, wildcard)
+  requires acc(T_class_global$class_Baz(local$baz), wildcard)
+  ensures acc(T_class_global$class_Baz(local$baz), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$baz), dom$RuntimeType$T_class_global$class_Baz())
+  unfold acc(T_class_global$class_Baz(local$baz), wildcard)
+  unfold acc(T_class_global$class_Bar(local$baz), wildcard)
+  unfold acc(T_class_global$class_Foo(local$baz), wildcard)
   ret$0 := local$baz.class_Foo$member_x
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
   goto label$ret$0
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance_fields.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance_fields.fir.diag.txt
@@ -5,15 +5,17 @@ field class_A$member_fieldOverride: Ref
 
 method class_B$constructor$fun_take$T_class_global$class_FieldB$return$T_class_global$class_B(local$fieldOverride: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_FieldB(local$fieldOverride), wildcard)
+  ensures acc(T_class_global$class_FieldB(local$fieldOverride), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_B())
-  ensures acc(ret.class_A$member_fieldNotOverride, wildcard)
-  ensures acc(ret.class_A$member_fieldOverride, wildcard)
+  ensures acc(T_class_global$class_B(ret), wildcard)
   ensures ret.class_A$member_fieldOverride == local$fieldOverride
 
 
 method class_FieldB$constructor$fun_take$$return$T_class_global$class_FieldB()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_FieldB())
+  ensures acc(T_class_global$class_FieldB(ret), wildcard)
 
 
 method global$fun_createB$fun_take$$return$T_Unit() returns (ret$0: Ref)
@@ -27,12 +29,13 @@ method global$fun_createB$fun_take$$return$T_Unit() returns (ret$0: Ref)
   ret$0 := dom$RuntimeType$unitValue()
   local0$fieldB := class_FieldB$constructor$fun_take$$return$T_class_global$class_FieldB()
   local0$b := class_B$constructor$fun_take$T_class_global$class_FieldB$return$T_class_global$class_B(local0$fieldB)
+  unfold acc(T_class_global$class_B(local0$b), wildcard)
+  unfold acc(T_class_global$class_A(local0$b), wildcard)
   anonymous$0 := local0$b.class_A$member_fieldOverride
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_FieldA())
   local0$fieldOverride := anonymous$0
+  unfold acc(T_class_global$class_B(local0$b), wildcard)
+  unfold acc(T_class_global$class_A(local0$b), wildcard)
   local0$fieldNotOverride := local0$b.class_A$member_fieldNotOverride
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$fieldNotOverride),
-    dom$RuntimeType$T_class_global$class_C())
   label label$ret$0
 }
 
@@ -42,25 +45,25 @@ field class_FirstBackingFieldClass$member_x: Ref
 method class_FirstBackingFieldClass$constructor$fun_take$$return$T_class_global$class_FirstBackingFieldClass()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_FirstBackingFieldClass())
-  ensures acc(ret.class_FirstBackingFieldClass$member_x, wildcard)
+  ensures acc(T_class_global$class_FirstBackingFieldClass(ret), wildcard)
 
 
 method class_NoBackingFieldClass$constructor$fun_take$$return$T_class_global$class_NoBackingFieldClass()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_NoBackingFieldClass())
-  ensures acc(ret.class_FirstBackingFieldClass$member_x, wildcard)
+  ensures acc(T_class_global$class_NoBackingFieldClass(ret), wildcard)
 
 
 method class_NoBackingFieldClass$getter_x(this: Ref) returns (ret: Ref)
-  requires acc(this.class_FirstBackingFieldClass$member_x, wildcard)
-  ensures acc(this.class_FirstBackingFieldClass$member_x, wildcard)
+  requires acc(T_class_global$class_NoBackingFieldClass(this), wildcard)
+  ensures acc(T_class_global$class_NoBackingFieldClass(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_SecondBackingFieldClass$constructor$fun_take$T_Int$return$T_class_global$class_SecondBackingFieldClass(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_SecondBackingFieldClass())
-  ensures acc(ret.class_FirstBackingFieldClass$member_x, wildcard)
+  ensures acc(T_class_global$class_SecondBackingFieldClass(ret), wildcard)
   ensures ret.class_FirstBackingFieldClass$member_x == local$x
 
 
@@ -76,13 +79,15 @@ method global$fun_createBFsAndNoBF$fun_take$$return$T_Unit()
   var local0$sbfx: Ref
   ret$0 := dom$RuntimeType$unitValue()
   local0$fbf := class_FirstBackingFieldClass$constructor$fun_take$$return$T_class_global$class_FirstBackingFieldClass()
+  unfold acc(T_class_global$class_FirstBackingFieldClass(local0$fbf), wildcard)
   local0$fbfx := local0$fbf.class_FirstBackingFieldClass$member_x
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$fbfx), dom$RuntimeType$intType())
   local0$nbf := class_NoBackingFieldClass$constructor$fun_take$$return$T_class_global$class_NoBackingFieldClass()
   local0$nbfx := class_NoBackingFieldClass$getter_x(local0$nbf)
   local0$sbf := class_SecondBackingFieldClass$constructor$fun_take$T_Int$return$T_class_global$class_SecondBackingFieldClass(dom$RuntimeType$intToRef(10))
+  unfold acc(T_class_global$class_SecondBackingFieldClass(local0$sbf), wildcard)
+  unfold acc(T_class_global$class_NoBackingFieldClass(local0$sbf), wildcard)
+  unfold acc(T_class_global$class_FirstBackingFieldClass(local0$sbf), wildcard)
   local0$sbfx := local0$sbf.class_FirstBackingFieldClass$member_x
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$sbfx), dom$RuntimeType$intType())
   label label$ret$0
 }
 
@@ -92,7 +97,7 @@ field class_X$member_a: Ref
 method class_Y$constructor$fun_take$T_Int$return$T_class_global$class_Y(local$a: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Y())
-  ensures acc(ret.class_X$member_a, wildcard)
+  ensures acc(T_class_global$class_Y(ret), wildcard)
 
 
 method global$fun_createY$fun_take$$return$T_Unit() returns (ret$0: Ref)
@@ -102,7 +107,8 @@ method global$fun_createY$fun_take$$return$T_Unit() returns (ret$0: Ref)
   var local0$ya: Ref
   ret$0 := dom$RuntimeType$unitValue()
   local0$y := class_Y$constructor$fun_take$T_Int$return$T_class_global$class_Y(dom$RuntimeType$intToRef(10))
+  unfold acc(T_class_global$class_Y(local0$y), wildcard)
+  unfold acc(T_class_global$class_X(local0$y), wildcard)
   local0$ya := local0$y.class_X$member_a
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$ya), dom$RuntimeType$intType())
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
@@ -1,19 +1,27 @@
 /interface.kt:(65,80): info: Generated Viper text for test_properties:
 method class_Foo$getter_valProp(this: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_Foo$getter_varProp(this: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_Foo$setter_varProp(this: Ref, local$value: Ref)
   returns (ret: Ref)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
 method global$fun_test_properties$fun_take$T_class_global$class_Foo$return$T_Unit(local$foo: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var anonymous$0: Ref
@@ -33,17 +41,21 @@ method global$fun_test_properties$fun_take$T_class_global$class_Foo$return$T_Uni
 field class_Impl$member_number: Ref
 
 method class_First$getter_number(this: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_First(this), wildcard)
+  ensures acc(T_class_global$class_First(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_Impl$constructor$fun_take$T_Int$return$T_class_global$class_Impl(local$number: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl())
-  ensures acc(ret.class_Impl$member_number, wildcard)
+  ensures acc(T_class_global$class_Impl(ret), wildcard)
   ensures ret.class_Impl$member_number == local$number
 
 
 method class_Second$getter_number(this: Ref) returns (ret: Ref)
+  requires acc(T_class_global$class_Second(this), wildcard)
+  ensures acc(T_class_global$class_Second(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -54,8 +66,7 @@ method global$fun_createImpl$fun_take$$return$T_Unit() returns (ret$0: Ref)
   var local0$implField: Ref
   ret$0 := dom$RuntimeType$unitValue()
   local0$impl := class_Impl$constructor$fun_take$T_Int$return$T_class_global$class_Impl(dom$RuntimeType$intToRef(-1))
+  unfold acc(T_class_global$class_Impl(local0$impl), wildcard)
   local0$implField := local0$impl.class_Impl$member_number
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$implField),
-    dom$RuntimeType$intType())
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -3,13 +3,13 @@ field class_Foo$member_x: Ref
 
 method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret$0: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_Foo())
+  unfold acc(T_class_global$class_Foo(this), wildcard)
   ret$0 := this.class_Foo$member_x
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$intType())
   goto label$ret$0
   label label$ret$0
 }
@@ -19,8 +19,8 @@ field class_Foo$member_x: Ref
 
 method class_Foo$fun_call_member_fun$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
   returns (ret$0: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var anonymous$0: Ref
@@ -32,8 +32,8 @@ method class_Foo$fun_call_member_fun$fun_take$T_class_global$class_Foo$return$T_
 
 method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -42,18 +42,18 @@ field class_Foo$member_x: Ref
 
 method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method class_Foo$fun_sibling_call$fun_take$T_class_global$class_Foo$T_class_global$class_Foo$return$T_Unit(this: Ref,
   local$other: Ref)
   returns (ret$0: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  requires acc(local$other.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
-  ensures acc(local$other.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  requires acc(T_class_global$class_Foo(local$other), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(local$other), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var anonymous$0: Ref
@@ -70,14 +70,14 @@ field class_Foo$member_x: Ref
 method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
-  ensures acc(ret.class_Foo$member_x, wildcard)
+  ensures acc(T_class_global$class_Foo(ret), wildcard)
   ensures ret.class_Foo$member_x == local$x
 
 
 method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/nullable.fir.diag.txt
@@ -135,9 +135,9 @@ field pkg$kotlin$class_String$member_length: Ref
 method global$fun_safe_call$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: Ref)
   returns (ret$0: Ref)
   requires local$s != dom$RuntimeType$nullValue() ==>
-    acc(local$s.pkg$kotlin$class_String$member_length, wildcard)
+    acc(T_class_pkg$kotlin$global$class_String(local$s), wildcard)
   ensures local$s != dom$RuntimeType$nullValue() ==>
-    acc(local$s.pkg$kotlin$class_String$member_length, wildcard)
+    acc(T_class_pkg$kotlin$global$class_String(local$s), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$s), dom$RuntimeType$nullable(dom$RuntimeType$T_class_pkg$kotlin$global$class_String()))
@@ -156,6 +156,8 @@ method pkg$kotlin$class_Any$fun_hashCode$fun_take$T_Any$return$T_Int(this: Ref)
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -165,9 +167,9 @@ field pkg$kotlin$class_String$member_length: Ref
 method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_String$return$T_Unit(local$s: Ref)
   returns (ret$0: Ref)
   requires local$s != dom$RuntimeType$nullValue() ==>
-    acc(local$s.pkg$kotlin$class_String$member_length, wildcard)
+    acc(T_class_pkg$kotlin$global$class_String(local$s), wildcard)
   ensures local$s != dom$RuntimeType$nullValue() ==>
-    acc(local$s.pkg$kotlin$class_String$member_length, wildcard)
+    acc(T_class_pkg$kotlin$global$class_String(local$s), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   var local0$l: Ref
@@ -175,8 +177,8 @@ method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_S
   ret$0 := dom$RuntimeType$unitValue()
   if (local$s != dom$RuntimeType$nullValue()) {
     var anonymous$0: Ref
+    unfold acc(T_class_pkg$kotlin$global$class_String(local$s), wildcard)
     anonymous$0 := local$s.pkg$kotlin$class_String$member_length
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$intType())
     local0$l := anonymous$0
   } else {
     local0$l := dom$RuntimeType$nullValue()}
@@ -185,6 +187,8 @@ method global$fun_safe_call_property$fun_take$NT_class_pkg$kotlin$global$class_S
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -193,19 +197,19 @@ field class_Foo$member_v: Ref
 
 method class_Foo$fun_nullable$fun_take$T_class_global$class_Foo$return$NT_class_global$class_Foo(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_v, wildcard)
-  ensures acc(this.class_Foo$member_v, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Foo()))
   ensures ret != dom$RuntimeType$nullValue() ==>
-    acc(ret.class_Foo$member_v, wildcard)
+    acc(T_class_global$class_Foo(ret), wildcard)
 
 
 method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_Int(local$foo: Ref)
   returns (ret$0: Ref)
   requires local$foo != dom$RuntimeType$nullValue() ==>
-    acc(local$foo.class_Foo$member_v, wildcard)
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures local$foo != dom$RuntimeType$nullValue() ==>
-    acc(local$foo.class_Foo$member_v, wildcard)
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$intType()))
 {
   var anonymous$0: Ref
@@ -221,8 +225,8 @@ method global$fun_safe_call_chain$fun_take$NT_class_global$class_Foo$return$NT_I
     anonymous$0 := dom$RuntimeType$nullValue()}
   if (anonymous$0 != dom$RuntimeType$nullValue()) {
     var anonymous$2: Ref
+    unfold acc(T_class_global$class_Foo(anonymous$0), wildcard)
     anonymous$2 := anonymous$0.class_Foo$member_v
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$2), dom$RuntimeType$intType())
     ret$0 := anonymous$2
   } else {
     ret$0 := dom$RuntimeType$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates.fir.diag.txt
@@ -7,31 +7,12 @@ field class_Foo$member_y: Ref
 
 field class_Rec$member_next: Ref
 
-function T_class_global$class_Bar$get$class_Bar$member_foo(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_Bar(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_Bar(special$get$function$subject), write) in
-    special$get$function$subject.class_Bar$member_foo)
-}
-
-function T_class_global$class_Foo$get$class_Foo$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_Foo(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_Foo(special$get$function$subject), write) in
-    special$get$function$subject.class_Foo$member_x)
-}
-
-function T_class_global$class_Rec$get$class_Rec$member_next(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_Rec(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_Rec(special$get$function$subject), write) in
-    special$get$function$subject.class_Rec$member_next)
-}
-
 predicate T_class_global$class_Bar(special$class$predicate$subject: Ref) {
   acc(special$class$predicate$subject.class_Bar$member_foo, wildcard) &&
-  acc(T_class_global$class_Foo(special$class$predicate$subject.class_Bar$member_foo), write) &&
-  acc(T_class_global$class_Baz(special$class$predicate$subject), write)
+  acc(T_class_global$class_Foo(special$class$predicate$subject.class_Bar$member_foo), wildcard) &&
+  acc(T_class_global$class_Baz(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_Bar$member_foo),
+  dom$RuntimeType$T_class_global$class_Foo())
 }
 
 predicate T_class_global$class_Baz(special$class$predicate$subject: Ref) {
@@ -39,23 +20,27 @@ predicate T_class_global$class_Baz(special$class$predicate$subject: Ref) {
 }
 
 predicate T_class_global$class_Foo(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.class_Foo$member_x, wildcard)
+  acc(special$class$predicate$subject.class_Foo$member_x, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_Foo$member_x),
+  dom$RuntimeType$intType())
 }
 
 predicate T_class_global$class_Rec(special$class$predicate$subject: Ref) {
   acc(special$class$predicate$subject.class_Rec$member_next, wildcard) &&
   (special$class$predicate$subject.class_Rec$member_next !=
   dom$RuntimeType$nullValue() ==>
-  acc(T_class_global$class_Rec(special$class$predicate$subject.class_Rec$member_next), write))
+  acc(T_class_global$class_Rec(special$class$predicate$subject.class_Rec$member_next), wildcard)) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_Rec$member_next),
+  dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Rec()))
 }
 
 method global$fun_useFoo$fun_take$T_class_global$class_Bar$T_class_global$class_Rec$return$T_Unit(local$bar: Ref,
   local$rec: Ref)
   returns (ret$0: Ref)
-  requires acc(local$bar.class_Bar$member_foo, wildcard)
-  requires acc(local$rec.class_Rec$member_next, wildcard)
-  ensures acc(local$bar.class_Bar$member_foo, wildcard)
-  ensures acc(local$rec.class_Rec$member_next, wildcard)
+  requires acc(T_class_global$class_Bar(local$bar), wildcard)
+  requires acc(T_class_global$class_Rec(local$rec), wildcard)
+  ensures acc(T_class_global$class_Bar(local$bar), wildcard)
+  ensures acc(T_class_global$class_Rec(local$rec), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$bar), dom$RuntimeType$T_class_global$class_Bar())
@@ -69,43 +54,24 @@ field class_A$member_x: Ref
 
 field class_A$member_y: Ref
 
-function T_class_global$class_A$get$class_A$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_A(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_A(special$get$function$subject), write) in
-    special$get$function$subject.class_A$member_x)
-}
-
-function T_class_global$class_B$get$class_A$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_B(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_B(special$get$function$subject), write) in
-    T_class_global$class_A$get$class_A$member_x(special$get$function$subject))
-}
-
-function T_class_global$class_C$get$class_A$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_C(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), write) in
-    T_class_global$class_B$get$class_A$member_x(special$get$function$subject))
-}
-
 predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.class_A$member_x, wildcard)
+  acc(special$class$predicate$subject.class_A$member_x, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_x),
+  dom$RuntimeType$intType())
 }
 
 predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
-  acc(T_class_global$class_A(special$class$predicate$subject), write)
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard)
 }
 
 predicate T_class_global$class_C(special$class$predicate$subject: Ref) {
-  acc(T_class_global$class_B(special$class$predicate$subject), write)
+  acc(T_class_global$class_B(special$class$predicate$subject), wildcard)
 }
 
 method global$fun_three_layers_hierarchy$fun_take$T_class_global$class_C$return$T_Unit(local$c: Ref)
   returns (ret$0: Ref)
-  requires acc(local$c.class_A$member_x, wildcard)
-  ensures acc(local$c.class_A$member_x, wildcard)
+  requires acc(T_class_global$class_C(local$c), wildcard)
+  ensures acc(T_class_global$class_C(local$c), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$c), dom$RuntimeType$T_class_global$class_C())
@@ -116,39 +82,8 @@ method global$fun_three_layers_hierarchy$fun_take$T_class_global$class_C$return$
 /predicates.kt:(287,301): info: Generated Viper text for list_hierarchy:
 field special$size: Ref
 
-function T_class_pkg$kotlin$collections$global$class_Collection$get$special$size(special$get$function$subject: Ref): Ref
-  requires acc(T_class_pkg$kotlin$collections$global$class_Collection(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_pkg$kotlin$collections$global$class_Collection(special$get$function$subject), write) in
-    special$get$function$subject.special$size)
-}
-
-function T_class_pkg$kotlin$collections$global$class_List$get$special$size(special$get$function$subject: Ref): Ref
-  requires acc(T_class_pkg$kotlin$collections$global$class_List(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_pkg$kotlin$collections$global$class_List(special$get$function$subject), write) in
-    T_class_pkg$kotlin$collections$global$class_Collection$get$special$size(special$get$function$subject))
-}
-
-function T_class_pkg$kotlin$collections$global$class_MutableCollection$get$special$size(special$get$function$subject: Ref): Ref
-  requires acc(T_class_pkg$kotlin$collections$global$class_MutableCollection(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_pkg$kotlin$collections$global$class_MutableCollection(special$get$function$subject), write) in
-    T_class_pkg$kotlin$collections$global$class_Collection$get$special$size(special$get$function$subject))
-}
-
-function T_class_pkg$kotlin$collections$global$class_MutableList$get$special$size(special$get$function$subject: Ref): Ref
-  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(special$get$function$subject), write)
-{
-  (unfolding acc(T_class_pkg$kotlin$collections$global$class_MutableList(special$get$function$subject), write) in
-    T_class_pkg$kotlin$collections$global$class_List$get$special$size(special$get$function$subject))
-}
-
 predicate T_class_pkg$kotlin$collections$global$class_Collection(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.special$size, write) &&
-  dom$RuntimeType$intFromRef(special$class$predicate$subject.special$size) >=
-  0 &&
-  acc(T_class_pkg$kotlin$collections$global$class_Iterable(special$class$predicate$subject), write)
+  acc(T_class_pkg$kotlin$collections$global$class_Iterable(special$class$predicate$subject), wildcard)
 }
 
 predicate T_class_pkg$kotlin$collections$global$class_Iterable(special$class$predicate$subject: Ref) {
@@ -156,29 +91,31 @@ predicate T_class_pkg$kotlin$collections$global$class_Iterable(special$class$pre
 }
 
 predicate T_class_pkg$kotlin$collections$global$class_List(special$class$predicate$subject: Ref) {
-  acc(T_class_pkg$kotlin$collections$global$class_Collection(special$class$predicate$subject), write)
+  acc(T_class_pkg$kotlin$collections$global$class_Collection(special$class$predicate$subject), wildcard)
 }
 
 predicate T_class_pkg$kotlin$collections$global$class_MutableCollection(special$class$predicate$subject: Ref) {
-  acc(T_class_pkg$kotlin$collections$global$class_Collection(special$class$predicate$subject), write) &&
-  acc(T_class_pkg$kotlin$collections$global$class_MutableIterable(special$class$predicate$subject), write)
+  acc(T_class_pkg$kotlin$collections$global$class_Collection(special$class$predicate$subject), wildcard) &&
+  acc(T_class_pkg$kotlin$collections$global$class_MutableIterable(special$class$predicate$subject), wildcard)
 }
 
 predicate T_class_pkg$kotlin$collections$global$class_MutableIterable(special$class$predicate$subject: Ref) {
-  acc(T_class_pkg$kotlin$collections$global$class_Iterable(special$class$predicate$subject), write)
+  acc(T_class_pkg$kotlin$collections$global$class_Iterable(special$class$predicate$subject), wildcard)
 }
 
 predicate T_class_pkg$kotlin$collections$global$class_MutableList(special$class$predicate$subject: Ref) {
-  acc(T_class_pkg$kotlin$collections$global$class_List(special$class$predicate$subject), write) &&
-  acc(T_class_pkg$kotlin$collections$global$class_MutableCollection(special$class$predicate$subject), write)
+  acc(T_class_pkg$kotlin$collections$global$class_List(special$class$predicate$subject), wildcard) &&
+  acc(T_class_pkg$kotlin$collections$global$class_MutableCollection(special$class$predicate$subject), wildcard)
 }
 
 method global$fun_list_hierarchy$fun_take$T_class_pkg$kotlin$collections$global$class_MutableList$return$T_Unit(local$xs: Ref)
   returns (ret$0: Ref)
   requires acc(local$xs.special$size, write)
   requires dom$RuntimeType$intFromRef(local$xs.special$size) >= 0
+  requires acc(T_class_pkg$kotlin$collections$global$class_MutableList(local$xs), wildcard)
   ensures acc(local$xs.special$size, write)
   ensures dom$RuntimeType$intFromRef(local$xs.special$size) >= 0
+  ensures acc(T_class_pkg$kotlin$collections$global$class_MutableList(local$xs), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$xs), dom$RuntimeType$T_class_pkg$kotlin$collections$global$class_MutableList())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
@@ -250,7 +250,6 @@ method global$fun_accessSmartCast$fun_take$T_class_global$class_A$return$T_Unit(
   if (dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_B())) {
     var anonymous$0: Ref
     anonymous$0 := local$x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_B())
     inhale acc(T_class_global$class_B(anonymous$0), wildcard)
     unfold acc(T_class_global$class_B(anonymous$0), wildcard)
     local0$n := anonymous$0.class_B$member_b

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
@@ -1,4 +1,4 @@
-/predicates_access.kt:(223,246): info: Generated Viper text for accessSuperTypeProperty:
+/predicates_access.kt:(209,232): info: Generated Viper text for accessSuperTypeProperty:
 field class_A$member_a: Ref
 
 field class_B$member_b: Ref
@@ -55,7 +55,7 @@ method global$fun_accessSuperTypeProperty$fun_take$T_class_global$class_C$return
   label label$ret$0
 }
 
-/predicates_access.kt:(294,306): info: Generated Viper text for accessNested:
+/predicates_access.kt:(266,278): info: Generated Viper text for accessNested:
 field class_A$member_a: Ref
 
 field class_B$member_b: Ref
@@ -113,7 +113,7 @@ method global$fun_accessNested$fun_take$T_class_global$class_C$return$T_Unit(loc
   label label$ret$0
 }
 
-/predicates_access.kt:(356,370): info: Generated Viper text for accessNullable:
+/predicates_access.kt:(314,328): info: Generated Viper text for accessNullable:
 field class_A$member_a: Ref
 
 predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
@@ -140,7 +140,7 @@ method global$fun_accessNullable$fun_take$NT_class_global$class_A$return$T_Unit(
   label label$ret$0
 }
 
-/predicates_access.kt:(458,468): info: Generated Viper text for accessCast:
+/predicates_access.kt:(402,412): info: Generated Viper text for accessCast:
 field class_A$member_a: Ref
 
 field class_B$member_b: Ref
@@ -176,7 +176,7 @@ method global$fun_accessCast$fun_take$T_class_global$class_A$return$T_Unit(local
   label label$ret$0
 }
 
-/predicates_access.kt:(531,545): info: Generated Viper text for accessSafeCast:
+/predicates_access.kt:(461,475): info: Generated Viper text for accessSafeCast:
 field class_A$member_a: Ref
 
 field class_B$member_b: Ref
@@ -219,7 +219,7 @@ method global$fun_accessSafeCast$fun_take$T_class_global$class_A$return$T_Unit(l
   label label$ret$0
 }
 
-/predicates_access.kt:(654,669): info: Generated Viper text for accessSmartCast:
+/predicates_access.kt:(572,587): info: Generated Viper text for accessSmartCast:
 field class_A$member_a: Ref
 
 field class_B$member_b: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
@@ -1,0 +1,218 @@
+/predicates_access.kt:(223,246): info: Generated Viper text for accessSuperTypeProperty:
+field class_A$member_a: Int
+
+field class_B$member_b: Int
+
+field class_C$member_x: Ref
+
+field class_C$member_y: Ref
+
+function T_class_global$class_A$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_A(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_A(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_A$member_a)
+}
+
+function T_class_global$class_B$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
+    T_class_global$class_A$get$class_A$member_a(special$get$function$subject))
+}
+
+function T_class_global$class_B$get$class_B$member_b(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_B$member_b)
+}
+
+function T_class_global$class_C$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
+    T_class_global$class_B$get$class_A$member_a(special$get$function$subject))
+}
+
+function T_class_global$class_C$get$class_B$member_b(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
+    T_class_global$class_B$get$class_B$member_b(special$get$function$subject))
+}
+
+function T_class_global$class_C$get$class_C$member_x(special$get$function$subject: Ref): Ref
+  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_C$member_x)
+}
+
+predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_A$member_a, wildcard)
+}
+
+predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard)
+}
+
+predicate T_class_global$class_C(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_C$member_x, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject.class_C$member_x), wildcard) &&
+  acc(T_class_global$class_D(special$class$predicate$subject), wildcard) &&
+  acc(T_class_global$class_B(special$class$predicate$subject), wildcard)
+}
+
+predicate T_class_global$class_D(special$class$predicate$subject: Ref) {
+  true
+}
+
+method class_D$getter_d(this: Ref) returns (ret: Int)
+  requires acc(T_class_global$class_D(this), wildcard)
+  ensures acc(T_class_global$class_D(this), wildcard)
+
+
+method global$fun_accessSuperTypeProperty$fun_take$T_class_global$class_C$return$T_Unit(local$c: Ref)
+  returns (ret$0: dom$Unit)
+  requires acc(T_class_global$class_C(local$c), wildcard)
+  ensures acc(T_class_global$class_C(local$c), wildcard)
+{
+  var local0$temp: Int
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$c): dom$Type), dom$Type$global$class_C())
+  unfold acc(T_class_global$class_C(local$c), wildcard)
+  unfold acc(T_class_global$class_B(local$c), wildcard)
+  unfold acc(T_class_global$class_A(local$c), wildcard)
+  local0$temp := local$c.class_A$member_a
+  label label$ret$0
+}
+
+/predicates_access.kt:(294,306): info: Generated Viper text for accessNested:
+field class_A$member_a: Int
+
+field class_B$member_b: Int
+
+field class_C$member_x: Ref
+
+field class_C$member_y: Ref
+
+function T_class_global$class_A$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_A(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_A(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_A$member_a)
+}
+
+function T_class_global$class_B$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
+    T_class_global$class_A$get$class_A$member_a(special$get$function$subject))
+}
+
+function T_class_global$class_B$get$class_B$member_b(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_B$member_b)
+}
+
+function T_class_global$class_C$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
+    T_class_global$class_B$get$class_A$member_a(special$get$function$subject))
+}
+
+function T_class_global$class_C$get$class_B$member_b(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
+    T_class_global$class_B$get$class_B$member_b(special$get$function$subject))
+}
+
+function T_class_global$class_C$get$class_C$member_x(special$get$function$subject: Ref): Ref
+  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_C$member_x)
+}
+
+predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_A$member_a, wildcard)
+}
+
+predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard)
+}
+
+predicate T_class_global$class_C(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_C$member_x, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject.class_C$member_x), wildcard) &&
+  acc(T_class_global$class_D(special$class$predicate$subject), wildcard) &&
+  acc(T_class_global$class_B(special$class$predicate$subject), wildcard)
+}
+
+predicate T_class_global$class_D(special$class$predicate$subject: Ref) {
+  true
+}
+
+method class_D$getter_d(this: Ref) returns (ret: Int)
+  requires acc(T_class_global$class_D(this), wildcard)
+  ensures acc(T_class_global$class_D(this), wildcard)
+
+
+method global$fun_accessNested$fun_take$T_class_global$class_C$return$T_Unit(local$c: Ref)
+  returns (ret$0: dom$Unit)
+  requires acc(T_class_global$class_C(local$c), wildcard)
+  ensures acc(T_class_global$class_C(local$c), wildcard)
+{
+  var local0$temp: Int
+  var anonymous$0: Ref
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$c): dom$Type), dom$Type$global$class_C())
+  unfold acc(T_class_global$class_C(local$c), wildcard)
+  anonymous$0 := local$c.class_C$member_x
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_A())
+  unfold acc(T_class_global$class_A(anonymous$0), wildcard)
+  local0$temp := anonymous$0.class_A$member_a
+  label label$ret$0
+}
+
+/predicates_access.kt:(356,370): info: Generated Viper text for accessNullable:
+field class_A$member_a: Int
+
+function T_class_global$class_A$get$class_A$member_a(special$get$function$subject: Ref): Int
+  requires acc(T_class_global$class_A(special$get$function$subject), wildcard)
+{
+  (unfolding acc(T_class_global$class_A(special$get$function$subject), wildcard) in
+    special$get$function$subject.class_A$member_a)
+}
+
+predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_A$member_a, wildcard)
+}
+
+method global$fun_accessNullable$fun_take$NT_class_global$class_A$return$T_Unit(local$x: dom$Nullable[Ref])
+  returns (ret$0: dom$Unit)
+  requires local$x != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc(T_class_global$class_A((dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref)), wildcard)
+  ensures local$x != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
+    acc(T_class_global$class_A((dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref)), wildcard)
+{
+  var local0$n: Int
+  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$global$class_A()))
+  if (!(local$x == (dom$Nullable$null(): dom$Nullable[Ref]) &&
+  (dom$Nullable$null(): dom$Nullable[dom$Unit]) ==
+  (dom$Nullable$null(): dom$Nullable[dom$Unit]) ||
+  local$x != (dom$Nullable$null(): dom$Nullable[Ref]) &&
+  (dom$Nullable$null(): dom$Nullable[dom$Unit]) !=
+  (dom$Nullable$null(): dom$Nullable[dom$Unit]) &&
+  (dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref) ==
+  (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]), dom$Type$global$class_A()): Ref))) {
+    unfold acc(T_class_global$class_A((dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref)), wildcard)
+    local0$n := (dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref).class_A$member_a
+  }
+  label label$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.fir.diag.txt
@@ -1,86 +1,53 @@
 /predicates_access.kt:(223,246): info: Generated Viper text for accessSuperTypeProperty:
-field class_A$member_a: Int
+field class_A$member_a: Ref
 
-field class_B$member_b: Int
+field class_B$member_b: Ref
 
 field class_C$member_x: Ref
 
 field class_C$member_y: Ref
 
-function T_class_global$class_A$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_A(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_A(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_A$member_a)
-}
-
-function T_class_global$class_B$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
-    T_class_global$class_A$get$class_A$member_a(special$get$function$subject))
-}
-
-function T_class_global$class_B$get$class_B$member_b(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_B$member_b)
-}
-
-function T_class_global$class_C$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
-    T_class_global$class_B$get$class_A$member_a(special$get$function$subject))
-}
-
-function T_class_global$class_C$get$class_B$member_b(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
-    T_class_global$class_B$get$class_B$member_b(special$get$function$subject))
-}
-
-function T_class_global$class_C$get$class_C$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_C$member_x)
-}
-
 predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.class_A$member_a, wildcard)
+  acc(special$class$predicate$subject.class_A$member_a, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_a),
+  dom$RuntimeType$intType())
 }
 
 predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
   acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
-  acc(T_class_global$class_A(special$class$predicate$subject), wildcard)
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_B$member_b),
+  dom$RuntimeType$intType())
 }
 
 predicate T_class_global$class_C(special$class$predicate$subject: Ref) {
   acc(special$class$predicate$subject.class_C$member_x, wildcard) &&
   acc(T_class_global$class_A(special$class$predicate$subject.class_C$member_x), wildcard) &&
   acc(T_class_global$class_D(special$class$predicate$subject), wildcard) &&
-  acc(T_class_global$class_B(special$class$predicate$subject), wildcard)
+  acc(T_class_global$class_B(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_C$member_x),
+  dom$RuntimeType$T_class_global$class_A())
 }
 
 predicate T_class_global$class_D(special$class$predicate$subject: Ref) {
   true
 }
 
-method class_D$getter_d(this: Ref) returns (ret: Int)
+method class_D$getter_d(this: Ref) returns (ret: Ref)
   requires acc(T_class_global$class_D(this), wildcard)
   ensures acc(T_class_global$class_D(this), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method global$fun_accessSuperTypeProperty$fun_take$T_class_global$class_C$return$T_Unit(local$c: Ref)
-  returns (ret$0: dom$Unit)
+  returns (ret$0: Ref)
   requires acc(T_class_global$class_C(local$c), wildcard)
   ensures acc(T_class_global$class_C(local$c), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
-  var local0$temp: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$c): dom$Type), dom$Type$global$class_C())
+  var local0$temp: Ref
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$c), dom$RuntimeType$T_class_global$class_C())
+  ret$0 := dom$RuntimeType$unitValue()
   unfold acc(T_class_global$class_C(local$c), wildcard)
   unfold acc(T_class_global$class_B(local$c), wildcard)
   unfold acc(T_class_global$class_A(local$c), wildcard)
@@ -89,130 +56,204 @@ method global$fun_accessSuperTypeProperty$fun_take$T_class_global$class_C$return
 }
 
 /predicates_access.kt:(294,306): info: Generated Viper text for accessNested:
-field class_A$member_a: Int
+field class_A$member_a: Ref
 
-field class_B$member_b: Int
+field class_B$member_b: Ref
 
 field class_C$member_x: Ref
 
 field class_C$member_y: Ref
 
-function T_class_global$class_A$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_A(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_A(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_A$member_a)
-}
-
-function T_class_global$class_B$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
-    T_class_global$class_A$get$class_A$member_a(special$get$function$subject))
-}
-
-function T_class_global$class_B$get$class_B$member_b(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_B(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_B(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_B$member_b)
-}
-
-function T_class_global$class_C$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
-    T_class_global$class_B$get$class_A$member_a(special$get$function$subject))
-}
-
-function T_class_global$class_C$get$class_B$member_b(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
-    T_class_global$class_B$get$class_B$member_b(special$get$function$subject))
-}
-
-function T_class_global$class_C$get$class_C$member_x(special$get$function$subject: Ref): Ref
-  requires acc(T_class_global$class_C(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_C(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_C$member_x)
-}
-
 predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.class_A$member_a, wildcard)
+  acc(special$class$predicate$subject.class_A$member_a, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_a),
+  dom$RuntimeType$intType())
 }
 
 predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
   acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
-  acc(T_class_global$class_A(special$class$predicate$subject), wildcard)
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_B$member_b),
+  dom$RuntimeType$intType())
 }
 
 predicate T_class_global$class_C(special$class$predicate$subject: Ref) {
   acc(special$class$predicate$subject.class_C$member_x, wildcard) &&
   acc(T_class_global$class_A(special$class$predicate$subject.class_C$member_x), wildcard) &&
   acc(T_class_global$class_D(special$class$predicate$subject), wildcard) &&
-  acc(T_class_global$class_B(special$class$predicate$subject), wildcard)
+  acc(T_class_global$class_B(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_C$member_x),
+  dom$RuntimeType$T_class_global$class_A())
 }
 
 predicate T_class_global$class_D(special$class$predicate$subject: Ref) {
   true
 }
 
-method class_D$getter_d(this: Ref) returns (ret: Int)
+method class_D$getter_d(this: Ref) returns (ret: Ref)
   requires acc(T_class_global$class_D(this), wildcard)
   ensures acc(T_class_global$class_D(this), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
 method global$fun_accessNested$fun_take$T_class_global$class_C$return$T_Unit(local$c: Ref)
-  returns (ret$0: dom$Unit)
+  returns (ret$0: Ref)
   requires acc(T_class_global$class_C(local$c), wildcard)
   ensures acc(T_class_global$class_C(local$c), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
-  var local0$temp: Int
+  var local0$temp: Ref
   var anonymous$0: Ref
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$c): dom$Type), dom$Type$global$class_C())
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$c), dom$RuntimeType$T_class_global$class_C())
+  ret$0 := dom$RuntimeType$unitValue()
   unfold acc(T_class_global$class_C(local$c), wildcard)
   anonymous$0 := local$c.class_C$member_x
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(anonymous$0): dom$Type), dom$Type$global$class_A())
   unfold acc(T_class_global$class_A(anonymous$0), wildcard)
   local0$temp := anonymous$0.class_A$member_a
   label label$ret$0
 }
 
 /predicates_access.kt:(356,370): info: Generated Viper text for accessNullable:
-field class_A$member_a: Int
-
-function T_class_global$class_A$get$class_A$member_a(special$get$function$subject: Ref): Int
-  requires acc(T_class_global$class_A(special$get$function$subject), wildcard)
-{
-  (unfolding acc(T_class_global$class_A(special$get$function$subject), wildcard) in
-    special$get$function$subject.class_A$member_a)
-}
+field class_A$member_a: Ref
 
 predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
-  acc(special$class$predicate$subject.class_A$member_a, wildcard)
+  acc(special$class$predicate$subject.class_A$member_a, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_a),
+  dom$RuntimeType$intType())
 }
 
-method global$fun_accessNullable$fun_take$NT_class_global$class_A$return$T_Unit(local$x: dom$Nullable[Ref])
-  returns (ret$0: dom$Unit)
-  requires local$x != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc(T_class_global$class_A((dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref)), wildcard)
-  ensures local$x != (dom$Nullable$null(): dom$Nullable[Ref]) ==>
-    acc(T_class_global$class_A((dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref)), wildcard)
+method global$fun_accessNullable$fun_take$NT_class_global$class_A$return$T_Unit(local$x: Ref)
+  returns (ret$0: Ref)
+  requires local$x != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_A(local$x), wildcard)
+  ensures local$x != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_A(local$x), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
-  var local0$n: Int
-  inhale dom$Type$isSubtype((dom$TypeOf$typeOf(local$x): dom$Type), dom$Type$special$Nullable(dom$Type$global$class_A()))
-  if (!(local$x == (dom$Nullable$null(): dom$Nullable[Ref]) &&
-  (dom$Nullable$null(): dom$Nullable[dom$Unit]) ==
-  (dom$Nullable$null(): dom$Nullable[dom$Unit]) ||
-  local$x != (dom$Nullable$null(): dom$Nullable[Ref]) &&
-  (dom$Nullable$null(): dom$Nullable[dom$Unit]) !=
-  (dom$Nullable$null(): dom$Nullable[dom$Unit]) &&
-  (dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref) ==
-  (dom$Casting$cast((dom$Nullable$null(): dom$Nullable[dom$Unit]), dom$Type$global$class_A()): Ref))) {
-    unfold acc(T_class_global$class_A((dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref)), wildcard)
-    local0$n := (dom$Casting$cast(local$x, dom$Type$global$class_A()): Ref).class_A$member_a
+  var local0$n: Ref
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_A()))
+  ret$0 := dom$RuntimeType$unitValue()
+  if (!(local$x == dom$RuntimeType$nullValue())) {
+    unfold acc(T_class_global$class_A(local$x), wildcard)
+    local0$n := local$x.class_A$member_a
+  }
+  label label$ret$0
+}
+
+/predicates_access.kt:(458,468): info: Generated Viper text for accessCast:
+field class_A$member_a: Ref
+
+field class_B$member_b: Ref
+
+predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_A$member_a, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_a),
+  dom$RuntimeType$intType())
+}
+
+predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_B$member_b),
+  dom$RuntimeType$intType())
+}
+
+method global$fun_accessCast$fun_take$T_class_global$class_A$return$T_Unit(local$x: Ref)
+  returns (ret$0: Ref)
+  requires acc(T_class_global$class_A(local$x), wildcard)
+  ensures acc(T_class_global$class_A(local$x), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  var local0$n: Ref
+  var anonymous$0: Ref
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_A())
+  ret$0 := dom$RuntimeType$unitValue()
+  anonymous$0 := local$x
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_B())
+  inhale acc(T_class_global$class_B(anonymous$0), wildcard)
+  unfold acc(T_class_global$class_B(anonymous$0), wildcard)
+  local0$n := anonymous$0.class_B$member_b
+  label label$ret$0
+}
+
+/predicates_access.kt:(531,545): info: Generated Viper text for accessSafeCast:
+field class_A$member_a: Ref
+
+field class_B$member_b: Ref
+
+predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_A$member_a, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_a),
+  dom$RuntimeType$intType())
+}
+
+predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_B$member_b),
+  dom$RuntimeType$intType())
+}
+
+method global$fun_accessSafeCast$fun_take$T_class_global$class_A$return$T_Unit(local$x: Ref)
+  returns (ret$0: Ref)
+  requires acc(T_class_global$class_A(local$x), wildcard)
+  ensures acc(T_class_global$class_A(local$x), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  var local0$n: Ref
+  var local0$y: Ref
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_A())
+  ret$0 := dom$RuntimeType$unitValue()
+  local0$n := dom$RuntimeType$intToRef(0)
+  if (dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_B())) {
+    local0$y := local$x
+  } else {
+    local0$y := dom$RuntimeType$nullValue()}
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local0$y), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_B()))
+  inhale local0$y != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_B(local0$y), wildcard)
+  if (!(local0$y == dom$RuntimeType$nullValue())) {
+    unfold acc(T_class_global$class_B(local0$y), wildcard)
+    local0$n := local0$y.class_B$member_b
+  }
+  label label$ret$0
+}
+
+/predicates_access.kt:(654,669): info: Generated Viper text for accessSmartCast:
+field class_A$member_a: Ref
+
+field class_B$member_b: Ref
+
+predicate T_class_global$class_A(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_A$member_a, wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_A$member_a),
+  dom$RuntimeType$intType())
+}
+
+predicate T_class_global$class_B(special$class$predicate$subject: Ref) {
+  acc(special$class$predicate$subject.class_B$member_b, wildcard) &&
+  acc(T_class_global$class_A(special$class$predicate$subject), wildcard) &&
+  dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(special$class$predicate$subject.class_B$member_b),
+  dom$RuntimeType$intType())
+}
+
+method global$fun_accessSmartCast$fun_take$T_class_global$class_A$return$T_Unit(local$x: Ref)
+  returns (ret$0: Ref)
+  requires acc(T_class_global$class_A(local$x), wildcard)
+  ensures acc(T_class_global$class_A(local$x), wildcard)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  var local0$n: Ref
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_A())
+  ret$0 := dom$RuntimeType$unitValue()
+  local0$n := dom$RuntimeType$intToRef(0)
+  if (dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$T_class_global$class_B())) {
+    var anonymous$0: Ref
+    anonymous$0 := local$x
+    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$T_class_global$class_B())
+    inhale acc(T_class_global$class_B(anonymous$0), wildcard)
+    unfold acc(T_class_global$class_B(anonymous$0), wildcard)
+    local0$n := anonymous$0.class_B$member_b
   }
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt
@@ -28,3 +28,26 @@ fun <!VIPER_TEXT!>accessNullable<!>(x: A?){
         n = x.a
     }
 }
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>accessCast<!>(x: A){
+    var n: Int
+    n = (x as B).b
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>accessSafeCast<!>(x: A){
+    var n: Int = 0
+    val y = x as? B
+    if(y != null){
+        n = y.b
+    }
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>accessSmartCast<!>(x: A){
+    var n: Int = 0
+    if(x is B){
+        n = x.b
+    }
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt
@@ -11,17 +11,14 @@ interface D {
 
 class C(val x: A, var y: A) : D, B(0)
 
-@AlwaysVerify
 fun <!VIPER_TEXT!>accessSuperTypeProperty<!>(c: C){
     val temp = c.a
 }
 
-@AlwaysVerify
 fun <!VIPER_TEXT!>accessNested<!>(c: C){
     val temp = c.x.a
 }
 
-@AlwaysVerify
 fun <!VIPER_TEXT!>accessNullable<!>(x: A?){
     var n: Int
     if (x != null) {
@@ -29,25 +26,22 @@ fun <!VIPER_TEXT!>accessNullable<!>(x: A?){
     }
 }
 
-@AlwaysVerify
 fun <!VIPER_TEXT!>accessCast<!>(x: A){
     var n: Int
     n = (x as B).b
 }
 
-@AlwaysVerify
 fun <!VIPER_TEXT!>accessSafeCast<!>(x: A){
     var n: Int = 0
     val y = x as? B
-    if(y != null){
+    if (y != null) {
         n = y.b
     }
 }
 
-@AlwaysVerify
 fun <!VIPER_TEXT!>accessSmartCast<!>(x: A){
     var n: Int = 0
-    if(x is B){
+    if (x is B) {
         n = x.b
     }
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+
+open class A(val a: Int)
+
+open class B(val b: Int) : A(0)
+
+interface D {
+    val d: Int
+        get() = 2
+}
+
+class C(val x: A, var y: A) : D, B(0)
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>accessSuperTypeProperty<!>(c: C){
+    val temp = c.a
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>accessNested<!>(c: C){
+    val temp = c.x.a
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>accessNullable<!>(x: A?){
+    var n: Int
+    if (x != null) {
+        n = x.a
+    }
+}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/safe_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/safe_call.fir.diag.txt
@@ -3,17 +3,17 @@ field class_Foo$member_x: Ref
 
 method class_Foo$fun_f$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
 method global$fun_testSafeCall$fun_take$NT_class_global$class_Foo$return$NT_Unit(local$foo: Ref)
   returns (ret$0: Ref)
   requires local$foo != dom$RuntimeType$nullValue() ==>
-    acc(local$foo.class_Foo$member_x, wildcard)
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures local$foo != dom$RuntimeType$nullValue() ==>
-    acc(local$foo.class_Foo$member_x, wildcard)
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$unitType()))
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Foo()))
@@ -32,15 +32,15 @@ field class_Foo$member_x: Ref
 
 method class_Foo$fun_f$fun_take$T_class_global$class_Foo$return$T_Unit(this: Ref)
   returns (ret: Ref)
-  requires acc(this.class_Foo$member_x, wildcard)
-  ensures acc(this.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(this), wildcard)
+  ensures acc(T_class_global$class_Foo(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
 method global$fun_testSafeCallNonNullable$fun_take$T_class_global$class_Foo$return$NT_Unit(local$foo: Ref)
   returns (ret$0: Ref)
-  requires acc(local$foo.class_Foo$member_x, wildcard)
-  ensures acc(local$foo.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$unitType()))
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
@@ -60,16 +60,16 @@ field class_Foo$member_x: Ref
 method global$fun_testSafeCallProperty$fun_take$NT_class_global$class_Foo$return$NT_Int(local$foo: Ref)
   returns (ret$0: Ref)
   requires local$foo != dom$RuntimeType$nullValue() ==>
-    acc(local$foo.class_Foo$member_x, wildcard)
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures local$foo != dom$RuntimeType$nullValue() ==>
-    acc(local$foo.class_Foo$member_x, wildcard)
+    acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$intType()))
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_Foo()))
   if (local$foo != dom$RuntimeType$nullValue()) {
     var anonymous$0: Ref
+    unfold acc(T_class_global$class_Foo(local$foo), wildcard)
     anonymous$0 := local$foo.class_Foo$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$intType())
     ret$0 := anonymous$0
   } else {
     ret$0 := dom$RuntimeType$nullValue()}
@@ -82,15 +82,15 @@ field class_Foo$member_x: Ref
 
 method global$fun_testSafeCallPropertyNonNullable$fun_take$T_class_global$class_Foo$return$NT_Int(local$foo: Ref)
   returns (ret$0: Ref)
-  requires acc(local$foo.class_Foo$member_x, wildcard)
-  ensures acc(local$foo.class_Foo$member_x, wildcard)
+  requires acc(T_class_global$class_Foo(local$foo), wildcard)
+  ensures acc(T_class_global$class_Foo(local$foo), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$intType()))
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
   if (local$foo != dom$RuntimeType$nullValue()) {
     var anonymous$0: Ref
+    unfold acc(T_class_global$class_Foo(local$foo), wildcard)
     anonymous$0 := local$foo.class_Foo$member_x
-    inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$0), dom$RuntimeType$intType())
     ret$0 := anonymous$0
   } else {
     ret$0 := dom$RuntimeType$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/smartcast.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/smartcast.fir.diag.txt
@@ -15,6 +15,10 @@ method global$fun_smartcastReturn$fun_take$NT_Int$return$T_Int(local$n: Ref)
 /smartcast.kt:(69,87): info: Generated Viper text for isNullOrEmptyWrong:
 method global$fun_isNullOrEmptyWrong$fun_take$NT_class_pkg$kotlin$global$class_CharSequence$return$T_Boolean(local$seq: Ref)
   returns (ret$0: Ref)
+  requires local$seq != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$global$class_CharSequence(local$seq), wildcard)
+  ensures local$seq != dom$RuntimeType$nullValue() ==>
+    acc(T_class_pkg$kotlin$global$class_CharSequence(local$seq), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$seq), dom$RuntimeType$nullable(dom$RuntimeType$T_class_pkg$kotlin$global$class_CharSequence()))
@@ -36,4 +40,7 @@ method global$fun_isNullOrEmptyWrong$fun_take$NT_class_pkg$kotlin$global$class_C
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/try_catch.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/try_catch.fir.diag.txt
@@ -38,6 +38,8 @@ method global$fun_try_catch$fun_take$$return$T_Unit() returns (ret$0: Ref)
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -95,6 +97,8 @@ method global$fun_nested_try_catch$fun_take$$return$T_Unit()
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -141,6 +145,8 @@ method global$fun_try_catch_with_inline$fun_take$$return$T_Unit()
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -180,6 +186,8 @@ method global$fun_try_catch_shadowing$fun_take$$return$T_Unit()
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -237,6 +245,8 @@ method global$fun_multiple_catches$fun_take$$return$T_Unit()
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
 
 
@@ -254,10 +264,8 @@ method global$fun_call$fun_take$T_Int$return$T_Unit(local$x: Ref)
 
 method global$fun_ignore$fun_take$T_class_pkg$java$lang$global$class_Exception$return$T_Unit(local$e: Ref)
   returns (ret: Ref)
-  requires acc(local$e.pkg$kotlin$class_Throwable$member_cause, wildcard)
-  requires acc(local$e.pkg$kotlin$class_Throwable$member_message, wildcard)
-  ensures acc(local$e.pkg$kotlin$class_Throwable$member_cause, wildcard)
-  ensures acc(local$e.pkg$kotlin$class_Throwable$member_message, wildcard)
+  requires acc(T_class_pkg$java$lang$global$class_Exception(local$e), wildcard)
+  ensures acc(T_class_pkg$java$lang$global$class_Exception(local$e), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$unitType())
 
 
@@ -288,4 +296,7 @@ method global$fun_use_exception$fun_take$$return$T_Unit()
 
 method pkg$kotlin$class_CharSequence$getter_length(this: Ref)
   returns (ret: Ref)
+  requires acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
+  ensures acc(T_class_pkg$kotlin$global$class_CharSequence(this), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/when.fir.diag.txt
@@ -156,6 +156,8 @@ method global$fun_unused_result$fun_take$$return$T_Int()
 /when.kt:(1222,1229): info: Generated Viper text for when_is:
 method global$fun_when_is$fun_take$T_class_global$class_Foo$return$T_Boolean(local$x: Ref)
   returns (ret$0: Ref)
+  requires acc(T_class_global$class_Foo(local$x), wildcard)
+  ensures acc(T_class_global$class_Foo(local$x), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
 {
   var anonymous$0: Ref

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -412,6 +412,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
         }
 
         @Test
+        @TestMetadata("predicates_access.kt")
+        public void testPredicates_access() throws Exception {
+            runTest("plugins/formal-verification/testData/diagnostics/no_contracts/predicates_access.kt");
+        }
+
+        @Test
         @TestMetadata("recursion.kt")
         public void testRecursion() throws Exception {
             runTest("plugins/formal-verification/testData/diagnostics/no_contracts/recursion.kt");


### PR DESCRIPTION
With this PR, the following field accesses have the right permissions

```kt
open class A(val a: Int)
open class B(val b: Int) : A(0)
class C(val x: A) : B(0)

fun f(c: C, c2: C?){
  val x = c.x.a
  val y = c.a
  var z: Int
  if (c2 != null){
    z = c2.a
  }
}
```

# Implemented:
- access predicates for immutable properties only with `wildcard` permissions
- distinction between immutable and mutable fields 
- add immutable predicates to preconditions
- unfold predicates for nested accesses
- unfold predicates for supertypes properties

# TODO
- [x] inhale predicates after a cast (`good-contract/as-type-contract` raises a verification error now)
- [x] better distinction between mutable and immutable properties may avoid to filter in `VariableEmbedding.accessInvariants`
- [x] update all the tests