### PR TITLE
Pick result variable for function object call earlier

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -200,9 +200,9 @@ data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbe
 data class InvokeFunctionObject(val receiver: ExpEmbedding, val args: List<ExpEmbedding>, override val type: TypeEmbedding) :
     OnlyToViperExpEmbedding {
     override fun toViper(ctx: LinearizationContext): Exp {
+        val variable = ctx.freshAnonVar(type)
         val receiverViper = receiver.toViper(ctx)
         for (arg in args) arg.toViperUnusedResult(ctx)
-        val variable = ctx.freshAnonVar(type)
         // NOTE: Since it is only relevant to update the number of times that a function object is called,
         // the function call invocation is intentionally not assigned to the return variable
         ctx.addStatement(

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/calls_in_place.fir.diag.txt
@@ -13,9 +13,9 @@ method global$fun_incorrect_at_most_once$fun_take$fun_take$T_Int$return$T_Int$re
   var anonymous$1: Ref
   var anonymous$2: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$f), dom$RuntimeType$functionType())
-  anonymous$0 := global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f)
+  anonymous$1 := global$fun_unknown$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(local$f)
   special$invoke_function_object(local$f)
-  anonymous$2 := anonymous$1
+  anonymous$2 := anonymous$0
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$2), dom$RuntimeType$intType())
   ret$0 := anonymous$2
   goto label$ret$0
@@ -51,10 +51,10 @@ method global$fun_incorrect_exactly_once$fun_take$fun_take$T_Int$return$T_Int$re
   var anonymous$3: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$f), dom$RuntimeType$functionType())
   special$invoke_function_object(local$f)
-  anonymous$1 := anonymous$0
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
+  anonymous$2 := anonymous$1
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$2), dom$RuntimeType$intType())
   special$invoke_function_object(local$f)
-  anonymous$3 := anonymous$2
+  anonymous$3 := anonymous$0
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$3), dom$RuntimeType$intType())
   ret$0 := anonymous$3
   goto label$ret$0

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/inlining_captured.fir.diag.txt
@@ -19,10 +19,10 @@ method global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$return$T_Int(
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$g), dom$RuntimeType$functionType())
   anonymous$0 := dom$RuntimeType$intToRef(0)
   special$invoke_function_object(local$g)
-  anonymous$2 := anonymous$1
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$2), dom$RuntimeType$intType())
+  anonymous$3 := anonymous$2
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$3), dom$RuntimeType$intType())
   special$invoke_function_object(local$g)
-  anonymous$4 := anonymous$3
+  anonymous$4 := anonymous$1
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$4), dom$RuntimeType$intType())
   ret$2 := anonymous$4
   goto label$ret$2

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/inlining_captured.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/inlining_captured.fir.diag.txt
@@ -104,10 +104,10 @@ method global$fun_nested_call$fun_take$fun_take$T_Int$return$T_Int$fun_take$T_In
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$g), dom$RuntimeType$functionType())
   anonymous$0 := dom$RuntimeType$intToRef(0)
   special$invoke_function_object(local$g)
-  anonymous$2 := anonymous$1
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$2), dom$RuntimeType$intType())
+  anonymous$3 := anonymous$2
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$3), dom$RuntimeType$intType())
   special$invoke_function_object(local$f)
-  anonymous$4 := anonymous$3
+  anonymous$4 := anonymous$1
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$4), dom$RuntimeType$intType())
   ret$2 := anonymous$4
   goto label$ret$2

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_object.fir.diag.txt
@@ -59,13 +59,13 @@ method global$fun_function_object_nested_call$fun_take$fun_take$T_Int$return$T_I
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$f), dom$RuntimeType$functionType())
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$g), dom$RuntimeType$functionType())
   special$invoke_function_object(local$g)
-  anonymous$1 := anonymous$0
-  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$1), dom$RuntimeType$intType())
-  special$invoke_function_object(local$f)
   anonymous$3 := anonymous$2
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$3), dom$RuntimeType$intType())
   special$invoke_function_object(local$f)
-  anonymous$5 := anonymous$4
+  anonymous$4 := anonymous$1
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$4), dom$RuntimeType$intType())
+  special$invoke_function_object(local$f)
+  anonymous$5 := anonymous$0
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(anonymous$5), dom$RuntimeType$intType())
   ret$0 := anonymous$5
   goto label$ret$0


### PR DESCRIPTION
We currently pick the local variable to store the result of a function object call only after evaluating the parameters.  Picking the variable earlier makes the statement structure a little more straightforward, which will simplify future refactorings.