### PR TITLE
Unfolding for Primary Constructors

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -15,9 +15,7 @@ import org.jetbrains.kotlin.formver.embeddings.expression.debug.*
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.addLabel
 import org.jetbrains.kotlin.formver.linearization.pureToViper
-import org.jetbrains.kotlin.formver.viper.ast.Exp
-import org.jetbrains.kotlin.formver.viper.ast.Label
-import org.jetbrains.kotlin.formver.viper.ast.Stmt
+import org.jetbrains.kotlin.formver.viper.ast.*
 
 // TODO: make a nice BlockBuilder interface.
 data class Block(val exps: List<ExpEmbedding>) : OptionalResultExpEmbedding {
@@ -140,6 +138,35 @@ data class NonDeterministically(val exp: ExpEmbedding) : UnitResultExpEmbedding,
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
         get() = listOf(exp)
+}
+
+data class UnfoldingClassPredicateEmbedding(val predicated: VariableEmbedding, override val inner: ExpEmbedding) :
+    UnaryDirectResultExpEmbedding {
+    override val type: TypeEmbedding = inner.type
+    fun toViper(ctx: LinearizationContext, action: ExpEmbedding.() -> Exp): Exp {
+        val predicatedType = predicated.type
+        check(predicatedType is ClassTypeEmbedding) {
+            "Built-in types do not have predicates"
+        }
+        return Exp.Unfolding(
+            Exp.PredicateAccess(
+                predicatedType.predicate.name,
+                listOf(predicated.pureToViper(false)),
+                PermExp.WildcardPerm(),
+                pos = ctx.source.asPosition,
+                info = sourceRole.asInfo
+            ),
+            inner.action()
+        )
+    }
+
+    override fun toViper(ctx: LinearizationContext): Exp = toViper(ctx) {
+        toViper(ctx)
+    }
+
+    override fun toViperBuiltinType(ctx: LinearizationContext): Exp  = toViper(ctx) {
+        toViperBuiltinType(ctx)
+    }
 }
 
 // Note: this is always a *real* Viper method call.

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -143,10 +143,10 @@ data class NonDeterministically(val exp: ExpEmbedding) : UnitResultExpEmbedding,
 data class UnfoldingClassPredicateEmbedding(val predicated: VariableEmbedding, override val inner: ExpEmbedding) :
     UnaryDirectResultExpEmbedding {
     override val type: TypeEmbedding = inner.type
-    fun toViper(ctx: LinearizationContext, action: ExpEmbedding.() -> Exp): Exp {
+    private fun toViperImpl(ctx: LinearizationContext, action: ExpEmbedding.() -> Exp): Exp {
         val predicatedType = predicated.type
         check(predicatedType is ClassTypeEmbedding) {
-            "Built-in types do not have predicates"
+            "Built-in types do not have predicates."
         }
         return Exp.Unfolding(
             Exp.PredicateAccess(
@@ -160,11 +160,11 @@ data class UnfoldingClassPredicateEmbedding(val predicated: VariableEmbedding, o
         )
     }
 
-    override fun toViper(ctx: LinearizationContext): Exp = toViper(ctx) {
+    override fun toViper(ctx: LinearizationContext): Exp = toViperImpl(ctx) {
         toViper(ctx)
     }
 
-    override fun toViperBuiltinType(ctx: LinearizationContext): Exp  = toViper(ctx) {
+    override fun toViperBuiltinType(ctx: LinearizationContext): Exp = toViperImpl(ctx) {
         toViperBuiltinType(ctx)
     }
 }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -211,3 +211,46 @@ method global$fun_nonNullableReceiverSafeGet$fun_take$$return$T_Boolean()
   goto label$ret$0
   label label$ret$0
 }
+
+/backing_field_getters.kt:(1681,1693): info: Generated Viper text for checkPrimary:
+field class_ClassI$member_x: Ref
+
+field class_ClassI$member_y: Ref
+
+field class_ClassI$member_z: Ref
+
+method class_ClassI$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_ClassI(local$x: Ref,
+  local$y: Ref)
+  returns (ret: Ref)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_ClassI())
+  ensures acc(T_class_global$class_ClassI(ret), wildcard)
+  ensures (unfolding acc(T_class_global$class_ClassI(ret), wildcard) in
+      ret.class_ClassI$member_x == local$x &&
+      ret.class_ClassI$member_y == local$y)
+
+
+method global$fun_checkPrimary$fun_take$T_Int$T_Int$return$T_Boolean(local$x: Ref,
+  local$y: Ref)
+  returns (ret$0: Ref)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
+  ensures dom$RuntimeType$boolFromRef(ret$0) == false ==> false
+{
+  var local0$classI: Ref
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$x), dom$RuntimeType$intType())
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$y), dom$RuntimeType$intType())
+  local0$classI := class_ClassI$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_ClassI(local$x,
+    local$y)
+  if (!(local$x == local$y)) {
+    ret$0 := dom$RuntimeType$boolToRef(true)
+  } else {
+    var anonymous$0: Ref
+    var anonymous$1: Ref
+    unfold acc(T_class_global$class_ClassI(local0$classI), wildcard)
+    anonymous$0 := local0$classI.class_ClassI$member_x
+    unfold acc(T_class_global$class_ClassI(local0$classI), wildcard)
+    anonymous$1 := local0$classI.class_ClassI$member_y
+    ret$0 := dom$RuntimeType$boolToRef(anonymous$0 == anonymous$1)
+  }
+  goto label$ret$0
+  label label$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.kt
@@ -69,3 +69,21 @@ fun <!VIPER_TEXT!>nonNullableReceiverSafeGet<!>(): Boolean {
     val f: Baz = Baz()
     return f?.x == null
 }
+
+open class ClassI(val x: Int, val y: Int) {
+    open val z: Z = Z()
+}
+
+class ClassII(final override val z: Z) : ClassI(10, 10)
+
+
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>checkPrimary<!>(x: Int, y: Int): Boolean {
+    contract {
+        returns(false) implies false
+    }
+    val classI = ClassI(x, y)
+    // The second example doesn't work now but hopefully will be working with the upcoming PR.
+    // val z = Z()
+    return (x != y || classI.x == classI.y) // && ClassII(z).z == z
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/binary_search.fir.diag.txt
@@ -196,4 +196,3 @@ method pkg$kotlin$collections$class_List$fun_get$fun_take$T_class_pkg$kotlin$col
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$intType())
   ensures dom$RuntimeType$intFromRef(this.special$size) ==
     old(dom$RuntimeType$intFromRef(this.special$size))
-

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -275,4 +275,3 @@ method pkg$kotlin$collections$class_List$fun_isEmpty$fun_take$T_class_pkg$kotlin
     dom$RuntimeType$intFromRef(this.special$size) == 0
   ensures !dom$RuntimeType$boolFromRef(ret) ==>
     dom$RuntimeType$intFromRef(this.special$size) > 0
-

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -143,4 +143,3 @@ method pkg$kotlin$collections$class_Collection$fun_isEmpty$fun_take$T_class_pkg$
     dom$RuntimeType$intFromRef(this.special$size) == 0
   ensures !dom$RuntimeType$boolFromRef(ret) ==>
     dom$RuntimeType$intFromRef(this.special$size) > 0
-

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/class_constructors.fir.diag.txt
@@ -57,7 +57,8 @@ method class_Bar$constructor$fun_take$T_Int$return$T_class_global$class_Bar(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
   ensures acc(T_class_global$class_Bar(ret), wildcard)
-  ensures ret.class_Bar$member_a == local$a
+  ensures (unfolding acc(T_class_global$class_Bar(ret), wildcard) in
+      ret.class_Bar$member_a == local$a)
 
 
 method global$fun_primaryAndSecondConstructor$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes.fir.diag.txt
@@ -8,8 +8,9 @@ method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Fo
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
-  ensures ret.class_Foo$member_a == local$a
-  ensures ret.class_Foo$member_b == local$b
+  ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
+      ret.class_Foo$member_a == local$a &&
+      ret.class_Foo$member_b == local$b)
 
 
 method global$fun_createFoo$fun_take$$return$T_class_global$class_Foo()
@@ -42,7 +43,8 @@ method class_Bar$constructor$fun_take$NT_class_global$class_Bar$return$T_class_g
     acc(T_class_global$class_Bar(local$a), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
   ensures acc(T_class_global$class_Bar(ret), wildcard)
-  ensures ret.class_Bar$member_a == local$a
+  ensures (unfolding acc(T_class_global$class_Bar(ret), wildcard) in
+      ret.class_Bar$member_a == local$a)
 
 
 method global$fun_createBar$fun_take$$return$T_Unit() returns (ret$0: Ref)
@@ -63,7 +65,8 @@ method class_Baz$constructor$fun_take$T_Int$return$T_class_global$class_Baz(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
   ensures acc(T_class_global$class_Baz(ret), wildcard)
-  ensures ret.class_Baz$member_c == local$c
+  ensures (unfolding acc(T_class_global$class_Baz(ret), wildcard) in
+      ret.class_Baz$member_c == local$c)
 
 
 method global$fun_createBaz$fun_take$$return$T_Unit() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes_getters.fir.diag.txt
@@ -5,7 +5,8 @@ method class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_I
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_IntWrapper())
   ensures acc(T_class_global$class_IntWrapper(ret), wildcard)
-  ensures ret.class_IntWrapper$member_n == local$n
+  ensures (unfolding acc(T_class_global$class_IntWrapper(ret), wildcard) in
+      ret.class_IntWrapper$member_n == local$n)
 
 
 method class_IntWrapper$getter_succ(this: Ref) returns (ret: Ref)
@@ -38,7 +39,8 @@ method class_Bar$constructor$fun_take$T_class_global$class_Foo$return$T_class_gl
   ensures acc(T_class_global$class_Foo(local$f), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
   ensures acc(T_class_global$class_Bar(ret), wildcard)
-  ensures ret.class_Bar$member_f == local$f
+  ensures (unfolding acc(T_class_global$class_Bar(ret), wildcard) in
+      ret.class_Bar$member_f == local$f)
 
 
 method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Foo(local$a: Ref,
@@ -46,8 +48,9 @@ method class_Foo$constructor$fun_take$T_Int$T_Int$return$T_class_global$class_Fo
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
-  ensures ret.class_Foo$member_a == local$a
-  ensures ret.class_Foo$member_b == local$b
+  ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
+      ret.class_Foo$member_a == local$a &&
+      ret.class_Foo$member_b == local$b)
 
 
 method global$fun_testCascadeGetter$fun_take$$return$T_Unit()
@@ -84,7 +87,8 @@ method class_IntWrapper$constructor$fun_take$T_Int$return$T_class_global$class_I
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_IntWrapper())
   ensures acc(T_class_global$class_IntWrapper(ret), wildcard)
-  ensures ret.class_IntWrapper$member_n == local$n
+  ensures (unfolding acc(T_class_global$class_IntWrapper(ret), wildcard) in
+      ret.class_IntWrapper$member_n == local$n)
 
 
 method class_IntWrapper$getter_succ(this: Ref) returns (ret: Ref)
@@ -99,7 +103,8 @@ method class_IntWrapperContainer$constructor$fun_take$T_class_global$class_IntWr
   ensures acc(T_class_global$class_IntWrapper(local$i), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_IntWrapperContainer())
   ensures acc(T_class_global$class_IntWrapperContainer(ret), wildcard)
-  ensures ret.class_IntWrapperContainer$member_i == local$i
+  ensures (unfolding acc(T_class_global$class_IntWrapperContainer(ret), wildcard) in
+      ret.class_IntWrapperContainer$member_i == local$i)
 
 
 method global$fun_testCascadeCustomGetters$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -48,7 +48,8 @@ method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
-  ensures ret.class_Foo$member_x == local$x
+  ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
+      ret.class_Foo$member_x == local$x)
 
 
 method global$ext_getter_succ$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)
@@ -77,7 +78,8 @@ method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
-  ensures ret.class_Foo$member_x == local$x
+  ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
+      ret.class_Foo$member_x == local$x)
 
 
 method global$ext_getter_strange$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -296,7 +296,8 @@ method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
-  ensures ret.class_Foo$member_x == local$x
+  ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
+      ret.class_Foo$member_x == local$x)
 
 
 method global$fun_f$fun_take$$return$T_Unit() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance_fields.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/inheritance_fields.fir.diag.txt
@@ -9,7 +9,8 @@ method class_B$constructor$fun_take$T_class_global$class_FieldB$return$T_class_g
   ensures acc(T_class_global$class_FieldB(local$fieldOverride), wildcard)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_B())
   ensures acc(T_class_global$class_B(ret), wildcard)
-  ensures ret.class_A$member_fieldOverride == local$fieldOverride
+  ensures (unfolding acc(T_class_global$class_B(ret), wildcard) in
+      ret.class_A$member_fieldOverride == local$fieldOverride)
 
 
 method class_FieldB$constructor$fun_take$$return$T_class_global$class_FieldB()
@@ -64,7 +65,8 @@ method class_SecondBackingFieldClass$constructor$fun_take$T_Int$return$T_class_g
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_SecondBackingFieldClass())
   ensures acc(T_class_global$class_SecondBackingFieldClass(ret), wildcard)
-  ensures ret.class_FirstBackingFieldClass$member_x == local$x
+  ensures (unfolding acc(T_class_global$class_SecondBackingFieldClass(ret), wildcard) in
+      ret.class_FirstBackingFieldClass$member_x == local$x)
 
 
 method global$fun_createBFsAndNoBF$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/interface.fir.diag.txt
@@ -50,7 +50,8 @@ method class_Impl$constructor$fun_take$T_Int$return$T_class_global$class_Impl(lo
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl())
   ensures acc(T_class_global$class_Impl(ret), wildcard)
-  ensures ret.class_Impl$member_number == local$number
+  ensures (unfolding acc(T_class_global$class_Impl(ret), wildcard) in
+      ret.class_Impl$member_number == local$number)
 
 
 method class_Second$getter_number(this: Ref) returns (ret: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/member_functions.fir.diag.txt
@@ -71,7 +71,8 @@ method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
-  ensures ret.class_Foo$member_x == local$x
+  ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
+      ret.class_Foo$member_x == local$x)
 
 
 method class_Foo$fun_member_fun$fun_take$T_class_global$class_Foo$return$T_Int(this: Ref)


### PR DESCRIPTION
This PR fixes a bug with invariants of primary constructors which has arisen because now we need to unfold the predicate to access the fields.
