### PR TITLE
Stdlib Functions for Tests Accessible with Bodies

### DIFF
--- a/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.fir.diag.txt
@@ -1,16 +1,185 @@
-/stdlib_replacement_tests.kt:(151,160): info: Generated Viper text for useRepeat:
-method global$fun_useRepeat$fun_take$$return$T_Unit() returns (ret$0: Ref)
-  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
-  ensures true
+/stdlib_replacement_tests.kt:(104,113): info: Generated Viper text for useChecks:
+method f$useChecks$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var ret$1: Ref
-  var anonymous$0: Ref
+  var anon$0: Ref
   var ret$2: Ref
-  var anonymous$1: Ref
-  ret$0 := dom$RuntimeType$unitValue()
-  anonymous$0 := dom$RuntimeType$boolToRef(true)
-  label label$ret$1
-  anonymous$1 := dom$RuntimeType$boolToRef(true)
-  label label$ret$2
-  label label$ret$0
+  var anon$1: Ref
+  anon$0 := df$rt$boolToRef(true)
+  label lbl$ret$1
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$1), df$rt$unitType())
+  anon$1 := df$rt$boolToRef(true)
+  label lbl$ret$2
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/stdlib_replacement_tests.kt:(298,305): info: Generated Viper text for useRuns:
+method f$useRuns$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$2: Ref
+  var anon$3: Ref
+  var ret$1: Ref
+  var anon$4: Ref
+  var ret$2: Ref
+  var anon$5: Ref
+  var anon$6: Ref
+  var ret$3: Ref
+  var anon$0: Ref
+  var anon$7: Ref
+  var ret$4: Ref
+  var anon$1: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  ret$2 := sp$plusInts(p$x, df$rt$intToRef(1))
+  goto lbl$ret$2
+  label lbl$ret$2
+  anon$4 := ret$2
+  ret$1 := anon$4
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$1), df$rt$nullable(df$rt$anyType()))
+  goto lbl$ret$1
+  label lbl$ret$1
+  anon$3 := ret$1
+  anon$2 := anon$3
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
+  assert df$rt$intFromRef(anon$2) == 1 + df$rt$intFromRef(p$x)
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+  anon$0 := p$x
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  anon$1 := anon$0
+  ret$4 := sp$plusInts(anon$1, df$rt$intToRef(1))
+  goto lbl$ret$4
+  label lbl$ret$4
+  anon$7 := ret$4
+  ret$3 := anon$7
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$3), df$rt$nullable(df$rt$anyType()))
+  goto lbl$ret$3
+  label lbl$ret$3
+  anon$6 := ret$3
+  anon$5 := anon$6
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$5), df$rt$intType())
+  assert df$rt$intFromRef(anon$5) == 1 + df$rt$intFromRef(p$x)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/stdlib_replacement_tests.kt:(403,410): info: Generated Viper text for useAlso:
+method f$useAlso$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$2: Ref
+  var anon$3: Ref
+  var ret$1: Ref
+  var anon$0: Ref
+  var ret$2: Ref
+  var anon$1: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  anon$1 := anon$0
+  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(p$x)
+  label lbl$ret$2
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
+  ret$1 := anon$0
+  goto lbl$ret$1
+  label lbl$ret$1
+  anon$3 := ret$1
+  anon$2 := anon$3
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/stdlib_replacement_tests.kt:(475,481): info: Generated Viper text for useLet:
+method f$useLet$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$2: Ref
+  var anon$3: Ref
+  var ret$1: Ref
+  var anon$0: Ref
+  var anon$4: Ref
+  var ret$2: Ref
+  var anon$1: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+  anon$0 := p$x
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  anon$1 := anon$0
+  ret$2 := sp$plusInts(anon$1, df$rt$intToRef(1))
+  goto lbl$ret$2
+  label lbl$ret$2
+  anon$4 := ret$2
+  ret$1 := anon$4
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$1), df$rt$nullable(df$rt$anyType()))
+  goto lbl$ret$1
+  label lbl$ret$1
+  anon$3 := ret$1
+  anon$2 := anon$3
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
+  assert df$rt$intFromRef(anon$2) == 1 + df$rt$intFromRef(p$x)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/stdlib_replacement_tests.kt:(543,550): info: Generated Viper text for useWith:
+method f$useWith$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$2: Ref
+  var anon$3: Ref
+  var ret$1: Ref
+  var anon$0: Ref
+  var anon$4: Ref
+  var ret$2: Ref
+  var anon$1: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  anon$1 := anon$0
+  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(p$x)
+  label lbl$ret$2
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
+  anon$4 := ret$2
+  ret$1 := anon$4
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$1), df$rt$nullable(df$rt$anyType()))
+  goto lbl$ret$1
+  label lbl$ret$1
+  anon$3 := ret$1
+  anon$2 := anon$3
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$unitType())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/stdlib_replacement_tests.kt:(616,624): info: Generated Viper text for useApply:
+method f$useApply$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$2: Ref
+  var anon$3: Ref
+  var ret$1: Ref
+  var anon$0: Ref
+  var ret$2: Ref
+  var anon$1: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  anon$1 := anon$0
+  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(p$x)
+  label lbl$ret$2
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
+  ret$1 := anon$0
+  goto lbl$ret$1
+  label lbl$ret$1
+  anon$3 := ret$1
+  anon$2 := anon$3
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.fir.diag.txt
@@ -1,0 +1,16 @@
+/stdlib_replacement_tests.kt:(151,160): info: Generated Viper text for useRepeat:
+method global$fun_useRepeat$fun_take$$return$T_Unit() returns (ret$0: Ref)
+  ensures dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$unitType())
+  ensures true
+{
+  var ret$1: Ref
+  var anonymous$0: Ref
+  var ret$2: Ref
+  var anonymous$1: Ref
+  ret$0 := dom$RuntimeType$unitValue()
+  anonymous$0 := dom$RuntimeType$boolToRef(true)
+  label label$ret$1
+  anonymous$1 := dom$RuntimeType$boolToRef(true)
+  label label$ret$2
+  label label$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt
@@ -1,0 +1,17 @@
+// REPLACE_STDLIB_EXTENSIONS
+
+import kotlin.contracts.contract
+import kotlin.contracts.ExperimentalContracts
+
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>useRepeat<!>(): Unit {
+    contract {
+        returns()
+    }
+    check(true)
+    check(true) { "Lazy message" }
+}
+
+// TODO: add test for `repeat` (we actually have a bug there because we require unsatisfied precondition in loops)
+
+// TODO: add tests for `let`, `apply`, `with`, `run`, `also`

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt
@@ -1,17 +1,33 @@
 // REPLACE_STDLIB_EXTENSIONS
+// ALWAYS_VALIDATE
 
-import kotlin.contracts.contract
-import kotlin.contracts.ExperimentalContracts
+import org.jetbrains.kotlin.formver.plugin.verify
 
-@OptIn(ExperimentalContracts::class)
-fun <!VIPER_TEXT!>useRepeat<!>(): Unit {
-    contract {
-        returns()
-    }
+fun <!VIPER_TEXT!>useChecks<!>(): Unit {
     check(true)
     check(true) { "Lazy message" }
 }
 
 // TODO: add test for `repeat` (we actually have a bug there because we require unsatisfied precondition in loops)
 
-// TODO: add tests for `let`, `apply`, `with`, `run`, `also`
+fun <!VIPER_TEXT!>useRuns<!>(x: Int): Unit {
+    verify(run { x + 1 } == 1 + x)
+    verify(x.run { plus(1) } == 1 + x)
+}
+
+fun <!VIPER_TEXT!>useAlso<!>(x: Int): Unit {
+    (x + 1).also { verify(it == 1 + x) }
+}
+
+fun <!VIPER_TEXT!>useLet<!>(x: Int): Unit {
+    verify(x.let { it + 1 } == 1 + x)
+}
+
+fun <!VIPER_TEXT!>useWith<!>(x: Int): Unit {
+    with(x + 1) { verify(this == 1 + x) }
+}
+
+fun <!VIPER_TEXT!>useApply<!>(x: Int): Unit {
+    (x + 1).apply { verify(this == 1 + x) }
+}
+

--- a/plugins/formal-verification/testData/stdlibReplacements.kt
+++ b/plugins/formal-verification/testData/stdlibReplacements.kt
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.formver.plugin.NeverConvert
+import org.jetbrains.kotlin.formver.plugin.verify
 
 @NeverConvert
 inline fun <T> run(block: () -> T): T = block()
@@ -23,3 +24,23 @@ inline fun <T> T.apply(block: T.() -> Unit): T = {
 
 @NeverConvert
 inline fun <T, R> with(receiver: T, block: T.() -> R): R = receiver.block()
+
+@NeverConvert
+inline fun repeat(times: Int, action: (Int) -> Unit) {
+    var counter: Int = 0
+    while (counter < times) {
+        action(counter)
+        counter = counter + 1
+    }
+}
+
+// `check`s are intended for runtime, we have our own `verify` to check static properties
+@NeverConvert
+inline fun check(value: Boolean) {
+}
+
+@NeverConvert
+inline fun check(value: Boolean, lazyMessage: () -> Any) {
+}
+
+

--- a/plugins/formal-verification/testData/stdlibReplacements.kt
+++ b/plugins/formal-verification/testData/stdlibReplacements.kt
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.formver.plugin.NeverConvert
-import org.jetbrains.kotlin.formver.plugin.verify
 
 @NeverConvert
 inline fun <T> run(block: () -> T): T = block()
@@ -17,7 +16,7 @@ inline fun <T> T.also(block: (T) -> Unit): T {
 inline fun <T, R> T.let(block: (T) -> R): R = block(this)
 
 @NeverConvert
-inline fun <T> T.apply(block: T.() -> Unit): T = {
+inline fun <T> T.apply(block: T.() -> Unit): T {
     this.block()
     return this
 }

--- a/plugins/formal-verification/testData/stdlibReplacements.kt
+++ b/plugins/formal-verification/testData/stdlibReplacements.kt
@@ -1,0 +1,25 @@
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+
+@NeverConvert
+inline fun <T> run(block: () -> T): T = block()
+
+@NeverConvert
+inline fun <T, R> T.run(block: T.() -> R): R = block()
+
+@NeverConvert
+inline fun <T> T.also(block: (T) -> Unit): T {
+    block(this)
+    return this
+}
+
+@NeverConvert
+inline fun <T, R> T.let(block: (T) -> R): R = block(this)
+
+@NeverConvert
+inline fun <T> T.apply(block: T.() -> Unit): T = {
+    this.block()
+    return this
+}
+
+@NeverConvert
+inline fun <T, R> with(receiver: T, block: T.() -> R): R = receiver.block()

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -210,6 +210,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     public void testViper_casts_while_inlining() {
       runTest("plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.kt");
     }
+
+    @Test
+    @TestMetadata("stdlib_replacement_tests.kt")
+    public void testStdlib_replacement_tests() {
+      runTest("plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt");
+    }
   }
 
   @Nested

--- a/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/runners/PluginPrototypeTests.kt
+++ b/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/runners/PluginPrototypeTests.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.plugin.runners
 
 import org.jetbrains.kotlin.formver.plugin.services.ExtensionRegistrarConfigurator
 import org.jetbrains.kotlin.formver.plugin.services.PluginAnnotationsProvider
+import org.jetbrains.kotlin.formver.plugin.services.StdlibReplacementsProvider
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.RENDER_DIAGNOSTICS_FULL_TEXT
 import org.jetbrains.kotlin.test.directives.DiagnosticsDirectives.STOP_ON_FAILURE
@@ -29,6 +30,8 @@ fun TestConfigurationBuilder.commonFirWithPluginFrontendConfiguration() {
         +RENDER_DIAGNOSTICS_FULL_TEXT
         +STOP_ON_FAILURE
     }
+
+    useAdditionalSourceProviders(::StdlibReplacementsProvider)
 
     useConfigurators(
         ::PluginAnnotationsProvider,

--- a/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/plugins/formal-verification/tests/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -13,12 +13,17 @@ import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VAL
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FULL_VIPER_DUMP
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.NEVER_VALIDATE
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.RENDER_PREDICATES
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.REPLACE_STDLIB_EXTENSIONS
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.UNIQUE_CHECK_ONLY
 import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
+import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.SimpleDirectivesContainer
+import org.jetbrains.kotlin.test.model.TestFile
 import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.AdditionalSourceProvider
 import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.TestServices
+import java.io.File
 
 class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
     override val directiveContainers: List<DirectivesContainer>
@@ -77,4 +82,17 @@ object FormVerDirectives : SimpleDirectivesContainer() {
     val UNIQUE_CHECK_ONLY by directive(
         description = "Do uniqueness checking"
     )
+
+    val REPLACE_STDLIB_EXTENSIONS by directive(
+        description = "Use replacements for stdlib functions like run with accessible bodies"
+    )
+}
+
+class StdlibReplacementsProvider(testServices: TestServices, baseDir: String = ".") : AdditionalSourceProvider(testServices) {
+    private val libraryPath = "$baseDir/plugins/formal-verification/testData/stdlibReplacements.kt"
+
+    override fun produceAdditionalFiles(globalDirectives: RegisteredDirectives, module: TestModule) =
+        if (containsDirective(globalDirectives, module, REPLACE_STDLIB_EXTENSIONS))
+            listOf(File(libraryPath).toTestFile())
+        else emptyList()
 }


### PR DESCRIPTION
Our plugin currently cannot inline functions like `run`, `let` etc. from standard library because it does not have access to their implementation (i.e. fir body). This PR introduces a (half-) measure for our tests: just use ```// REPLACE_STDLIB_EXTENSIONS``` in order to use our own implementations which are basically copied from stdlib.