### PR TITLE
Add conditions for unique arguments

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.fir.FirAnnotationContainer
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.contracts.FirEffectDeclaration
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
@@ -48,7 +49,13 @@ val KtSourceElement?.asPosition: Position
 val FirBasedSymbol<*>.asSourceRole: SourceRole
     get() = SourceRole.FirSymbolHolder(this)
 
-fun FirBasedSymbol<*>.isUnique(session: FirSession) = hasAnnotation(
-    ClassId(FqName.fromSegments(listOf("org", "jetbrains", "kotlin", "formver", "plugin")), Name.identifier("Unique")),
-    session
-)
+fun annotationId(name: String): ClassId =
+    ClassId(FqName.fromSegments(listOf("org", "jetbrains", "kotlin", "formver", "plugin")), Name.identifier(name))
+
+fun FirBasedSymbol<*>.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
+
+fun FirBasedSymbol<*>.isBorrowed(session: FirSession) = hasAnnotation(annotationId("Borrowed"), session)
+
+fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
+
+fun FirAnnotationContainer.isBorrowed(session: FirSession) = hasAnnotation(annotationId("Borrowed"), session)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableSignature.kt
@@ -15,6 +15,8 @@ interface CallableSignature {
     val receiverType: TypeEmbedding?
     val paramTypes: List<TypeEmbedding>
     val returnType: TypeEmbedding
+    val returnsUnique: Boolean
+        get() = false
 
     /**
      * The flattened structure of the callable parameters: in case the callable has a receiver

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -241,7 +241,7 @@ data class FunctionExp(val signature: FullNamedFunctionSignature?, val body: Exp
             // Unfortunately Silicon for some reason does not allow Assumes. However, it doesn't matter as long as the
             // provenInvariants don't contain permissions.
             // TODO (inhale vs require) Decide if `predicateAccessInvariant` should be required rather than inhaled in the beginning of the body.
-            (arg.provenInvariants() + listOfNotNull(arg.predicateAccessInvariant())).forEach { invariant ->
+            (arg.provenInvariants() + listOfNotNull(arg.sharedPredicateAccessInvariant())).forEach { invariant ->
                 ctx.addStatement { Stmt.Inhale(invariant.toViperBuiltinType(ctx), ctx.source.asPosition) }
             }
         }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -126,6 +126,7 @@ method class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
   ensures acc(T_class_global$class_Baz(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Baz(ret), write)
 
 
 method global$fun_nullableReceiverNotNullSafeGet$fun_take$$return$T_Boolean()
@@ -182,6 +183,7 @@ method class_Baz$constructor$fun_take$$return$T_class_global$class_Baz()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Baz())
   ensures acc(T_class_global$class_Baz(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Baz(ret), write)
 
 
 method global$fun_nonNullableReceiverSafeGet$fun_take$$return$T_Boolean()
@@ -217,6 +219,7 @@ method class_ClassI$constructor$fun_take$T_Int$T_Int$return$T_class_global$class
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_ClassI())
   ensures acc(T_class_global$class_ClassI(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_ClassI(ret), write)
   ensures (unfolding acc(T_class_global$class_ClassI(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_x) ==
       dom$RuntimeType$intFromRef(local$x) &&
@@ -228,6 +231,7 @@ method class_ClassII$constructor$fun_take$T_class_global$class_Z$return$T_class_
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_ClassII())
   ensures acc(T_class_global$class_ClassII(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_ClassII(ret), write)
   ensures (unfolding acc(T_class_global$class_ClassII(ret), wildcard) in
       ret.public$backing_field_z == local$z)
 
@@ -236,6 +240,7 @@ method class_Z$constructor$fun_take$$return$T_class_global$class_Z()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Z())
   ensures acc(T_class_global$class_Z(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Z(ret), write)
 
 
 method global$fun_checkPrimary$fun_take$T_Int$T_Int$return$T_Boolean(local$x: Ref,

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.fir.diag.txt
@@ -38,6 +38,7 @@ method class_CustomList$constructor$fun_take$T_Int$T_Int$return$T_class_global$c
   ensures acc(ret.special$size, write)
   ensures dom$RuntimeType$intFromRef(ret.special$size) >= 0
   ensures acc(T_class_global$class_CustomList(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_CustomList(ret), write)
 
 
 method class_CustomList$fun_get$fun_take$T_class_global$class_CustomList$T_Int$return$T_Int(this: Ref,

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -55,6 +55,7 @@ method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Foo(ret), write)
 
 
 method global$fun_constructorReturnType$fun_take$$return$T_Boolean()

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_interfaces.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_interfaces.fir.diag.txt
@@ -75,30 +75,35 @@ method class_Impl12$constructor$fun_take$$return$T_class_global$class_Impl12()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl12())
   ensures acc(T_class_global$class_Impl12(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Impl12(ret), write)
 
 
 method class_Impl14$constructor$fun_take$$return$T_class_global$class_Impl14()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl14())
   ensures acc(T_class_global$class_Impl14(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Impl14(ret), write)
 
 
 method class_Impl23$constructor$fun_take$$return$T_class_global$class_Impl23()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl23())
   ensures acc(T_class_global$class_Impl23(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Impl23(ret), write)
 
 
 method class_Impl24$constructor$fun_take$$return$T_class_global$class_Impl24()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl24())
   ensures acc(T_class_global$class_Impl24(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Impl24(ret), write)
 
 
 method class_Impl3$constructor$fun_take$$return$T_class_global$class_Impl3()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl3())
   ensures acc(T_class_global$class_Impl3(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Impl3(ret), write)
 
 
 method global$fun_create6$fun_take$$return$T_class_global$class_InheritingInterfaceWithoutImplementation6()

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
@@ -66,12 +66,14 @@ method class_C$constructor$fun_take$$return$T_class_global$class_C()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_C())
   ensures acc(T_class_global$class_C(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_C(ret), write)
 
 
 method class_D$constructor$fun_take$$return$T_class_global$class_D()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_D())
   ensures acc(T_class_global$class_D(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_D(ret), write)
 
 
 method global$fun_extractPublic$fun_take$$return$T_Boolean()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
@@ -5,12 +5,14 @@ method class_B$constructor$fun_take$T_class_global$class_FieldB$return$T_class_g
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_B())
   ensures acc(T_class_global$class_B(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_B(ret), write)
 
 
 method class_FieldB$constructor$fun_take$$return$T_class_global$class_FieldB()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_FieldB())
   ensures acc(T_class_global$class_FieldB(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_FieldB(ret), write)
 
 
 method global$fun_createB$fun_take$$return$T_Unit() returns (ret$0: Ref)
@@ -45,18 +47,21 @@ method class_FirstBackingFieldClass$constructor$fun_take$$return$T_class_global$
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_FirstBackingFieldClass())
   ensures acc(T_class_global$class_FirstBackingFieldClass(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_FirstBackingFieldClass(ret), write)
 
 
 method class_NoBackingFieldClass$constructor$fun_take$$return$T_class_global$class_NoBackingFieldClass()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_NoBackingFieldClass())
   ensures acc(T_class_global$class_NoBackingFieldClass(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_NoBackingFieldClass(ret), write)
 
 
 method class_SecondBackingFieldClass$constructor$fun_take$T_Int$return$T_class_global$class_SecondBackingFieldClass(local$x: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_SecondBackingFieldClass())
   ensures acc(T_class_global$class_SecondBackingFieldClass(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_SecondBackingFieldClass(ret), write)
   ensures (unfolding acc(T_class_global$class_SecondBackingFieldClass(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_x) ==
       dom$RuntimeType$intFromRef(local$x))
@@ -99,6 +104,7 @@ method class_Y$constructor$fun_take$T_Int$return$T_class_global$class_Y(local$a:
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Y())
   ensures acc(T_class_global$class_Y(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Y(ret), write)
 
 
 method global$fun_createY$fun_take$$return$T_Unit() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
@@ -40,6 +40,7 @@ method class_Impl$constructor$fun_take$T_Int$return$T_class_global$class_Impl(lo
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Impl())
   ensures acc(T_class_global$class_Impl(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Impl(ret), write)
   ensures (unfolding acc(T_class_global$class_Impl(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_number) ==
       dom$RuntimeType$intFromRef(local$number))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/multiple_interfaces.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/multiple_interfaces.fir.diag.txt
@@ -3,6 +3,7 @@ method class_D$constructor$fun_take$$return$T_class_global$class_D()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_D())
   ensures acc(T_class_global$class_D(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_D(ret), write)
 
 
 method global$fun_testDiamond$fun_take$$return$T_Int() returns (ret$0: Ref)
@@ -26,12 +27,14 @@ method class_G$constructor$fun_take$$return$T_class_global$class_G()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_G())
   ensures acc(T_class_global$class_G(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_G(ret), write)
 
 
 method class_I$constructor$fun_take$$return$T_class_global$class_I()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_I())
   ensures acc(T_class_global$class_I(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_I(ret), write)
 
 
 method global$fun_testVarVal$fun_take$$return$T_Unit() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
@@ -8,6 +8,7 @@ method class_PrimitiveFields$constructor$fun_take$T_Int$T_Int$return$T_class_glo
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_PrimitiveFields())
   ensures acc(T_class_global$class_PrimitiveFields(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_PrimitiveFields(ret), write)
   ensures (unfolding acc(T_class_global$class_PrimitiveFields(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_a) ==
       dom$RuntimeType$intFromRef(local$a) &&
@@ -33,6 +34,7 @@ method class_Recursive$constructor$fun_take$NT_class_global$class_Recursive$retu
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Recursive())
   ensures acc(T_class_global$class_Recursive(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Recursive(ret), write)
   ensures (unfolding acc(T_class_global$class_Recursive(ret), wildcard) in
       ret.public$backing_field_a == local$a)
 
@@ -56,6 +58,7 @@ method class_FieldInBody$constructor$fun_take$T_Int$return$T_class_global$class_
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_FieldInBody())
   ensures acc(T_class_global$class_FieldInBody(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_FieldInBody(ret), write)
   ensures (unfolding acc(T_class_global$class_FieldInBody(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_c) ==
       dom$RuntimeType$intFromRef(local$c))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
@@ -5,12 +5,14 @@ method class_NoPrimaryConstructor$constructor$fun_take$T_Boolean$return$T_class_
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_NoPrimaryConstructor())
   ensures acc(T_class_global$class_NoPrimaryConstructor(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_NoPrimaryConstructor(ret), write)
 
 
 method class_NoPrimaryConstructor$constructor$fun_take$T_Int$return$T_class_global$class_NoPrimaryConstructor(local$n: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_NoPrimaryConstructor())
   ensures acc(T_class_global$class_NoPrimaryConstructor(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_NoPrimaryConstructor(ret), write)
 
 
 method global$fun_onlySecondConstructors$fun_take$$return$T_Unit()
@@ -32,12 +34,14 @@ method class_BothConstructors$constructor$fun_take$T_Boolean$return$T_class_glob
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_BothConstructors())
   ensures acc(T_class_global$class_BothConstructors(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_BothConstructors(ret), write)
 
 
 method class_BothConstructors$constructor$fun_take$T_Int$return$T_class_global$class_BothConstructors(local$a: Ref)
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_BothConstructors())
   ensures acc(T_class_global$class_BothConstructors(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_BothConstructors(ret), write)
   ensures (unfolding acc(T_class_global$class_BothConstructors(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_a) ==
       dom$RuntimeType$intFromRef(local$a))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/setters.fir.diag.txt
@@ -23,6 +23,7 @@ method class_PrimitiveField$constructor$fun_take$T_Int$return$T_class_global$cla
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_PrimitiveField())
   ensures acc(T_class_global$class_PrimitiveField(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_PrimitiveField(ret), write)
 
 
 method global$fun_testReferenceFieldSetter$fun_take$T_class_global$class_ReferenceField$return$T_Unit(local$rf: Ref)
@@ -65,6 +66,7 @@ method class_PrimitiveProperty$constructor$fun_take$$return$T_class_global$class
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_PrimitiveProperty())
   ensures acc(T_class_global$class_PrimitiveProperty(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_PrimitiveProperty(ret), write)
 
 
 method global$fun_testReferencePropertySetter$fun_take$T_class_global$class_ReferenceProperty$return$T_Unit(local$rp: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
@@ -1,4 +1,4 @@
-/unique_predicates.kt:(217,231): info: Generated Viper text for use_unique_foo:
+/unique_predicates.kt:(269,283): info: Generated Viper text for unique_foo_arg:
 field public$backing_field_w: Ref
 
 field public$backing_field_x: Ref
@@ -54,12 +54,146 @@ predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
   true
 }
 
-method global$fun_use_unique_foo$fun_take$T_class_global$class_Foo$return$T_Unit(local$foo: Ref)
+method global$fun_unique_foo_arg$fun_take$T_class_global$class_Foo$return$T_Unit(local$foo: Ref)
   returns (ret$0: Ref)
+  requires acc(Unique$T_class_global$class_Foo(local$foo), write)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
 {
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$foo), dom$RuntimeType$T_class_global$class_Foo())
   inhale acc(T_class_global$class_Foo(local$foo), wildcard)
   ret$0 := dom$RuntimeType$unitValue()
+  label label$ret$0
+}
+
+/unique_predicates.kt:(310,329): info: Generated Viper text for nullable_unique_arg:
+predicate T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+method global$fun_nullable_unique_arg$fun_take$NT_class_global$class_T$return$T_Unit(local$t: Ref)
+  returns (ret$0: Ref)
+  requires local$t != dom$RuntimeType$nullValue() ==>
+    acc(Unique$T_class_global$class_T(local$t), write)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$t), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_T()))
+  inhale local$t != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_T(local$t), wildcard)
+  ret$0 := dom$RuntimeType$unitValue()
+  label label$ret$0
+}
+
+/unique_predicates.kt:(353,372): info: Generated Viper text for borrowed_unique_arg:
+predicate T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+method global$fun_borrowed_unique_arg$fun_take$T_class_global$class_T$return$T_Unit(local$t: Ref)
+  returns (ret$0: Ref)
+  requires acc(Unique$T_class_global$class_T(local$t), write)
+  ensures acc(Unique$T_class_global$class_T(local$t), write)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$t), dom$RuntimeType$T_class_global$class_T())
+  inhale acc(T_class_global$class_T(local$t), wildcard)
+  ret$0 := dom$RuntimeType$unitValue()
+  label label$ret$0
+}
+
+/unique_predicates.kt:(424,439): info: Generated Viper text for unique_receiver:
+predicate T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+method global$fun_unique_receiver$fun_take$T_class_global$class_T$return$T_Unit(this: Ref)
+  returns (ret$0: Ref)
+  requires acc(Unique$T_class_global$class_T(this), write)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_T())
+  inhale acc(T_class_global$class_T(this), wildcard)
+  ret$0 := dom$RuntimeType$unitValue()
+  label label$ret$0
+}
+
+/unique_predicates.kt:(488,512): info: Generated Viper text for borrowed_unique_receiver:
+predicate T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+method global$fun_borrowed_unique_receiver$fun_take$T_class_global$class_T$return$T_Unit(this: Ref)
+  returns (ret$0: Ref)
+  requires acc(Unique$T_class_global$class_T(this), write)
+  ensures acc(Unique$T_class_global$class_T(this), write)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+{
+  inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_T())
+  inhale acc(T_class_global$class_T(this), wildcard)
+  ret$0 := dom$RuntimeType$unitValue()
+  label label$ret$0
+}
+
+/unique_predicates.kt:(531,544): info: Generated Viper text for unique_result:
+predicate T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+method class_T$constructor$fun_take$$return$T_class_global$class_T()
+  returns (ret: Ref)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_T())
+  ensures acc(T_class_global$class_T(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_T(ret), write)
+
+
+method global$fun_unique_result$fun_take$$return$T_class_global$class_T()
+  returns (ret$0: Ref)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$T_class_global$class_T())
+  ensures acc(T_class_global$class_T(ret$0), wildcard)
+  ensures acc(Unique$T_class_global$class_T(ret$0), write)
+{
+  ret$0 := class_T$constructor$fun_take$$return$T_class_global$class_T()
+  goto label$ret$0
+  label label$ret$0
+}
+
+/unique_predicates.kt:(579,601): info: Generated Viper text for unique_nullable_result:
+predicate T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+predicate Unique$T_class_global$class_T(special$class$predicate$subject: Ref) {
+  true
+}
+
+method global$fun_unique_nullable_result$fun_take$$return$NT_class_global$class_T()
+  returns (ret$0: Ref)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$nullable(dom$RuntimeType$T_class_global$class_T()))
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(T_class_global$class_T(ret$0), wildcard)
+  ensures ret$0 != dom$RuntimeType$nullValue() ==>
+    acc(Unique$T_class_global$class_T(ret$0), write)
+{
+  ret$0 := dom$RuntimeType$nullValue()
+  goto label$ret$0
   label label$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.kt
@@ -2,6 +2,7 @@
 // NEVER_VALIDATE
 
 import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
 
 class T()
 
@@ -9,4 +10,18 @@ open class S()
 
 class Foo(val w: Int, var x: Int, @property:Unique val y: T, @property:Unique var z: T) : S()
 
-fun <!VIPER_TEXT!>use_unique_foo<!>(@Unique foo: Foo) {}
+fun <!VIPER_TEXT!>unique_foo_arg<!>(@Unique foo: Foo) {}
+
+fun <!VIPER_TEXT!>nullable_unique_arg<!>(@Unique t: T?) {}
+
+fun <!VIPER_TEXT!>borrowed_unique_arg<!>(@Unique @Borrowed t: T) {}
+
+fun @receiver:Unique T.<!VIPER_TEXT!>unique_receiver<!>() {}
+
+fun @receiver:Unique @receiver:Borrowed T.<!VIPER_TEXT!>borrowed_unique_receiver<!>() {}
+
+@Unique
+fun <!VIPER_TEXT!>unique_result<!>() : T { return T() }
+
+@Unique
+fun <!VIPER_TEXT!>unique_nullable_result<!>() : T? { return null }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -305,6 +305,7 @@ method class_Foo$constructor$fun_take$T_Int$return$T_class_global$class_Foo(loca
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Foo(ret), write)
   ensures (unfolding acc(T_class_global$class_Foo(ret), wildcard) in
       dom$RuntimeType$intFromRef(ret.public$backing_field_x) ==
       dom$RuntimeType$intFromRef(local$x))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -73,12 +73,14 @@ method class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
   ensures acc(T_class_global$class_Bar(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Bar(ret), write)
 
 
 method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Foo(ret), write)
 
 
 method global$fun_fakePrint$fun_take$T_Boolean$return$T_Unit(local$truth: Ref)
@@ -126,6 +128,7 @@ method class_Bar$constructor$fun_take$$return$T_class_global$class_Bar()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Bar())
   ensures acc(T_class_global$class_Bar(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Bar(ret), write)
 
 
 method class_Bar$fun_baz$fun_take$T_class_global$class_Bar$T_class_global$class_Bar$return$T_Unit(this: Ref,
@@ -144,6 +147,7 @@ method class_Foo$constructor$fun_take$$return$T_class_global$class_Foo()
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Foo())
   ensures acc(T_class_global$class_Foo(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Foo(ret), write)
 
 
 method global$fun_testClassFunctionOverloading$fun_take$$return$T_Unit()

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
@@ -21,6 +21,7 @@ method class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(loc
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Box())
   ensures acc(T_class_global$class_Box(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Box(ret), write)
 
 
 method global$fun_createBox$fun_take$$return$T_Int() returns (ret$0: Ref)
@@ -56,6 +57,7 @@ method class_Box$constructor$fun_take$NT_Any$return$T_class_global$class_Box(loc
   returns (ret: Ref)
   ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret), dom$RuntimeType$T_class_global$class_Box())
   ensures acc(T_class_global$class_Box(ret), wildcard)
+  ensures acc(Unique$T_class_global$class_Box(ret), write)
 
 
 method global$fun_setGenericField$fun_take$$return$T_Unit()


### PR DESCRIPTION
This PR adds preconditions and postconditions for:
- unique and borrowed parameters
- unique and borrowed receivers
- unique return values
- constructors return values

Basic (without unfolding) function calls with these conditions will be supported in an upcoming PR