### PR TITLE
Add a builder for `TypeEmbedding`s

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -119,7 +119,11 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
      */
     private fun embedClass(symbol: FirRegularClassSymbol): ClassTypeEmbedding {
         val className = symbol.classId.embedName()
-        val embedding = classes.getOrPut(className) { ClassTypeEmbedding(className) }
+        val embedding = classes.getOrPut(className) {
+            buildType {
+                klass { withName(className) }
+            } as ClassTypeEmbedding
+        }
         if (embedding.hasDetails) return embedding
 
         val newDetails = ClassEmbeddingDetails(embedding, symbol.classKind == ClassKind.INTERFACE)
@@ -150,7 +154,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
 
     override fun embedType(type: ConeKotlinType): TypeEmbedding = when {
         type is ConeErrorType -> error("Encountered an erroneous type: $type")
-        type is ConeTypeParameterType -> buildType { nullable = true; any() }
+        type is ConeTypeParameterType -> buildType { isNullable = true; any() }
         type.isUnit -> buildType { unit() }
         type.isInt -> buildType { int() }
         type.isBoolean -> buildType { boolean() }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -7,10 +7,17 @@ package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.formver.conversion.AccessPolicy
-import org.jetbrains.kotlin.formver.embeddings.expression.*
-import org.jetbrains.kotlin.formver.names.*
+import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.embeddings.expression.FieldAccess
+import org.jetbrains.kotlin.formver.embeddings.expression.GeCmp
+import org.jetbrains.kotlin.formver.embeddings.expression.IntLit
+import org.jetbrains.kotlin.formver.names.NameMatcher
+import org.jetbrains.kotlin.formver.names.ScopedKotlinName
+import org.jetbrains.kotlin.formver.names.SpecialName
 import org.jetbrains.kotlin.formver.viper.MangledName
-import org.jetbrains.kotlin.formver.viper.ast.*
+import org.jetbrains.kotlin.formver.viper.ast.Field
+import org.jetbrains.kotlin.formver.viper.ast.PermExp
+import org.jetbrains.kotlin.formver.viper.ast.Type
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 /**
@@ -67,7 +74,7 @@ class UserFieldEmbedding(
 
 object ListSizeFieldEmbedding : FieldEmbedding {
     override val name = SpecialName("size")
-    override val type = IntTypeEmbedding
+    override val type = buildType { int() }
     override val viperType = Type.Ref
     override val accessPolicy = AccessPolicy.ALWAYS_WRITEABLE
     override val includeInShortDump: Boolean = true

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.formver.embeddings.callables.CallableSignatureData
+import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 
 /**
  * We use "pretype" to refer to types that do not contain information on nullability or
@@ -62,5 +63,19 @@ class FunctionPretypeBuilder : PretypeBuilder {
     override fun complete(): TypeEmbedding {
         require(returnType != null) { "Return type not set" }
         return FunctionTypeEmbedding(CallableSignatureData(receiverType, paramTypes, returnType!!))
+    }
+}
+
+class ClassPretypeBuilder : PretypeBuilder {
+    private var className: ScopedKotlinName? = null
+
+    fun withName(name: ScopedKotlinName) {
+        require(className == null) { "Class name already set" }
+        className = name
+    }
+
+    override fun complete(): TypeEmbedding {
+        require(className != null) { "Class name not set" }
+        return ClassTypeEmbedding(className!!)
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+import org.jetbrains.kotlin.formver.embeddings.callables.CallableSignatureData
+
+/**
+ * We use "pretype" to refer to types that do not contain information on nullability or
+ * other flags.
+ */
+interface PretypeBuilder {
+    /**
+     * Turn the builder into a `TypeEmbedding`.
+     *
+     * We allow this deferral so that the build can be done in any order.
+     */
+    fun complete(): TypeEmbedding
+}
+
+object UnitPretypeBuilder : PretypeBuilder {
+    override fun complete(): TypeEmbedding = UnitTypeEmbedding
+}
+
+object NothingPretypeBuilder : PretypeBuilder {
+    override fun complete(): TypeEmbedding = NothingTypeEmbedding
+}
+
+object AnyPretypeBuilder : PretypeBuilder {
+    override fun complete(): TypeEmbedding = AnyTypeEmbedding
+}
+
+object IntPretypeBuilder : PretypeBuilder {
+    override fun complete(): TypeEmbedding = IntTypeEmbedding
+}
+
+object BooleanPretypeBuilder : PretypeBuilder {
+    override fun complete(): TypeEmbedding = BooleanTypeEmbedding
+}
+
+class FunctionPretypeBuilder : PretypeBuilder {
+    private val paramTypes = mutableListOf<TypeEmbedding>()
+    private var receiverType: TypeEmbedding? = null
+    private var returnType: TypeEmbedding? = null
+
+    fun withParam(paramInit: TypeBuilder.() -> PretypeBuilder) {
+        paramTypes.add(buildType { paramInit() })
+    }
+
+    fun withReceiver(receiverInit: TypeBuilder.() -> PretypeBuilder) {
+        require(receiverType == null) { "Receiver already set" }
+        receiverType = buildType { receiverInit() }
+    }
+
+    fun withReturnType(returnTypeInit: TypeBuilder.() -> PretypeBuilder) {
+        require(returnType == null) { "Return type already set" }
+        returnType = buildType { returnTypeInit() }
+    }
+
+    override fun complete(): TypeEmbedding {
+        require(returnType != null) { "Return type not set" }
+        return FunctionTypeEmbedding(CallableSignatureData(receiverType, paramTypes, returnType!!))
+    }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
@@ -13,7 +13,7 @@ package org.jetbrains.kotlin.formver.embeddings
  * state at any point, though a `TypeBuilder`, `PretypeBuilder` pair does.
  */
 class TypeBuilder {
-    var nullable = false
+    var isNullable = false
 
     fun complete(init: TypeBuilder.() -> PretypeBuilder): TypeEmbedding {
         return completeWithPretypeBuilder(init())
@@ -21,7 +21,7 @@ class TypeBuilder {
 
     private fun completeWithPretypeBuilder(subBuilder: PretypeBuilder): TypeEmbedding {
         val subResult = subBuilder.complete()
-        return if (nullable) NullableTypeEmbedding(subResult) else subResult
+        return if (isNullable) NullableTypeEmbedding(subResult) else subResult
     }
 
     fun unit() = UnitPretypeBuilder
@@ -30,10 +30,11 @@ class TypeBuilder {
     fun int() = IntPretypeBuilder
     fun boolean() = BooleanPretypeBuilder
     fun function(init: FunctionPretypeBuilder.() -> Unit) = FunctionPretypeBuilder().also { it.init() }
+    fun klass(init: ClassPretypeBuilder.() -> Unit) = ClassPretypeBuilder().also { it.init() }
 }
 
 fun TypeBuilder.nullableAny(): AnyPretypeBuilder {
-    nullable = true
+    isNullable = true
     return any()
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
@@ -15,9 +15,7 @@ package org.jetbrains.kotlin.formver.embeddings
 class TypeBuilder {
     var isNullable = false
 
-    fun complete(init: TypeBuilder.() -> PretypeBuilder): TypeEmbedding {
-        return completeWithPretypeBuilder(init())
-    }
+    fun complete(init: TypeBuilder.() -> PretypeBuilder): TypeEmbedding = completeWithPretypeBuilder(init())
 
     private fun completeWithPretypeBuilder(subBuilder: PretypeBuilder): TypeEmbedding {
         val subResult = subBuilder.complete()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings
+
+/**
+ * Builder for a `TypeEmbedding`.
+ *
+ * We split most of the work into `PretypeBuilder`, which builds the type modulo nullability
+ * (and potentially other flags).  As a result, the builder does not contain the full building
+ * state at any point, though a `TypeBuilder`, `PretypeBuilder` pair does.
+ */
+class TypeBuilder {
+    var nullable = false
+
+    fun complete(init: TypeBuilder.() -> PretypeBuilder): TypeEmbedding {
+        return completeWithPretypeBuilder(init())
+    }
+
+    private fun completeWithPretypeBuilder(subBuilder: PretypeBuilder): TypeEmbedding {
+        val subResult = subBuilder.complete()
+        return if (nullable) NullableTypeEmbedding(subResult) else subResult
+    }
+
+    fun unit() = UnitPretypeBuilder
+    fun nothing() = NothingPretypeBuilder
+    fun any() = AnyPretypeBuilder
+    fun int() = IntPretypeBuilder
+    fun boolean() = BooleanPretypeBuilder
+    fun function(init: FunctionPretypeBuilder.() -> Unit) = FunctionPretypeBuilder().also { it.init() }
+}
+
+fun TypeBuilder.nullableAny(): AnyPretypeBuilder {
+    nullable = true
+    return any()
+}
+
+fun buildType(init: TypeBuilder.() -> PretypeBuilder): TypeEmbedding = TypeBuilder().complete(init)
+

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -78,8 +78,6 @@ data object AnyTypeEmbedding : TypeEmbedding {
     override val name = TypeName("Any")
 }
 
-data object NullableAnyTypeEmbedding : TypeEmbedding by NullableTypeEmbedding(AnyTypeEmbedding)
-
 data object IntTypeEmbedding : TypeEmbedding {
     override val runtimeType = RuntimeTypeDomain.intType()
     override val name = TypeName("Int")
@@ -89,7 +87,6 @@ data object BooleanTypeEmbedding : TypeEmbedding {
     override val runtimeType = RuntimeTypeDomain.boolType()
     override val name = TypeName("Boolean")
 }
-
 
 data class NullableTypeEmbedding(val elementType: TypeEmbedding) : TypeEmbedding {
     override val runtimeType = RuntimeTypeDomain.nullable(elementType.runtimeType)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
@@ -8,10 +8,13 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.NullableAnyTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.UnitTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.expression.*
+import org.jetbrains.kotlin.formver.embeddings.buildType
+import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.embeddings.expression.FirVariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.expression.PlaceholderVariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.nullableAny
 import org.jetbrains.kotlin.formver.linearization.pureToViper
 import org.jetbrains.kotlin.formver.names.SetterValueName
 import org.jetbrains.kotlin.formver.names.ThisReceiverName
@@ -47,7 +50,7 @@ abstract class PropertyAccessorFunctionSignature(
     override fun getPreconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
     override fun getPostconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
     override val receiver: VariableEmbedding
-        get() = PlaceholderVariableEmbedding(ThisReceiverName, NullableAnyTypeEmbedding)
+        get() = PlaceholderVariableEmbedding(ThisReceiverName, buildType { nullableAny() })
     override val declarationSource: KtSourceElement? = symbol.source
 }
 
@@ -55,15 +58,15 @@ class GetterFunctionSignature(name: MangledName, symbol: FirPropertySymbol) :
     PropertyAccessorFunctionSignature(name, symbol) {
 
     override val params = emptyList<FirVariableEmbedding>()
-    override val returnType: TypeEmbedding = NullableAnyTypeEmbedding
+    override val returnType: TypeEmbedding = buildType { nullableAny() }
 }
 
 class SetterFunctionSignature(name: MangledName, symbol: FirPropertySymbol) :
     PropertyAccessorFunctionSignature(name, symbol) {
     override val params = listOf(
-        FirVariableEmbedding(SetterValueName, NullableAnyTypeEmbedding, symbol)
+        FirVariableEmbedding(SetterValueName, buildType { nullableAny() }, symbol)
     )
-    override val returnType: TypeEmbedding = UnitTypeEmbedding
+    override val returnType: TypeEmbedding = buildType { unit() }
 }
 
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -46,7 +46,7 @@ object KotlinContractFunction : SpecialKotlinFunction {
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))
-    override val returnType: TypeEmbedding = UnitTypeEmbedding
+    override val returnType: TypeEmbedding = buildType { unit() }
 
     override fun insertCallImpl(
         args: List<ExpEmbedding>,
@@ -58,9 +58,9 @@ abstract class KotlinIntSpecialFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin")
     override val className: String? = "Int"
 
-    override val receiverType: TypeEmbedding = IntTypeEmbedding
-    override val paramTypes: List<TypeEmbedding> = listOf(IntTypeEmbedding)
-    override val returnType: TypeEmbedding = IntTypeEmbedding
+    override val receiverType: TypeEmbedding = buildType { int() }
+    override val paramTypes: List<TypeEmbedding> = listOf(buildType { int() })
+    override val returnType: TypeEmbedding = buildType { int() }
 }
 
 object KotlinIntPlusFunctionImplementation : KotlinIntSpecialFunction() {
@@ -103,9 +103,9 @@ abstract class KotlinBooleanSpecialFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin")
     override val className: String? = "Boolean"
 
-    override val receiverType: TypeEmbedding = BooleanTypeEmbedding
+    override val receiverType: TypeEmbedding = buildType { boolean() }
     override val paramTypes: List<TypeEmbedding> = emptyList()
-    override val returnType: TypeEmbedding = BooleanTypeEmbedding
+    override val returnType: TypeEmbedding = buildType { boolean() }
 }
 
 object KotlinBooleanNotFunctionImplementation : KotlinBooleanSpecialFunction() {
@@ -129,8 +129,8 @@ object SpecialVerifyFunction : SpecialKotlinFunction {
     }
 
     override val receiverType: TypeEmbedding? = null
-    override val paramTypes: List<TypeEmbedding> = listOf(BooleanTypeEmbedding)
-    override val returnType: TypeEmbedding = UnitTypeEmbedding
+    override val paramTypes: List<TypeEmbedding> = listOf(buildType { boolean() })
+    override val returnType: TypeEmbedding = buildType { unit() }
 }
 
 object SpecialKotlinFunctions {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -6,9 +6,14 @@
 package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.expression.*
-import org.jetbrains.kotlin.formver.names.*
+import org.jetbrains.kotlin.formver.names.ClassKotlinName
+import org.jetbrains.kotlin.formver.names.ScopedKotlinName
+import org.jetbrains.kotlin.formver.names.buildName
+import org.jetbrains.kotlin.formver.names.embedFunctionName
 import org.jetbrains.kotlin.formver.viper.ast.Method
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -42,10 +47,18 @@ object KotlinContractFunction : SpecialKotlinFunction {
         packageScope(packageName)
         ClassKotlinName(listOf("ContractBuilder"))
     }
-    private val contractBuilderType = ClassTypeEmbedding(contractBuilderTypeName)
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
-        listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))
+        listOf(buildType {
+            function {
+                withReceiver {
+                    klass {
+                        withName(contractBuilderTypeName)
+                    }
+                }
+                withReturnType { unit() }
+            }
+        })
     override val returnType: TypeEmbedding = buildType { unit() }
 
     override fun insertCallImpl(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Arithmetic.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Arithmetic.kt
@@ -5,15 +5,12 @@
 
 package org.jetbrains.kotlin.formver.embeddings.expression
 
-import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.domains.InjectionImageFunction
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.IntTypeEmbedding
-import org.jetbrains.kotlin.formver.linearization.LinearizationContext
+import org.jetbrains.kotlin.formver.embeddings.buildType
 
 sealed interface IntArithmeticExpression : OperationBaseExpEmbedding {
     override val type
-        get() = IntTypeEmbedding
+        get() = buildType { int() }
 }
 
 data class Add(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Boolean.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Boolean.kt
@@ -7,13 +7,15 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
+import org.jetbrains.kotlin.formver.embeddings.asInfo
+import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 sealed interface BinaryBooleanExpression : OperationBaseExpEmbedding {
     override val type
-        get() = BooleanTypeEmbedding
+        get() = buildType { boolean() }
 }
 
 data class And(
@@ -45,7 +47,7 @@ data class Not(
     override val inner: ExpEmbedding,
     override val sourceRole: SourceRole? = null
 ) : UnaryDirectResultExpEmbedding {
-    override val type = BooleanTypeEmbedding
+    override val type = buildType { boolean() }
     override fun toViper(ctx: LinearizationContext) =
         RuntimeTypeDomain.notBool(inner.toViper(ctx), pos = ctx.source.asPosition, info = sourceRole.asInfo)
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
@@ -8,16 +8,18 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.InjectionImageFunction
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
+import org.jetbrains.kotlin.formver.embeddings.asInfo
+import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
-import org.jetbrains.kotlin.formver.viper.ast.Operator
 import org.jetbrains.kotlin.formver.viper.ast.EqAny
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.NeAny
+import org.jetbrains.kotlin.formver.viper.ast.Operator
 
 sealed interface AnyComparisonExpression : BinaryDirectResultExpEmbedding {
     override val type
-        get() = BooleanTypeEmbedding
+        get() = buildType { boolean() }
 
     val comparisonOperation: Operator
 
@@ -47,7 +49,7 @@ sealed interface AnyComparisonExpression : BinaryDirectResultExpEmbedding {
 
 sealed interface IntComparisonExpression : OperationBaseExpEmbedding {
     override val type
-        get() = BooleanTypeEmbedding
+        get() = buildType { boolean() }
 }
 
 data class LtCmp(

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -237,7 +237,7 @@ sealed interface StoredResultExpEmbedding : BaseStoredResultExpEmbedding, Defaul
  */
 sealed interface NoResultExpEmbedding : DefaultMaybeStoringInExpEmbedding, DefaultToBuiltinExpEmbedding {
     override val type: TypeEmbedding
-        get() = NothingTypeEmbedding
+        get() = buildType { nothing() }
 
     // Result ignored, since it is never used.
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
@@ -317,7 +317,7 @@ sealed interface PassthroughExpEmbedding : ExpEmbedding {
  */
 sealed interface UnitResultExpEmbedding : OnlyToViperExpEmbedding {
     override val type: TypeEmbedding
-        get() = UnitTypeEmbedding
+        get() = buildType { unit() }
 
     override fun toViper(ctx: LinearizationContext): Exp {
         toViperSideEffects(ctx)
@@ -414,7 +414,7 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
 data class FieldAccessPermissions(override val inner: ExpEmbedding, val field: FieldEmbedding, val perm: PermExp) :
     OnlyToBuiltinTypeExpEmbedding, UnaryDirectResultExpEmbedding {
     // We consider access permissions to have type Boolean, though this is a bit questionable.
-    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val type: TypeEmbedding = buildType { boolean() }
 
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
         inner.toViper(ctx).fieldAccessPredicate(field.toViper(), perm, ctx.source.asPosition)
@@ -427,7 +427,7 @@ data class FieldAccessPermissions(override val inner: ExpEmbedding, val field: F
 // Ideally we would use the predicate, but due to the possibility of recursion this is inconvenient at present.
 data class PredicateAccessPermissions(val predicateName: MangledName, val args: List<ExpEmbedding>, val perm: PermExp) :
     OnlyToBuiltinTypeExpEmbedding {
-    override val type: TypeEmbedding = BooleanTypeEmbedding
+    override val type: TypeEmbedding = buildType { boolean() }
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
         Exp.PredicateAccess(predicateName, args.map { it.toViper(ctx) }, perm, ctx.source.asPosition)
 
@@ -460,7 +460,7 @@ data class Assign(val lhs: ExpEmbedding, val rhs: ExpEmbedding) : UnitResultExpE
 
 data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbedding?) : UnitResultExpEmbedding,
     DefaultDebugTreeViewImplementation {
-    override val type: TypeEmbedding = UnitTypeEmbedding
+    override val type: TypeEmbedding = buildType { unit() }
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addDeclaration(variable.toLocalVarDecl(ctx.source.asPosition))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
@@ -57,7 +57,7 @@ data class BooleanLit(val value: Boolean, override val sourceRole: SourceRole? =
 }
 
 data object NullLit : PureExpEmbedding {
-    override val type = buildType { nullable = true; nothing() }
+    override val type = buildType { isNullable = true; nothing() }
     override fun toViper(source: KtSourceElement?): Exp =
         RuntimeTypeDomain.nullValue(pos = source.asPosition)
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
@@ -8,7 +8,9 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.SourceRole
+import org.jetbrains.kotlin.formver.embeddings.asInfo
+import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
@@ -23,7 +25,7 @@ data object UnitLit : UnitResultExpEmbedding {
 }
 
 data class IntLit(val value: Int) : PureExpEmbedding {
-    override val type = IntTypeEmbedding
+    override val type = buildType { int() }
     override fun toViper(source: KtSourceElement?): Exp =
         RuntimeTypeDomain.intInjection.toRef(
             Exp.IntLit(value, source.asPosition, sourceRole.asInfo),
@@ -39,7 +41,7 @@ data class IntLit(val value: Int) : PureExpEmbedding {
 }
 
 data class BooleanLit(val value: Boolean, override val sourceRole: SourceRole? = null) : PureExpEmbedding {
-    override val type = BooleanTypeEmbedding
+    override val type = buildType { boolean() }
     override fun toViper(source: KtSourceElement?): Exp =
         RuntimeTypeDomain.boolInjection.toRef(
             Exp.BoolLit(value, source.asPosition, sourceRole.asInfo),
@@ -55,7 +57,7 @@ data class BooleanLit(val value: Boolean, override val sourceRole: SourceRole? =
 }
 
 data object NullLit : PureExpEmbedding {
-    override val type = NullableTypeEmbedding(NothingTypeEmbedding)
+    override val type = buildType { nullable = true; nothing() }
     override fun toViper(source: KtSourceElement?): Exp =
         RuntimeTypeDomain.nullValue(pos = source.asPosition)
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -7,8 +7,8 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.NothingTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
@@ -23,7 +23,7 @@ data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : PureEx
 }
 
 data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {
-    override val type: TypeEmbedding = NothingTypeEmbedding
+    override val type: TypeEmbedding = buildType { nothing() }
     override fun toViperUnusedResult(ctx: LinearizationContext) {
         ctx.addStatement { Stmt.Inhale(Exp.BoolLit(false, ctx.source.asPosition), ctx.source.asPosition) }
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/TypeOp.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 data class Is(override val inner: ExpEmbedding, val comparisonType: TypeEmbedding, override val sourceRole: SourceRole? = null) :
     UnaryDirectResultExpEmbedding {
-    override val type = BooleanTypeEmbedding
+    override val type = buildType { boolean() }
 
     override fun toViper(ctx: LinearizationContext) =
         RuntimeTypeDomain.boolInjection.toRef(
@@ -51,6 +51,8 @@ data class Cast(override val inner: ExpEmbedding, override val type: TypeEmbeddi
 }
 
 fun ExpEmbedding.withType(newType: TypeEmbedding): ExpEmbedding = if (type == newType) this else Cast(this, newType)
+
+fun ExpEmbedding.withType(init: TypeBuilder.() -> PretypeBuilder): ExpEmbedding = withType(buildType(init))
 
 
 /**

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -6,7 +6,10 @@
 package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.embeddings.PretypeBuilder
+import org.jetbrains.kotlin.formver.embeddings.TypeBuilder
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Label
@@ -32,6 +35,9 @@ interface LinearizationContext {
 
     fun addModifier(mod: StmtModifier)
 }
+
+fun LinearizationContext.freshAnonVar(init: TypeBuilder.() -> PretypeBuilder): AnonymousVariableEmbedding =
+    freshAnonVar(buildType(init))
 
 fun LinearizationContext.addLabel(label: Label) {
     addDeclaration(label.toDecl())


### PR DESCRIPTION
Previously, we used the type embeddings directly in the code.  This makes changing their representation quite hard; this PR introduces a builder that lets us hide the implementation details.

This isn't quite perfect; we sometimes still check what subtype a particular embedding is.  Getting rid of that entirely would be an even bigger change, though.