### PR TITLE
Move `type` into local name

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ClassScopeNameMatcher.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ClassScopeNameMatcher.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 internal sealed class NameMatcher(val name: MangledName) {
-
     companion object {
         inline fun matchClassScope(name: MangledName, action: ClassScopeNameMatcher.() -> Nothing): Nothing {
             ClassScopeNameMatcher(name).action()
@@ -50,7 +49,6 @@ internal sealed class NameMatcher(val name: MangledName) {
 }
 
 internal class ClassScopeNameMatcher(name: MangledName) : NameMatcher(name) {
-
     override val className = (scopedName?.scope as? ClassScope)?.className
 
     inline fun ifNoReceiver(action: NameMatcher.() -> Unit) {
@@ -59,7 +57,8 @@ internal class ClassScopeNameMatcher(name: MangledName) : NameMatcher(name) {
     }
 
     inline fun ifFunctionName(name: String, action: ClassScopeNameMatcher.() -> Unit) {
-        if (scopedName?.name == FunctionKotlinName(Name.identifier(name)))
+        val functionName = scopedName?.name as? FunctionKotlinName
+        if (functionName?.name == Name.identifier(name))
             this.action()
     }
 
@@ -70,6 +69,5 @@ internal class ClassScopeNameMatcher(name: MangledName) : NameMatcher(name) {
 }
 
 internal class GlobalScopeNameMatcher(name: MangledName) : NameMatcher(name) {
-
     override val className = scopedName?.name as ClassKotlinName?
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
@@ -27,7 +27,7 @@ abstract class PrefixedKotlinName(prefix: String, name: Name) : KotlinName {
 }
 
 abstract class PrefixedKotlinNameWithType(prefix: String, name: Name, type: TypeEmbedding) : KotlinName {
-    override val mangled: String = "${prefix}_${name.asStringStripSpecialMarkers()}${'$'}${type.name.mangled}"
+    override val mangled: String = "${prefix}_${name.asStringStripSpecialMarkers()}\$${type.name.mangled}"
 }
 
 data class FunctionKotlinName(val name: Name, val type: TypeEmbedding) : PrefixedKotlinNameWithType("fun", name, type)
@@ -57,6 +57,6 @@ data class ClassKotlinName(val name: FqName) : KotlinName {
 }
 
 data class ConstructorKotlinName(val type: TypeEmbedding) : KotlinName {
-    override val mangled: String = "constructor${'$'}${type.name.mangled}"
+    override val mangled: String = "constructor\$${type.name.mangled}"
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.names
 
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -25,7 +26,11 @@ abstract class PrefixedKotlinName(prefix: String, name: Name) : KotlinName {
     override val mangled: String = "${prefix}_${name.asStringStripSpecialMarkers()}"
 }
 
-data class FunctionKotlinName(val name: Name) : PrefixedKotlinName("fun", name)
+abstract class PrefixedKotlinNameWithType(prefix: String, name: Name, type: TypeEmbedding) : KotlinName {
+    override val mangled: String = "${prefix}_${name.asStringStripSpecialMarkers()}${'$'}${type.name.mangled}"
+}
+
+data class FunctionKotlinName(val name: Name, val type: TypeEmbedding) : PrefixedKotlinNameWithType("fun", name, type)
 
 /**
  * This name will never occur in the viper output, but rather is used to lookup properties.
@@ -34,8 +39,16 @@ data class PropertyKotlinName(val name: Name) : PrefixedKotlinName("property_pro
 data class BackingFieldKotlinName(val name: Name) : PrefixedKotlinName("backing_field", name)
 data class GetterKotlinName(val name: Name) : PrefixedKotlinName("property_getter", name)
 data class SetterKotlinName(val name: Name) : PrefixedKotlinName("property_setter", name)
-data class ExtensionSetterKotlinName(val name: Name) : PrefixedKotlinName("ext_setter", name)
-data class ExtensionGetterKotlinName(val name: Name) : PrefixedKotlinName("ext_getter", name)
+data class ExtensionSetterKotlinName(val name: Name, val type: TypeEmbedding) : PrefixedKotlinNameWithType(
+    "ext_setter",
+    name, type
+)
+
+data class ExtensionGetterKotlinName(val name: Name, val type: TypeEmbedding) : PrefixedKotlinNameWithType
+    (
+    "ext_getter",
+    name, type
+)
 
 data class ClassKotlinName(val name: FqName) : KotlinName {
     override val mangled: String = "class_${name.asViperString()}"
@@ -43,7 +56,7 @@ data class ClassKotlinName(val name: FqName) : KotlinName {
     constructor(classSegments: List<String>) : this(FqName.fromSegments(classSegments))
 }
 
-data object ConstructorKotlinName : KotlinName {
-    override val mangled: String = "constructor"
+data class ConstructorKotlinName(val type: TypeEmbedding) : KotlinName {
+    override val mangled: String = "constructor${'$'}${type.name.mangled}"
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
@@ -27,14 +27,12 @@ fun CallableId.embedScopeName(): NameScope =
         else -> DefaultClassScope(packageName, ClassKotlinName(id.relativeClassName))
     }
 
-fun CallableId.embedScopedWithType(type: TypeEmbedding, name: KotlinName) = ScopedKotlinName(embedScopeName(), name, type)
-
 fun ClassId.embedName(): ScopedKotlinName = ScopedKotlinName(GlobalScope(packageFqName), ClassKotlinName(relativeClassName))
 fun CallableId.embedExtensionGetterName(type: TypeEmbedding): ScopedKotlinName =
-    embedScopedWithType(type, ExtensionGetterKotlinName(callableName))
+    ScopedKotlinName(embedScopeName(), ExtensionGetterKotlinName(callableName, type))
 
 fun CallableId.embedExtensionSetterName(type: TypeEmbedding): ScopedKotlinName =
-    embedScopedWithType(type, ExtensionSetterKotlinName(callableName))
+    ScopedKotlinName(embedScopeName(), ExtensionSetterKotlinName(callableName, type))
 
 private fun CallableId.embedMemberPropertyNameBase(isPrivate: Boolean, withAction: (Name) -> KotlinName): ScopedKotlinName {
     val id = classId ?: error("Embedding non-member property $callableName as a member.")
@@ -52,7 +50,7 @@ fun CallableId.embedMemberBackingFieldName(isPrivate: Boolean) = embedMemberProp
 
 fun CallableId.embedUnscopedPropertyName(): SimpleKotlinName = SimpleKotlinName(callableName)
 fun CallableId.embedFunctionName(type: TypeEmbedding): ScopedKotlinName =
-    embedScopedWithType(type, FunctionKotlinName(callableName))
+    ScopedKotlinName(embedScopeName(), FunctionKotlinName(callableName, type))
 
 fun Name.embedScopedLocalName(scope: Int) = ScopedKotlinName(LocalScope(scope), SimpleKotlinName(this))
 fun Name.embedParameterName() = ScopedKotlinName(ParameterScope, SimpleKotlinName(this))
@@ -74,7 +72,7 @@ fun FirPropertySymbol.embedMemberPropertyName() = callableId.embedMemberProperty
 )
 
 fun FirConstructorSymbol.embedName(ctx: ProgramConversionContext): ScopedKotlinName =
-    callableId.embedScopedWithType(ctx.embedType(this), ConstructorKotlinName)
+    ScopedKotlinName(callableId.embedScopeName(), ConstructorKotlinName(ctx.embedType(this)))
 
 fun FirFunctionSymbol<*>.embedName(ctx: ProgramConversionContext): ScopedKotlinName = when (this) {
     is FirPropertyAccessorSymbol -> if (isGetter) propertySymbol.embedGetterName(ctx) else propertySymbol.embedSetterName(ctx)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinName.kt
@@ -5,16 +5,15 @@
 
 package org.jetbrains.kotlin.formver.names
 
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.FqName
 
 /**
  * Name of a Kotlin entity in the original program in a specified scope and optionally distinguished by type.
  */
-data class ScopedKotlinName(val scope: NameScope, val name: KotlinName, val type: TypeEmbedding? = null) : MangledName {
+data class ScopedKotlinName(val scope: NameScope, val name: KotlinName) : MangledName {
     override val mangled: String
-        get() = listOfNotNull(scope.mangled, name.mangled, type?.name?.mangled).joinToString("$")
+        get() = listOf(scope.mangled, name.mangled).joinToString("$")
 }
 
 fun FqName.asViperString() = asString().replace('.', '$')


### PR DESCRIPTION
We were storing it as part of the scoped name, which doesn't really make sense: it's a disambiguator on the local name.