### PR TITLE
Restructure scoping definitions to be more structured.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -8,10 +8,7 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.expression.*
-import org.jetbrains.kotlin.formver.names.ClassKotlinName
-import org.jetbrains.kotlin.formver.names.GlobalScope
-import org.jetbrains.kotlin.formver.names.ScopedKotlinName
-import org.jetbrains.kotlin.formver.names.embedFunctionName
+import org.jetbrains.kotlin.formver.names.*
 import org.jetbrains.kotlin.formver.viper.ast.Method
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -41,8 +38,12 @@ object KotlinContractFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin", "contracts")
     override val name: String = "contract"
 
-    private val contractBuilderType =
-        ClassTypeEmbedding(ScopedKotlinName(GlobalScope(packageName), ClassKotlinName(listOf("ContractBuilder"))))
+    private val contractBuilderTypeName = buildName {
+        packageScope(packageName)
+        globalScope()
+        ClassKotlinName(listOf("ContractBuilder"))
+    }
+    private val contractBuilderType = ClassTypeEmbedding(contractBuilderTypeName)
     override val receiverType: TypeEmbedding? = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(FunctionTypeEmbedding(CallableSignatureData(contractBuilderType, listOf(), UnitTypeEmbedding)))

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.formver.embeddings.expression.debug.*
 import org.jetbrains.kotlin.formver.linearization.InhaleExhaleStmtModifier
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.pureToViper
+import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -374,7 +375,7 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
     }
 
     private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
-        val hierarchyPath = (receiver.type as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field.name)
+        val hierarchyPath = (receiver.type as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field.name as ScopedKotlinName)
         hierarchyPath?.forEach { classType ->
             val predAcc = classType.sharedPredicateAccessInvariant().fillHole(receiverWrapper)
                 .pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ClassScopeNameMatcher.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ClassScopeNameMatcher.kt
@@ -21,7 +21,7 @@ internal sealed class NameMatcher(val name: MangledName) {
     }
 
     protected val scopedName = name as? ScopedKotlinName
-    protected val packageName = (scopedName?.scope as? PackagePrefixScope)?.packageName
+    protected val packageName = scopedName?.scope?.packageNameIfAny
     protected abstract val className: ClassKotlinName?
 
     inline fun ifPackageName(vararg segments: String, action: NameMatcher.() -> Unit) {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
@@ -7,51 +7,87 @@ package org.jetbrains.kotlin.formver.names
 
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.utils.addToStdlib.ifFalse
+import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
-sealed interface NameScope : MangledName
+sealed interface NameScope {
+    val parent: NameScope?
+    val mangledScopeName: String?
 
-sealed interface PackagePrefixScope : NameScope {
-    val packageName: FqName
-    val suffix: String
-    override val mangled: String
-        get() = if (packageName.isRoot) {
-            suffix
-        } else {
-            "pkg\$${packageName.asViperString()}\$$suffix"
-        }
+    // Determines whether the parent should be part of the name.
+    // This is a hack required by how we deal with public names.
+    // We use only accessible scopes when generating the names, but all scopes when doing lookups
+    // for things like package and class names.
+    val parentAccessible: Boolean
+        get() = true
 }
 
-data class GlobalScope(override val packageName: FqName) : PackagePrefixScope {
-    override val suffix = "global"
+// Includes the scope itself.
+val NameScope.parentScopes: Sequence<NameScope>
+    get() = sequence {
+        if (parentAccessible) parent?.parentScopes?.let { yieldAll(it) }
+        yield(this@parentScopes)
+    }
 
-    constructor(segments: List<String>) : this(FqName.fromSegments(segments))
+val NameScope.allParentScopes: Sequence<NameScope>
+    get() = sequence {
+        parent?.parentScopes?.let { yieldAll(it) }
+        yield(this@allParentScopes)
+    }
+
+val NameScope.fullMangledName: String?
+    get() {
+        val scopes = parentScopes.mapNotNull { it.mangledScopeName }.toList()
+        return if (scopes.isEmpty()) null else scopes.joinToString("$")
+    }
+
+val NameScope.packageNameIfAny: FqName?
+    get() = allParentScopes.filterIsInstance<PackageScope>().firstOrNull()?.packageName
+
+val NameScope.classNameIfAny: ClassKotlinName?
+    get() = allParentScopes.filterIsInstance<ClassScope>().firstOrNull()?.className
+
+data class PackageScope(val packageName: FqName) : NameScope {
+    override val parent = null
+
+    override val mangledScopeName: String?
+        get() = packageName.isRoot.ifFalse { "pkg\$${packageName.asViperString()}" }
 }
 
-sealed interface ClassScope : PackagePrefixScope {
-    val className: ClassKotlinName
+// This is really just package scope, here for backwards compatibility.
+data class GlobalScope(override val parent: NameScope) : NameScope {
+    override val mangledScopeName: String
+        get() = "global"
 }
 
-data class DefaultClassScope(override val packageName: FqName, override val className: ClassKotlinName, ) : ClassScope {
-    override val suffix = className.mangled
+data class ClassScope(override val parent: NameScope, val className: ClassKotlinName) : NameScope {
+    override val mangledScopeName: String
+        get() = className.mangled
 }
 
 /**
  * We do not want to mangle field names with class and package, hence introducing
  * this special `NameScope`. Note that it still needs package and class for other purposes.
  */
-data class PublicClassScope(override val packageName: FqName, override val className: ClassKotlinName) : ClassScope {
-    override val suffix = className.mangled + "_public"
-    override val mangled = "public"
+data class PublicScope(override val parent: NameScope) : NameScope {
+    override val mangledScopeName: String
+        get() = "public"
+    override val parentAccessible: Boolean
+        get() = false
 }
 
-data class PrivateClassScope(override val packageName: FqName, override val className: ClassKotlinName) : ClassScope {
-    override val suffix = className.mangled + "_private"
+data class PrivateScope(override val parent: NameScope) : NameScope {
+    override val mangledScopeName: String
+        get() = "private"
 }
 
 data object ParameterScope : NameScope {
-    override val mangled = "local"
+    override val parent: NameScope? = null
+    override val mangledScopeName: String
+        get() = "local"
 }
 
 data class LocalScope(val level: Int) : NameScope {
-    override val mangled = "local$level"
+    override val parent: NameScope? = null
+    override val mangledScopeName = "local$level"
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
@@ -42,10 +42,10 @@ val NameScope.fullMangledName: String?
     }
 
 val NameScope.packageNameIfAny: FqName?
-    get() = allParentScopes.filterIsInstance<PackageScope>().firstOrNull()?.packageName
+    get() = allParentScopes.filterIsInstance<PackageScope>().lastOrNull()?.packageName
 
 val NameScope.classNameIfAny: ClassKotlinName?
-    get() = allParentScopes.filterIsInstance<ClassScope>().firstOrNull()?.className
+    get() = allParentScopes.filterIsInstance<ClassScope>().lastOrNull()?.className
 
 data class PackageScope(val packageName: FqName) : NameScope {
     override val parent = null

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinName.kt
@@ -11,9 +11,9 @@ import org.jetbrains.kotlin.name.FqName
 /**
  * Name of a Kotlin entity in the original program in a specified scope and optionally distinguished by type.
  */
-data class ScopedKotlinName(val scope: NameScope, val name: KotlinName) : MangledName {
+data class ScopedKotlinName(val scope: NameScope, val name: KotlinName) : KotlinName {
     override val mangled: String
-        get() = listOf(scope.mangled, name.mangled).joinToString("$")
+        get() = listOf(scope.fullMangledName, name.mangled).joinToString("$")
 }
 
 fun FqName.asViperString() = asString().replace('.', '$')

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
@@ -31,17 +31,17 @@ class ScopedKotlinNameBuilder {
     }
 
     fun classScope(className: ClassKotlinName) {
-        require (scope != null) { "Public class scope cannot be top-level" }
+        require (scope != null) { "Class scope cannot be top-level" }
         scope = ClassScope(scope!!, className)
     }
 
     fun publicScope() {
-        require(scope != null) { "Public class scope cannot be top-level" }
+        require(scope is ClassScope) { "Public scope must be in a class scope." }
         scope = PublicScope(scope!!)
     }
 
     fun privateScope() {
-        require(scope != null) { "Private class scope cannot be top-level" }
+        require(scope is ClassScope) { "Private scope must be in a class scope." }
         scope = PrivateScope(scope!!)
     }
 
@@ -58,6 +58,4 @@ class ScopedKotlinNameBuilder {
 
 // TODO: generalise this to work for all names.
 fun buildName(init: ScopedKotlinNameBuilder.() -> KotlinName): ScopedKotlinName =
-    ScopedKotlinNameBuilder().let {
-        it.complete(it.init())
-    }
+    ScopedKotlinNameBuilder().run { complete(init()) }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.names
+
+import org.jetbrains.kotlin.name.FqName
+
+class ScopedKotlinNameBuilder {
+    private var scope: NameScope? = null
+
+    fun complete(name: KotlinName): ScopedKotlinName {
+        require(scope != null) { "No scope specified "}
+        return ScopedKotlinName(scope!!, name)
+    }
+
+    fun packageScope(packageName: FqName) {
+        require (scope == null) { "Invalid scope combination: package after $scope" }
+        scope = PackageScope(packageName)
+    }
+
+    fun packageScope(packageName: List<String>) {
+        require (scope == null) { "Invalid scope combination: package after $scope" }
+        scope = PackageScope(FqName.fromSegments(packageName))
+    }
+
+    fun globalScope() {
+        require (scope != null) { "Global scope cannot be top-level" }
+        scope = GlobalScope(scope!!)
+    }
+
+    fun classScope(className: ClassKotlinName) {
+        require (scope != null) { "Public class scope cannot be top-level" }
+        scope = ClassScope(scope!!, className)
+    }
+
+    fun publicScope() {
+        require(scope != null) { "Public class scope cannot be top-level" }
+        scope = PublicScope(scope!!)
+    }
+
+    fun privateScope() {
+        require(scope != null) { "Private class scope cannot be top-level" }
+        scope = PrivateScope(scope!!)
+    }
+
+    fun parameterScope() {
+        require(scope == null) { "Parameter scope cannot be nested." }
+        scope = ParameterScope
+    }
+
+    fun localScope(level: Int) {
+        require (scope == null) { "Local scope cannot be nested." }
+        scope = LocalScope(level)
+    }
+}
+
+// TODO: generalise this to work for all names.
+fun buildName(init: ScopedKotlinNameBuilder.() -> KotlinName): ScopedKotlinName =
+    ScopedKotlinNameBuilder().let {
+        it.complete(it.init())
+    }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.fir.diag.txt
@@ -1,5 +1,5 @@
 /custom_list.kt:(168,171): info: Generated Viper text for get:
-field class_CustomList_private$backing_field_value: Ref
+field class_CustomList$private$backing_field_value: Ref
 
 field special$size: Ref
 
@@ -21,13 +21,13 @@ method class_CustomList$fun_get$fun_take$T_class_global$class_CustomList$T_Int$r
   inhale acc(T_class_global$class_CustomList(this), wildcard)
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(local$index), dom$RuntimeType$intType())
   unfold acc(T_class_global$class_CustomList(this), wildcard)
-  ret$0 := this.class_CustomList_private$backing_field_value
+  ret$0 := this.class_CustomList$private$backing_field_value
   goto label$ret$0
   label label$ret$0
 }
 
 /custom_list.kt:(248,252): info: Generated Viper text for test:
-field class_CustomList_private$backing_field_value: Ref
+field class_CustomList$private$backing_field_value: Ref
 
 field special$size: Ref
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
@@ -6,29 +6,29 @@ method class_A$fun_getBooleanField$fun_take$T_class_global$class_A$return$T_Bool
   var anonymous$0: Ref
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_A())
   inhale acc(T_class_global$class_A(this), wildcard)
-  anonymous$0 := class_A_private$property_getter_field(this)
+  anonymous$0 := class_A$private$property_getter_field(this)
   ret$0 := anonymous$0
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(ret$0), dom$RuntimeType$boolType())
   goto label$ret$0
   label label$ret$0
 }
 
-method class_A_private$property_getter_field(this: Ref) returns (ret: Ref)
+method class_A$private$property_getter_field(this: Ref) returns (ret: Ref)
 
 
-method class_A_private$property_setter_field(this: Ref, value: Ref)
+method class_A$private$property_setter_field(this: Ref, value: Ref)
   returns (ret: Ref)
 
 
 /private_properties.kt:(289,303): info: Generated Viper text for getStringField:
-field class_B_private$backing_field_field: Ref
+field class_B$private$backing_field_field: Ref
 
 field public$backing_field_length: Ref
 
-method class_A_private$property_getter_field(this: Ref) returns (ret: Ref)
+method class_A$private$property_getter_field(this: Ref) returns (ret: Ref)
 
 
-method class_A_private$property_setter_field(this: Ref, value: Ref)
+method class_A$private$property_setter_field(this: Ref, value: Ref)
   returns (ret: Ref)
 
 
@@ -40,7 +40,7 @@ method class_B$fun_getStringField$fun_take$T_class_global$class_B$return$T_class
   inhale dom$RuntimeType$isSubtype(dom$RuntimeType$typeOf(this), dom$RuntimeType$T_class_global$class_B())
   inhale acc(T_class_global$class_B(this), wildcard)
   unfold acc(T_class_global$class_B(this), wildcard)
-  ret$0 := this.class_B_private$backing_field_field
+  ret$0 := this.class_B$private$backing_field_field
   goto label$ret$0
   label label$ret$0
 }
@@ -49,16 +49,16 @@ method public$property_getter_length(this: Ref) returns (ret: Ref)
 
 
 /private_properties.kt:(471,484): info: Generated Viper text for extractPublic:
-field class_B_private$backing_field_field: Ref
+field class_B$private$backing_field_field: Ref
 
 field public$backing_field_field: Ref
 
 field public$backing_field_length: Ref
 
-method class_A_private$property_getter_field(this: Ref) returns (ret: Ref)
+method class_A$private$property_getter_field(this: Ref) returns (ret: Ref)
 
 
-method class_A_private$property_setter_field(this: Ref, value: Ref)
+method class_A$private$property_setter_field(this: Ref, value: Ref)
   returns (ret: Ref)
 
 


### PR DESCRIPTION
Previously, scopes were just arbitrary names.  This imposes the kind of hierarchical structure on scopes that we will want to use for optimising mangled name length.