### PR TITLE
Implement statement modifier system for linearisation

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -370,9 +370,10 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             if (signature.returnType != UnitTypeEmbedding) body
             else Block(Assign(stmtCtx.defaultResolvedReturnTarget.variable, UnitLit), body)
         val bodyExp = FunctionExp(signature, unitExtendedBody, returnTarget.label)
-        val linearizer = Linearizer(SharedLinearizationState(anonVarProducer), SeqnBuilder(declaration.source), declaration.source)
+        val seqnBuilder = SeqnBuilder(declaration.source)
+        val linearizer = Linearizer(SharedLinearizationState(anonVarProducer), seqnBuilder, declaration.source)
         bodyExp.toViperUnusedResult(linearizer)
-        return FunctionBodyEmbedding(linearizer.block, returnTarget, bodyExp)
+        return FunctionBodyEmbedding(seqnBuilder.block, returnTarget, bodyExp)
     }
 
     private fun unimplementedTypeEmbedding(type: ConeKotlinType): TypeEmbedding =

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -102,7 +102,7 @@ sealed interface DefaultToBuiltinExpEmbedding : ExpEmbedding {
  */
 sealed interface DefaultStoringInExpEmbedding : ExpEmbedding {
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
-        ctx.addStatement(Stmt.assign(result.toViper(ctx), toViper(ctx)))
+        ctx.addStatement { Stmt.assign(result.toViper(ctx), toViper(ctx)) }
     }
 }
 
@@ -366,9 +366,9 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
 
         val fieldAccess = PrimitiveFieldAccess(receiverWrapper, field)
         val invariant = accessInvariant?.fillHole(receiverWrapper)?.pureToViper(toBuiltin = true, ctx.source)
-        invariant?.let { ctx.addStatement(Stmt.Inhale(it, ctx.source.asPosition)) }
-        ctx.addStatement(Stmt.assign(result.toViper(ctx), fieldAccess.pureToViper(toBuiltin = false, ctx.source), ctx.source.asPosition))
-        invariant?.let { ctx.addStatement(Stmt.Exhale(it, ctx.source.asPosition)) }
+        invariant?.let { ctx.addStatement { Stmt.Inhale(it, ctx.source.asPosition) } }
+        ctx.addStatement { Stmt.assign(result.toViper(ctx), fieldAccess.pureToViper(toBuiltin = false, ctx.source), ctx.source.asPosition) }
+        invariant?.let { ctx.addStatement { Stmt.Exhale(it, ctx.source.asPosition) } }
     }
 
     private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
@@ -376,7 +376,7 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
         hierarchyPath?.forEach { classType ->
             val predAcc = classType.predicateAccessInvariant().fillHole(receiverWrapper)
                 .pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess
-            predAcc?.let { ctx.addStatement(Stmt.Unfold(it)) }
+            predAcc?.let { ctx.addStatement { Stmt.Unfold(it) } }
         }
     }
 
@@ -397,9 +397,9 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
         val newValueViper = newValue.withType(field.type).toViper(ctx)
         val invariant =
             field.accessInvariantForAccess()?.fillHole(ExpWrapper(receiverViper, receiver.type))?.pureToViper(toBuiltin = true, ctx.source)
-        invariant?.let { ctx.addStatement(Stmt.Inhale(it, ctx.source.asPosition)) }
-        ctx.addStatement(Stmt.FieldAssign(Exp.FieldAccess(receiverViper, field.toViper()), newValueViper, ctx.source.asPosition))
-        invariant?.let { ctx.addStatement(Stmt.Exhale(it, ctx.source.asPosition)) }
+        invariant?.let { ctx.addStatement { Stmt.Inhale(it, ctx.source.asPosition) } }
+        ctx.addStatement { Stmt.FieldAssign(Exp.FieldAccess(receiverViper, field.toViper()), newValueViper, ctx.source.asPosition) }
+        invariant?.let { ctx.addStatement { Stmt.Exhale(it, ctx.source.asPosition) } }
     }
 
     override val debugTreeView: TreeView
@@ -445,7 +445,7 @@ data class Assign(val lhs: ExpEmbedding, val rhs: ExpEmbedding) : UnitResultExpE
             rhs.withType(lhs.type).toViperStoringIn(LinearizationVariableEmbedding(lhsViper.name, lhs.type), ctx)
         } else {
             val rhsViper = rhs.withType(lhs.type).toViper(ctx)
-            ctx.addStatement(Stmt.assign(lhsViper, rhsViper, ctx.source.asPosition))
+            ctx.addStatement { Stmt.assign(lhsViper, rhsViper, ctx.source.asPosition) }
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -25,7 +25,7 @@ data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : PureEx
 data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override val type: TypeEmbedding = NothingTypeEmbedding
     override fun toViperUnusedResult(ctx: LinearizationContext) {
-        ctx.addStatement{Stmt.Inhale(Exp.BoolLit(false, ctx.source.asPosition), ctx.source.asPosition)}
+        ctx.addStatement { Stmt.Inhale(Exp.BoolLit(false, ctx.source.asPosition), ctx.source.asPosition) }
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
@@ -34,7 +34,7 @@ data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation 
 
 data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        ctx.addStatement{Stmt.Assert(exp.toViperBuiltinType(ctx), ctx.source.asPosition)}
+        ctx.addStatement { Stmt.Assert(exp.toViperBuiltinType(ctx), ctx.source.asPosition) }
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
@@ -49,7 +49,7 @@ data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugT
  */
 data class InhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        ctx.addStatement{Stmt.Inhale(exp.toViperBuiltinType(ctx), ctx.source.asPosition)}
+        ctx.addStatement { Stmt.Inhale(exp.toViperBuiltinType(ctx), ctx.source.asPosition) }
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -25,7 +25,7 @@ data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : PureEx
 data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override val type: TypeEmbedding = NothingTypeEmbedding
     override fun toViperUnusedResult(ctx: LinearizationContext) {
-        ctx.addStatement(Stmt.Inhale(Exp.BoolLit(false, ctx.source.asPosition), ctx.source.asPosition))
+        ctx.addStatement{Stmt.Inhale(Exp.BoolLit(false, ctx.source.asPosition), ctx.source.asPosition)}
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
@@ -34,7 +34,7 @@ data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation 
 
 data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        ctx.addStatement(Stmt.Assert(exp.toViperBuiltinType(ctx), ctx.source.asPosition))
+        ctx.addStatement{Stmt.Assert(exp.toViperBuiltinType(ctx), ctx.source.asPosition)}
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
@@ -49,7 +49,7 @@ data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugT
  */
 data class InhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        ctx.addStatement(Stmt.Inhale(exp.toViperBuiltinType(ctx), ctx.source.asPosition))
+        ctx.addStatement{Stmt.Inhale(exp.toViperBuiltinType(ctx), ctx.source.asPosition)}
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
@@ -92,7 +92,7 @@ abstract class InhaleInvariants(val exp: ExpEmbedding) : StoredResultExpEmbeddin
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         exp.toViperStoringIn(result, ctx)
         for (invariant in invariants.fillHoles(result)) {
-            ctx.addStatement(Stmt.Inhale(invariant.pureToViper(toBuiltin = true, ctx.source), ctx.source.asPosition))
+            ctx.addStatement { Stmt.Inhale(invariant.pureToViper(toBuiltin = true, ctx.source), ctx.source.asPosition) }
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.linearization
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Label
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
@@ -18,16 +19,19 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
  * As such, an `ExpEmbedding` can represent a nested structure that has to be flattened into sequences
  * of statements. We call this process linearization.
  */
-interface LinearizationContext : SeqnBuildContext {
+interface LinearizationContext {
     val source: KtSourceElement?
 
     fun freshAnonVar(type: TypeEmbedding): AnonymousVariableEmbedding
 
     fun asBlock(action: LinearizationContext.() -> Unit): Stmt.Seqn
     fun <R> withPosition(newSource: KtSourceElement, action: LinearizationContext.() -> R): R
+
+    fun addStatement(buildStmt: () -> Stmt)
+    fun addDeclaration(decl: Declaration)
 }
 
 fun LinearizationContext.addLabel(label: Label) {
     addDeclaration(label.toDecl())
-    addStatement(label.toStmt())
+    addStatement { label.toStmt() }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -27,8 +27,10 @@ interface LinearizationContext {
     fun asBlock(action: LinearizationContext.() -> Unit): Stmt.Seqn
     fun <R> withPosition(newSource: KtSourceElement, action: LinearizationContext.() -> R): R
 
-    fun addStatement(buildStmt: () -> Stmt)
+    fun addStatement(buildStmt: LinearizationContext.() -> Stmt)
     fun addDeclaration(decl: Declaration)
+
+    fun addModifier(mod: StmtModifier)
 }
 
 fun LinearizationContext.addLabel(label: Label) {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.linearization
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 /**
@@ -17,7 +18,7 @@ data class Linearizer(
     val state: SharedLinearizationState,
     val seqnBuilder: SeqnBuilder,
     override val source: KtSourceElement?,
-) : LinearizationContext, SeqnBuildContext by seqnBuilder {
+) : LinearizationContext {
     override fun freshAnonVar(type: TypeEmbedding): AnonymousVariableEmbedding {
         val variable = state.freshAnonVar(type)
         addDeclaration(variable.toLocalVarDecl())
@@ -32,4 +33,12 @@ data class Linearizer(
 
     override fun <R> withPosition(newSource: KtSourceElement, action: LinearizationContext.() -> R): R =
         copy(source = newSource).action()
+
+    override fun addStatement(buildStmt: () -> Stmt) {
+        seqnBuilder.addStatement(buildStmt())
+    }
+
+    override fun addDeclaration(decl: Declaration) {
+        seqnBuilder.addDeclaration(decl)
+    }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
@@ -35,16 +35,13 @@ class PureLinearizer(override val source: KtSourceElement?) : LinearizationConte
         throw PureLinearizerMisuseException("withNewScopeToBlock")
     }
 
-    override fun addStatement(stmt: Stmt) {
+    override fun addStatement(buildStmt: () -> Stmt) {
         throw PureLinearizerMisuseException("addStatement")
     }
 
     override fun addDeclaration(decl: Declaration) {
         throw PureLinearizerMisuseException("addDeclaration")
     }
-
-    override val block: Stmt.Seqn
-        get() = throw PureLinearizerMisuseException("block")
 }
 
 fun ExpEmbedding.pureToViper(toBuiltin: Boolean, source: KtSourceElement? = null): Exp {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
@@ -35,12 +35,16 @@ class PureLinearizer(override val source: KtSourceElement?) : LinearizationConte
         throw PureLinearizerMisuseException("withNewScopeToBlock")
     }
 
-    override fun addStatement(buildStmt: () -> Stmt) {
+    override fun addStatement(buildStmt: LinearizationContext.() -> Stmt) {
         throw PureLinearizerMisuseException("addStatement")
     }
 
     override fun addDeclaration(decl: Declaration) {
         throw PureLinearizerMisuseException("addDeclaration")
+    }
+
+    override fun addModifier(mod: StmtModifier) {
+        throw PureLinearizerMisuseException("addModifier")
     }
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/StmtModifier.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/StmtModifier.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Position
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+/**
+ * Interface available to modifiers during statement generation.
+ */
+interface AddStatementContext {
+    val position: Position
+
+    // Adds a Viper statement directly to the block.
+    fun addImmediateStatement(statement: Stmt)
+}
+
+/**
+ * Represents a modifier to be applied to a generated Viper statement.
+ */
+sealed interface StmtModifier {
+    fun onEntry(ctx: AddStatementContext)
+    fun onExit(ctx: AddStatementContext) {}
+}
+
+class InhaleExhaleStmtModifier(private val permission: Exp) : StmtModifier {
+    override fun onEntry(ctx: AddStatementContext) {
+        ctx.addImmediateStatement(Stmt.Inhale(permission, ctx.position))
+    }
+
+    override fun onExit(ctx: AddStatementContext) {
+        ctx.addImmediateStatement(Stmt.Exhale(permission, ctx.position))
+    }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/StmtModifierTracker.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/StmtModifierTracker.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.linearization
+
+
+/**
+ * Tracks a set of modifications to be applied when adding a statement in a linearization context.
+ */
+class StmtModifierTracker {
+    private val modifiers: MutableList<StmtModifier> = mutableListOf()
+
+    fun add(modifier: StmtModifier) {
+        modifiers.add(modifier)
+    }
+
+    fun applyOnEntry(ctx: AddStatementContext) {
+        for (mod in modifiers) { mod.onEntry(ctx) }
+    }
+
+    fun applyOnExit(ctx: AddStatementContext) {
+        for (mod in modifiers.reversed()) { mod.onExit(ctx) }
+    }
+}


### PR DESCRIPTION
Previously, we have dealt with `Inhale` and `Exhale` statements by explicitly inserting them around statements that required them.  This change makes these statements modifiers on the statement they refer to; this should open the room for increased flexibility, and in particular make it easier to implement an unfolding/folding system.