### PR TITLE
Make public backing fields explicitly unscoped.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/BackingFieldAccessors.kt
@@ -17,7 +17,6 @@ class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
             FieldAccess(receiver, field).withAccessAndProvenInvariants()
         }
     }
-
 }
 
 class BackingFieldSetter(val field: FieldEmbedding) : SetterEmbedding {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassEmbeddingDetails.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassEmbeddingDetails.kt
@@ -6,10 +6,8 @@
 package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.formver.names.*
-import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Predicate
-import org.jetbrains.kotlin.formver.viper.mangled
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boolean) : TypeInvariantHolder {
@@ -100,16 +98,16 @@ class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boole
         PredicateAccessTypeInvariantEmbedding(uniquePredicateName, PermExp.FullPerm())
 
     // Returns the sequence of classes in a hierarchy that need to be unfolded in order to access the given field
-    fun hierarchyUnfoldPath(fieldName: ScopedKotlinName): Sequence<ClassTypeEmbedding> = sequence {
-        val className = fieldName.scope.classNameIfAny
-        require(className != null) { "Cannot find hierarchy unfold path of a field with no class scope" }
-        if (className == type.className.name) {
+    fun hierarchyUnfoldPath(field: FieldEmbedding): Sequence<ClassTypeEmbedding> = sequence {
+        val className = field.containingClass?.className
+        require(className != null) { "Cannot find hierarchy unfold path of a field with no class information" }
+        if (className == type.className) {
             yield(this@ClassEmbeddingDetails.type)
         } else {
             val sup = superTypes.firstOrNull { it is ClassTypeEmbedding && !it.details.isInterface }
             if (sup is ClassTypeEmbedding) {
                 yield(this@ClassEmbeddingDetails.type)
-                yieldAll(sup.details.hierarchyUnfoldPath(fieldName))
+                yieldAll(sup.details.hierarchyUnfoldPath(field))
             } else {
                 throw IllegalArgumentException("Reached top of the hierarchy without finding the field")
             }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -27,6 +27,8 @@ interface FieldEmbedding {
     // If true, it is necessary to unfold the predicate of the receiver before accessing the field
     val unfoldToAccess: Boolean
         get() = false
+    val containingClass: ClassTypeEmbedding?
+        get() = null
     val includeInShortDump: Boolean
     val symbol: FirPropertySymbol?
         get() = null
@@ -53,6 +55,7 @@ class UserFieldEmbedding(
     override val type: TypeEmbedding,
     override val symbol: FirPropertySymbol,
     override val isUnique: Boolean,
+    override val containingClass: ClassTypeEmbedding,
 ) : FieldEmbedding {
     override val viperType = Type.Ref
     override val accessPolicy: AccessPolicy = if (symbol.isVal) AccessPolicy.ALWAYS_READABLE else AccessPolicy.ALWAYS_INHALE_EXHALE

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.formver.embeddings.expression.debug.*
 import org.jetbrains.kotlin.formver.linearization.InhaleExhaleStmtModifier
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.pureToViper
-import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -376,7 +375,7 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
     }
 
     private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
-        val hierarchyPath = (receiver.type as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field.name as ScopedKotlinName)
+        val hierarchyPath = (receiver.type as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field)
         hierarchyPath?.forEach { classType ->
             val predAcc = classType.sharedPredicateAccessInvariant().fillHole(receiverWrapper)
                 .pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/MemberEmbeddingPolicy.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/MemberEmbeddingPolicy.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.names
+
+enum class MemberEmbeddingPolicy {
+    PRIVATE,
+    PUBLIC,
+    UNSCOPED,
+}
+
+fun alwaysScopedPolicy(isPrivate: Boolean): MemberEmbeddingPolicy =
+    if (isPrivate) MemberEmbeddingPolicy.PRIVATE else MemberEmbeddingPolicy.PUBLIC
+
+fun onlyPrivateScopedPolicy(isPrivate: Boolean): MemberEmbeddingPolicy =
+    if (isPrivate) MemberEmbeddingPolicy.PRIVATE else MemberEmbeddingPolicy.UNSCOPED
+
+val MemberEmbeddingPolicy.isScoped: Boolean
+    get() = this == MemberEmbeddingPolicy.PRIVATE || this == MemberEmbeddingPolicy.PUBLIC

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
@@ -84,3 +84,11 @@ data class LocalScope(val level: Int) : NameScope {
     override val parent: NameScope? = null
     override val mangledScopeName = "l$level"
 }
+
+/**
+ * Scope to use in cases when we need a scoped name, but don't actually want to introduce one.
+ */
+data object FakeScope : NameScope {
+    override val parent: NameScope? = null
+    override val mangledScopeName: String? = null
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
@@ -46,8 +46,13 @@ class ScopedKotlinNameBuilder {
     }
 
     fun localScope(level: Int) {
-        require (scope == null) { "Local scope cannot be nested." }
+        require(scope == null) { "Local scope cannot be nested." }
         scope = LocalScope(level)
+    }
+
+    fun fakeScope() {
+        require(scope == null) { "Fake scope cannot be nested." }
+        scope = FakeScope
     }
 }
 

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
@@ -1,5 +1,5 @@
 /as_type_contract.kt:(150,154): info: Generated Viper text for getX:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$getX$TF$T$Any(p$a: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
@@ -18,7 +18,7 @@ method f$getX$TF$T$Any(p$a: Ref) returns (ret$0: Ref)
   if (anon$0 != df$rt$nullValue()) {
     var anon$1: Ref
     unfold acc(p$c$IntHolder$shared(anon$0), wildcard)
-    anon$1 := anon$0.bf$public$x
+    anon$1 := anon$0.bf$x
     ret$0 := anon$1
   } else {
     ret$0 := df$rt$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
@@ -67,7 +67,7 @@ method pg$public$length(this: Ref) returns (ret: Ref)
 /cond_effects.kt:(796,832): warning: Cannot verify that if a false value is returned then seq != null.
 
 /cond_effects.kt:(925,942): info: Generated Viper text for recursiveContract:
-field bf$public$length: Ref
+field bf$length: Ref
 
 method f$recursiveContract$TF$T$Int$Any(p$n: Ref, p$x: Ref)
   returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_type_contract.kt:(151,172): info: Generated Viper text for unverifiableTypeCheck:
-field bf$public$length: Ref
+field bf$length: Ref
 
 method f$unverifiableTypeCheck$TF$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
@@ -32,7 +32,7 @@ method f$safeAsOperator$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_type_contract.kt:(504,508): info: Generated Viper text for getX:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$getX$TF$T$Any(p$a: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
@@ -53,7 +53,7 @@ method f$getX$TF$T$Any(p$a: Ref) returns (ret$0: Ref)
   if (anon$0 != df$rt$nullValue()) {
     var anon$1: Ref
     unfold acc(p$c$IntHolder$shared(anon$0), wildcard)
-    anon$1 := anon$0.bf$public$x
+    anon$1 := anon$0.bf$x
     ret$0 := anon$1
   } else {
     ret$0 := df$rt$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -1,7 +1,7 @@
 /backing_field_getters.kt:(178,188): info: Generated Viper text for cascadeGet:
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$cascadeGet$TF$T$c$X(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Z())
@@ -12,17 +12,17 @@ method f$cascadeGet$TF$T$c$X(p$x: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$X())
   inhale acc(p$c$X$shared(p$x), wildcard)
   unfold acc(p$c$X$shared(p$x), wildcard)
-  anon$0 := p$x.bf$public$y
+  anon$0 := p$x.bf$y
   unfold acc(p$c$Y$shared(anon$0), wildcard)
-  ret$0 := anon$0.bf$public$z
+  ret$0 := anon$0.bf$z
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /backing_field_getters.kt:(300,321): info: Generated Viper text for receiverNotNullProved:
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$receiverNotNullProved$TF$c$X(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -34,7 +34,7 @@ method f$receiverNotNullProved$TF$c$X(p$x: Ref) returns (ret$0: Ref)
   if (p$x != df$rt$nullValue()) {
     var anon$1: Ref
     unfold acc(p$c$X$shared(p$x), wildcard)
-    anon$1 := p$x.bf$public$y
+    anon$1 := p$x.bf$y
     anon$0 := anon$1
   } else {
     anon$0 := df$rt$nullValue()}
@@ -44,9 +44,9 @@ method f$receiverNotNullProved$TF$c$X(p$x: Ref) returns (ret$0: Ref)
 }
 
 /backing_field_getters.kt:(560,578): info: Generated Viper text for cascadeNullableGet:
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$cascadeNullableGet$TF$c$NullableX(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
@@ -59,12 +59,12 @@ method f$cascadeNullableGet$TF$c$NullableX(p$x: Ref) returns (ret$0: Ref)
     acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
     unfold acc(p$c$NullableX$shared(p$x), wildcard)
-    anon$0 := p$x.bf$public$y
+    anon$0 := p$x.bf$y
   } else {
     anon$0 := df$rt$nullValue()}
   if (anon$0 != df$rt$nullValue()) {
     unfold acc(p$c$NullableY$shared(anon$0), wildcard)
-    ret$0 := anon$0.bf$public$z
+    ret$0 := anon$0.bf$z
   } else {
     ret$0 := df$rt$nullValue()}
   goto lbl$ret$0
@@ -72,9 +72,9 @@ method f$cascadeNullableGet$TF$c$NullableX(p$x: Ref) returns (ret$0: Ref)
 }
 
 /backing_field_getters.kt:(729,756): info: Generated Viper text for cascadeNullableSmartcastGet:
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$cascadeNullableSmartcastGet$TF$c$NullableX(p$x: Ref)
   returns (ret$0: Ref)
@@ -92,7 +92,7 @@ method f$cascadeNullableSmartcastGet$TF$c$NullableX(p$x: Ref)
   } else {
     var anon$1: Ref
     unfold acc(p$c$NullableX$shared(p$x), wildcard)
-    anon$1 := p$x.bf$public$y
+    anon$1 := p$x.bf$y
     if (anon$1 == df$rt$nullValue()) {
       var anon$2: Ref
       anon$2 := df$rt$nullValue()
@@ -100,9 +100,9 @@ method f$cascadeNullableSmartcastGet$TF$c$NullableX(p$x: Ref)
     } else {
       var anon$3: Ref
       unfold acc(p$c$NullableX$shared(p$x), wildcard)
-      anon$3 := p$x.bf$public$y
+      anon$3 := p$x.bf$y
       unfold acc(p$c$NullableY$shared(anon$3), wildcard)
-      ret$0 := anon$3.bf$public$z
+      ret$0 := anon$3.bf$z
     }
   }
   goto lbl$ret$0
@@ -110,7 +110,7 @@ method f$cascadeNullableSmartcastGet$TF$c$NullableX(p$x: Ref)
 }
 
 /backing_field_getters.kt:(987,1017): info: Generated Viper text for nullableReceiverNotNullSafeGet:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method con$c$Baz$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Baz())
@@ -130,7 +130,7 @@ method f$nullableReceiverNotNullSafeGet$TF$() returns (ret$0: Ref)
   if (l0$f != df$rt$nullValue()) {
     var anon$2: Ref
     unfold acc(p$c$Baz$shared(l0$f), wildcard)
-    anon$2 := l0$f.bf$public$x
+    anon$2 := l0$f.bf$x
     anon$1 := anon$2
   } else {
     anon$1 := df$rt$nullValue()}
@@ -140,7 +140,7 @@ method f$nullableReceiverNotNullSafeGet$TF$() returns (ret$0: Ref)
 }
 
 /backing_field_getters.kt:(1167,1194): info: Generated Viper text for nullableReceiverNullSafeGet:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$nullableReceiverNullSafeGet$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -152,7 +152,7 @@ method f$nullableReceiverNullSafeGet$TF$() returns (ret$0: Ref)
   if (l0$f != df$rt$nullValue()) {
     var anon$1: Ref
     unfold acc(p$c$Baz$shared(l0$f), wildcard)
-    anon$1 := l0$f.bf$public$x
+    anon$1 := l0$f.bf$x
     anon$0 := anon$1
   } else {
     anon$0 := df$rt$nullValue()}
@@ -162,7 +162,7 @@ method f$nullableReceiverNullSafeGet$TF$() returns (ret$0: Ref)
 }
 
 /backing_field_getters.kt:(1377,1403): info: Generated Viper text for nonNullableReceiverSafeGet:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method con$c$Baz$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Baz())
@@ -180,7 +180,7 @@ method f$nonNullableReceiverSafeGet$TF$() returns (ret$0: Ref)
   if (l0$f != df$rt$nullValue()) {
     var anon$1: Ref
     unfold acc(p$c$Baz$shared(l0$f), wildcard)
-    anon$1 := l0$f.bf$public$x
+    anon$1 := l0$f.bf$x
     anon$0 := anon$1
   } else {
     anon$0 := df$rt$nullValue()}
@@ -190,19 +190,19 @@ method f$nonNullableReceiverSafeGet$TF$() returns (ret$0: Ref)
 }
 
 /backing_field_getters.kt:(1681,1693): info: Generated Viper text for checkPrimary:
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method con$c$ClassI$T$Int$T$Int(p$x: Ref, p$y: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$ClassI())
   ensures acc(p$c$ClassI$shared(ret), wildcard)
   ensures acc(p$c$ClassI$unique(ret), write)
   ensures (unfolding acc(p$c$ClassI$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$x) == df$rt$intFromRef(p$x) &&
-      df$rt$intFromRef(ret.bf$public$y) == df$rt$intFromRef(p$y))
+      df$rt$intFromRef(ret.bf$x) == df$rt$intFromRef(p$x) &&
+      df$rt$intFromRef(ret.bf$y) == df$rt$intFromRef(p$y))
 
 
 method con$c$ClassII$T$c$Z(p$z: Ref) returns (ret: Ref)
@@ -210,7 +210,7 @@ method con$c$ClassII$T$c$Z(p$z: Ref) returns (ret: Ref)
   ensures acc(p$c$ClassII$shared(ret), wildcard)
   ensures acc(p$c$ClassII$unique(ret), write)
   ensures (unfolding acc(p$c$ClassII$shared(ret), wildcard) in
-      ret.bf$public$z == p$z)
+      ret.bf$z == p$z)
 
 
 method con$c$Z$() returns (ret: Ref)
@@ -237,9 +237,9 @@ method f$checkPrimary$TF$T$Int$T$Int(p$x: Ref, p$y: Ref)
     var anon$1: Ref
     var anon$2: Ref
     unfold acc(p$c$ClassI$shared(l0$classI), wildcard)
-    anon$1 := l0$classI.bf$public$x
+    anon$1 := l0$classI.bf$x
     unfold acc(p$c$ClassI$shared(l0$classI), wildcard)
-    anon$2 := l0$classI.bf$public$y
+    anon$2 := l0$classI.bf$y
     anon$0 := df$rt$boolToRef(df$rt$intFromRef(anon$1) ==
       df$rt$intFromRef(anon$2))
   }
@@ -248,7 +248,7 @@ method f$checkPrimary$TF$T$Int$T$Int(p$x: Ref, p$y: Ref)
     var anon$4: Ref
     anon$4 := con$c$ClassII$T$c$Z(l0$z)
     unfold acc(p$c$ClassII$shared(anon$4), wildcard)
-    anon$3 := anon$4.bf$public$z
+    anon$3 := anon$4.bf$z
     ret$0 := df$rt$boolToRef(anon$3 == l0$z)
   } else {
     ret$0 := df$rt$boolToRef(false)}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/custom_run_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/custom_run_functions.fir.diag.txt
@@ -444,7 +444,7 @@ method f$complexScenario$TF$T$Boolean(p$arg: Ref) returns (ret$0: Ref)
 }
 
 /custom_run_functions.kt:(3305,3320): info: Generated Viper text for testCustomClass:
-field bf$public$member: Ref
+field bf$member: Ref
 
 method con$c$CustomClass$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$CustomClass())
@@ -467,7 +467,7 @@ method f$testCustomClass$TF$() returns (ret$0: Ref)
   var ret$4: Ref
   l0$custom := con$c$CustomClass$()
   unfold acc(p$c$CustomClass$shared(l0$custom), wildcard)
-  ret$2 := l0$custom.bf$public$member
+  ret$2 := l0$custom.bf$member
   goto lbl$ret$2
   label lbl$ret$2
   anon$1 := ret$2
@@ -476,7 +476,7 @@ method f$testCustomClass$TF$() returns (ret$0: Ref)
   label lbl$ret$1
   anon$0 := ret$1
   unfold acc(p$c$CustomClass$shared(l0$custom), wildcard)
-  ret$4 := l0$custom.bf$public$member
+  ret$4 := l0$custom.bf$member
   goto lbl$ret$4
   label lbl$ret$4
   anon$3 := ret$4

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
-field bf$public$length: Ref
+field bf$length: Ref
 
 method f$isString$TF$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -16,7 +16,7 @@ method pg$public$length(this: Ref) returns (ret: Ref)
 
 
 /is_type_contract.kt:(509,517): info: Generated Viper text for isString:
-field bf$public$length: Ref
+field bf$length: Ref
 
 method f$isString$TF$T$Any(p$obj: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -44,7 +44,7 @@ method f$subtypeTransitive$TF$T$Unit(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_type_contract.kt:(870,891): info: Generated Viper text for constructorReturnType:
-field bf$public$bar: Ref
+field bf$bar: Ref
 
 method con$c$Foo$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
@@ -64,7 +64,7 @@ method f$constructorReturnType$TF$() returns (ret$0: Ref)
 }
 
 /is_type_contract.kt:(1016,1032): info: Generated Viper text for subtypeSuperType:
-field bf$public$bar: Ref
+field bf$bar: Ref
 
 method f$subtypeSuperType$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -77,7 +77,7 @@ method f$subtypeSuperType$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
 }
 
 /is_type_contract.kt:(1149,1160): info: Generated Viper text for typeOfField:
-field bf$public$bar: Ref
+field bf$bar: Ref
 
 method f$typeOfField$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -87,7 +87,7 @@ method f$typeOfField$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   unfold acc(p$c$Foo$shared(p$foo), wildcard)
-  anon$0 := p$foo.bf$public$bar
+  anon$0 := p$foo.bf$bar
   if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$Bar())) {
     ret$0 := df$rt$boolToRef(true)
     goto lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_interfaces.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_interfaces.fir.diag.txt
@@ -37,7 +37,7 @@ method pg$public$field(this: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(957,962): info: Generated Viper text for take3:
-field bf$public$field: Ref
+field bf$field: Ref
 
 method f$take3$TF$T$c$AbstractWithFinalImplementation3(p$obj: Ref)
   returns (ret$0: Ref)
@@ -69,7 +69,7 @@ method pg$public$field(this: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(1728,1739): info: Generated Viper text for createImpls:
-field bf$public$field: Ref
+field bf$field: Ref
 
 method con$c$Impl12$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl12())
@@ -142,21 +142,21 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   var anon$17: Ref
   l0$impl12 := con$c$Impl12$()
   unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
-  anon$0 := l0$impl12.bf$public$field
+  anon$0 := l0$impl12.bf$field
   l0$start12 := sp$minusInts(sp$plusInts(anon$0, df$rt$intToRef(1)), df$rt$intToRef(1))
   anon$1 := f$take1$TF$T$c$InterfaceWithImplementation1(l0$impl12)
   anon$2 := f$take2$TF$T$c$InterfaceWithoutImplementation2(l0$impl12)
   l0$impl23 := con$c$Impl23$()
   unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
-  anon$3 := l0$impl23.bf$public$field
+  anon$3 := l0$impl23.bf$field
   l0$start23 := sp$minusInts(sp$plusInts(anon$3, df$rt$intToRef(1)), df$rt$intToRef(1))
   anon$4 := f$take2$TF$T$c$InterfaceWithoutImplementation2(l0$impl23)
   anon$5 := f$take3$TF$T$c$AbstractWithFinalImplementation3(l0$impl23)
   l0$impl3 := con$c$Impl3$()
   unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
-  anon$6 := l0$impl3.bf$public$field
+  anon$6 := l0$impl3.bf$field
   l0$start3 := sp$minusInts(sp$plusInts(anon$6, df$rt$intToRef(1)), df$rt$intToRef(1))
   anon$7 := f$take3$TF$T$c$AbstractWithFinalImplementation3(l0$impl3)
   l0$impl24 := con$c$Impl24$()
@@ -168,7 +168,7 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   anon$11 := f$take4$TF$T$c$AbstractWithOpenImplementation4(l0$impl24)
   l0$impl14 := con$c$Impl14$()
   unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
-  anon$12 := l0$impl14.bf$public$field
+  anon$12 := l0$impl14.bf$field
   l0$start14 := sp$minusInts(sp$plusInts(anon$12, df$rt$intToRef(1)), df$rt$intToRef(1))
   anon$13 := f$take1$TF$T$c$InterfaceWithImplementation1(l0$impl14)
   anon$14 := f$take4$TF$T$c$AbstractWithOpenImplementation4(l0$impl14)
@@ -180,7 +180,7 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   if (true) {
     var anon$18: Ref
     unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
-    anon$18 := l0$impl14.bf$public$field
+    anon$18 := l0$impl14.bf$field
     anon$17 := df$rt$boolToRef(df$rt$intFromRef(l0$start14) ==
       df$rt$intFromRef(anon$18))
   } else {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/override_properties_types.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/override_properties_types.fir.diag.txt
@@ -1,5 +1,5 @@
 /override_properties_types.kt:(520,530): info: Generated Viper text for extractInt:
-field bf$public$field: Ref
+field bf$field: Ref
 
 method f$extractInt$TF$T$c$Base$T$Boolean(p$base: Ref, p$returnNull: Ref)
   returns (ret$0: Ref)
@@ -27,23 +27,23 @@ method f$extractInt$TF$T$c$Base$T$Boolean(p$base: Ref, p$returnNull: Ref)
       var anon$4: Ref
       anon$4 := p$base
       inhale acc(p$c$FinalClassOpenFieldVarDerived$shared(anon$4), wildcard)
-      inhale acc(anon$4.bf$public$field, write)
-      anon$1 := anon$4.bf$public$field
-      exhale acc(anon$4.bf$public$field, write)
+      inhale acc(anon$4.bf$field, write)
+      anon$1 := anon$4.bf$field
+      exhale acc(anon$4.bf$field, write)
       inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
     } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$FinalClassFinalFieldValDerived())) {
       var anon$5: Ref
       anon$5 := p$base
       inhale acc(p$c$FinalClassFinalFieldValDerived$shared(anon$5), wildcard)
       unfold acc(p$c$FinalClassFinalFieldValDerived$shared(anon$5), wildcard)
-      anon$1 := anon$5.bf$public$field
+      anon$1 := anon$5.bf$field
     } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$OpenClassFinalFieldVarDerived())) {
       var anon$6: Ref
       anon$6 := p$base
       inhale acc(p$c$OpenClassFinalFieldVarDerived$shared(anon$6), wildcard)
-      inhale acc(anon$6.bf$public$field, write)
-      anon$1 := anon$6.bf$public$field
-      exhale acc(anon$6.bf$public$field, write)
+      inhale acc(anon$6.bf$field, write)
+      anon$1 := anon$6.bf$field
+      exhale acc(anon$6.bf$field, write)
       inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
     } else {
       anon$1 := df$rt$intToRef(0)}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
@@ -21,7 +21,7 @@ method ps$c$A$private$field(this: Ref, value: Ref) returns (ret: Ref)
 /private_properties.kt:(289,303): info: Generated Viper text for getStringField:
 field bf$c$B$private$field: Ref
 
-field bf$public$length: Ref
+field bf$length: Ref
 
 method f$c$B$getStringField$TF$T$c$B(this: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$pkg$kotlin$String())
@@ -47,9 +47,9 @@ method ps$c$A$private$field(this: Ref, value: Ref) returns (ret: Ref)
 /private_properties.kt:(471,484): info: Generated Viper text for extractPublic:
 field bf$c$B$private$field: Ref
 
-field bf$public$field: Ref
+field bf$field: Ref
 
-field bf$public$length: Ref
+field bf$length: Ref
 
 method con$c$C$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$C())
@@ -70,16 +70,16 @@ method f$extractPublic$TF$() returns (ret$0: Ref)
   var anon$0: Ref
   var anon$1: Ref
   anon$1 := con$c$C$()
-  inhale acc(anon$1.bf$public$field, write)
-  anon$0 := anon$1.bf$public$field
-  exhale acc(anon$1.bf$public$field, write)
+  inhale acc(anon$1.bf$field, write)
+  anon$0 := anon$1.bf$field
+  exhale acc(anon$1.bf$field, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())) {
     var anon$2: Ref
     var anon$3: Ref
     anon$3 := con$c$D$()
     unfold acc(p$c$D$shared(anon$3), wildcard)
-    anon$2 := anon$3.bf$public$field
+    anon$2 := anon$3.bf$field
     ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType()))
   } else {
     ret$0 := df$rt$boolToRef(false)}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/field_getters.fir.diag.txt
@@ -1,7 +1,7 @@
 /field_getters.kt:(70,94): info: Generated Viper text for testPrimitiveFieldGetter:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
 method f$testPrimitiveFieldGetter$TF$T$c$PrimitiveFields(p$pf: Ref)
   returns (ret$0: Ref)
@@ -13,22 +13,22 @@ method f$testPrimitiveFieldGetter$TF$T$c$PrimitiveFields(p$pf: Ref)
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   ret$0 := df$rt$unitValue()
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  l0$a := p$pf.bf$public$a
-  inhale acc(p$pf.bf$public$b, write)
-  l0$b := p$pf.bf$public$b
-  exhale acc(p$pf.bf$public$b, write)
+  l0$a := p$pf.bf$a
+  inhale acc(p$pf.bf$b, write)
+  l0$b := p$pf.bf$b
+  exhale acc(p$pf.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$intType())
   label lbl$ret$0
 }
 
 /field_getters.kt:(230,254): info: Generated Viper text for testReferenceFieldGetter:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$f: Ref
+field bf$f: Ref
 
-field bf$public$g: Ref
+field bf$g: Ref
 
 method f$testReferenceFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   returns (ret$0: Ref)
@@ -44,35 +44,35 @@ method f$testReferenceFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   ret$0 := df$rt$unitValue()
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  l0$f := p$rf.bf$public$f
-  inhale acc(p$rf.bf$public$g, write)
-  l0$g := p$rf.bf$public$g
-  exhale acc(p$rf.bf$public$g, write)
+  l0$f := p$rf.bf$f
+  inhale acc(p$rf.bf$g, write)
+  l0$g := p$rf.bf$g
+  exhale acc(p$rf.bf$g, write)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$T$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(l0$g), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(l0$f), wildcard)
-  l0$fa := l0$f.bf$public$a
-  inhale acc(l0$f.bf$public$b, write)
-  l0$fb := l0$f.bf$public$b
-  exhale acc(l0$f.bf$public$b, write)
+  l0$fa := l0$f.bf$a
+  inhale acc(l0$f.bf$b, write)
+  l0$fb := l0$f.bf$b
+  exhale acc(l0$f.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$fb), df$rt$intType())
   unfold acc(p$c$PrimitiveFields$shared(l0$g), wildcard)
-  l0$ga := l0$g.bf$public$a
-  inhale acc(l0$g.bf$public$b, write)
-  l0$gb := l0$g.bf$public$b
-  exhale acc(l0$g.bf$public$b, write)
+  l0$ga := l0$g.bf$a
+  inhale acc(l0$g.bf$b, write)
+  l0$gb := l0$g.bf$b
+  exhale acc(l0$g.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$gb), df$rt$intType())
   label lbl$ret$0
 }
 
 /field_getters.kt:(387,411): info: Generated Viper text for testCascadingFieldGetter:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$f: Ref
+field bf$f: Ref
 
-field bf$public$g: Ref
+field bf$g: Ref
 
 method f$testCascadingFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   returns (ret$0: Ref)
@@ -90,30 +90,30 @@ method f$testCascadingFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   ret$0 := df$rt$unitValue()
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  anon$0 := p$rf.bf$public$f
+  anon$0 := p$rf.bf$f
   unfold acc(p$c$PrimitiveFields$shared(anon$0), wildcard)
-  l0$fa := anon$0.bf$public$a
+  l0$fa := anon$0.bf$a
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  anon$1 := p$rf.bf$public$f
-  inhale acc(anon$1.bf$public$b, write)
-  l0$fb := anon$1.bf$public$b
-  exhale acc(anon$1.bf$public$b, write)
+  anon$1 := p$rf.bf$f
+  inhale acc(anon$1.bf$b, write)
+  l0$fb := anon$1.bf$b
+  exhale acc(anon$1.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$fb), df$rt$intType())
-  inhale acc(p$rf.bf$public$g, write)
-  anon$2 := p$rf.bf$public$g
-  exhale acc(p$rf.bf$public$g, write)
+  inhale acc(p$rf.bf$g, write)
+  anon$2 := p$rf.bf$g
+  exhale acc(p$rf.bf$g, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$T$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(anon$2), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(anon$2), wildcard)
-  l0$ga := anon$2.bf$public$a
-  inhale acc(p$rf.bf$public$g, write)
-  anon$3 := p$rf.bf$public$g
-  exhale acc(p$rf.bf$public$g, write)
+  l0$ga := anon$2.bf$a
+  inhale acc(p$rf.bf$g, write)
+  anon$3 := p$rf.bf$g
+  exhale acc(p$rf.bf$g, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$T$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(anon$3), wildcard)
-  inhale acc(anon$3.bf$public$b, write)
-  l0$gb := anon$3.bf$public$b
-  exhale acc(anon$3.bf$public$b, write)
+  inhale acc(anon$3.bf$b, write)
+  l0$gb := anon$3.bf$b
+  exhale acc(anon$3.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$gb), df$rt$intType())
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance.fir.diag.txt
@@ -1,9 +1,9 @@
 /inheritance.kt:(93,97): info: Generated Viper text for getY:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
 method f$c$Foo$getY$TF$T$c$Foo(this: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -11,19 +11,19 @@ method f$c$Foo$getY$TF$T$c$Foo(this: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(this), df$rt$T$c$Foo())
   inhale acc(p$c$Foo$shared(this), wildcard)
   unfold acc(p$c$Foo$shared(this), wildcard)
-  ret$0 := this.bf$public$y
+  ret$0 := this.bf$y
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /inheritance.kt:(190,193): info: Generated Viper text for sum:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$c$Bar$sum$TF$T$c$Bar(this: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -34,22 +34,22 @@ method f$c$Bar$sum$TF$T$c$Bar(this: Ref) returns (ret$0: Ref)
   inhale acc(p$c$Bar$shared(this), wildcard)
   unfold acc(p$c$Bar$shared(this), wildcard)
   unfold acc(p$c$Foo$shared(this), wildcard)
-  anon$0 := this.bf$public$x
+  anon$0 := this.bf$x
   unfold acc(p$c$Bar$shared(this), wildcard)
-  anon$1 := this.bf$public$z
+  anon$1 := this.bf$z
   ret$0 := sp$plusInts(anon$0, anon$1)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /inheritance.kt:(236,251): info: Generated Viper text for callSuperMethod:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$c$Foo$getY$TF$T$c$Foo(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -66,35 +66,35 @@ method f$callSuperMethod$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
 }
 
 /inheritance.kt:(298,314): info: Generated Viper text for accessSuperField:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$accessSuperField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  inhale acc(p$bar.bf$public$b, write)
-  ret$0 := p$bar.bf$public$b
-  exhale acc(p$bar.bf$public$b, write)
+  inhale acc(p$bar.bf$b, write)
+  ret$0 := p$bar.bf$b
+  exhale acc(p$bar.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /inheritance.kt:(360,374): info: Generated Viper text for accessNewField:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$accessNewField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -102,19 +102,19 @@ method f$accessNewField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   unfold acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := p$bar.bf$public$z
+  ret$0 := p$bar.bf$z
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /inheritance.kt:(416,429): info: Generated Viper text for callNewMethod:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$c$Bar$sum$TF$T$c$Bar(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -131,13 +131,13 @@ method f$callNewMethod$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
 }
 
 /inheritance.kt:(475,488): info: Generated Viper text for setSuperField:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$setSuperField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -145,20 +145,20 @@ method f$setSuperField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := df$rt$unitValue()
-  inhale acc(p$bar.bf$public$b, write)
-  p$bar.bf$public$b := df$rt$boolToRef(true)
-  exhale acc(p$bar.bf$public$b, write)
+  inhale acc(p$bar.bf$b, write)
+  p$bar.bf$b := df$rt$boolToRef(true)
+  exhale acc(p$bar.bf$b, write)
   label lbl$ret$0
 }
 
 /inheritance.kt:(525,546): info: Generated Viper text for accessSuperSuperField:
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 method f$accessSuperSuperField$TF$T$c$Baz(p$baz: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -168,7 +168,7 @@ method f$accessSuperSuperField$TF$T$c$Baz(p$baz: Ref) returns (ret$0: Ref)
   unfold acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Bar$shared(p$baz), wildcard)
   unfold acc(p$c$Foo$shared(p$baz), wildcard)
-  ret$0 := p$baz.bf$public$x
+  ret$0 := p$baz.bf$x
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
@@ -1,5 +1,5 @@
 /inheritance_fields.kt:(227,234): info: Generated Viper text for createB:
-field bf$public$fieldNotOverride: Ref
+field bf$fieldNotOverride: Ref
 
 method con$c$B$T$c$FieldB(p$fieldOverride: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$B())
@@ -30,7 +30,7 @@ method f$createB$TF$() returns (ret$0: Ref)
   inhale acc(p$c$FieldB$shared(l0$fieldOverride), wildcard)
   unfold acc(p$c$B$shared(l0$b), wildcard)
   unfold acc(p$c$A$shared(l0$b), wildcard)
-  l0$fieldNotOverride := l0$b.bf$public$fieldNotOverride
+  l0$fieldNotOverride := l0$b.bf$fieldNotOverride
   label lbl$ret$0
 }
 
@@ -38,7 +38,7 @@ method pg$public$fieldOverride(this: Ref) returns (ret: Ref)
 
 
 /inheritance_fields.kt:(699,715): info: Generated Viper text for createBFsAndNoBF:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method con$c$FirstBackingFieldClass$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$FirstBackingFieldClass())
@@ -57,7 +57,7 @@ method con$c$SecondBackingFieldClass$T$Int(p$x: Ref) returns (ret: Ref)
   ensures acc(p$c$SecondBackingFieldClass$shared(ret), wildcard)
   ensures acc(p$c$SecondBackingFieldClass$unique(ret), write)
   ensures (unfolding acc(p$c$SecondBackingFieldClass$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$x) == df$rt$intFromRef(p$x))
+      df$rt$intFromRef(ret.bf$x) == df$rt$intFromRef(p$x))
 
 
 method f$createBFsAndNoBF$TF$() returns (ret$0: Ref)
@@ -82,7 +82,7 @@ method f$createBFsAndNoBF$TF$() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$nbfx), df$rt$intType())
   l0$sbf := con$c$SecondBackingFieldClass$T$Int(df$rt$intToRef(10))
   unfold acc(p$c$SecondBackingFieldClass$shared(l0$sbf), wildcard)
-  l0$sbfx := l0$sbf.bf$public$x
+  l0$sbfx := l0$sbf.bf$x
   label lbl$ret$0
 }
 
@@ -90,7 +90,7 @@ method pg$public$x(this: Ref) returns (ret: Ref)
 
 
 /inheritance_fields.kt:(1038,1045): info: Generated Viper text for createY:
-field bf$public$a: Ref
+field bf$a: Ref
 
 method con$c$Y$T$Int(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Y())
@@ -107,6 +107,6 @@ method f$createY$TF$() returns (ret$0: Ref)
   l0$y := con$c$Y$T$Int(df$rt$intToRef(10))
   unfold acc(p$c$Y$shared(l0$y), wildcard)
   unfold acc(p$c$X$shared(l0$y), wildcard)
-  l0$ya := l0$y.bf$public$a
+  l0$ya := l0$y.bf$a
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
@@ -32,14 +32,14 @@ method ps$public$varProp(this: Ref, value: Ref) returns (ret: Ref)
 
 
 /interface.kt:(348,358): info: Generated Viper text for createImpl:
-field bf$public$number: Ref
+field bf$number: Ref
 
 method con$c$Impl$T$Int(p$number: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl())
   ensures acc(p$c$Impl$shared(ret), wildcard)
   ensures acc(p$c$Impl$unique(ret), write)
   ensures (unfolding acc(p$c$Impl$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$number) == df$rt$intFromRef(p$number))
+      df$rt$intFromRef(ret.bf$number) == df$rt$intFromRef(p$number))
 
 
 method f$createImpl$TF$() returns (ret$0: Ref)
@@ -50,7 +50,7 @@ method f$createImpl$TF$() returns (ret$0: Ref)
   ret$0 := df$rt$unitValue()
   l0$impl := con$c$Impl$T$Int(df$rt$intToRef(-1))
   unfold acc(p$c$Impl$shared(l0$impl), wildcard)
-  l0$implField := l0$impl.bf$public$number
+  l0$implField := l0$impl.bf$number
   label lbl$ret$0
 }
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/member_functions.fir.diag.txt
@@ -1,5 +1,5 @@
 /member_functions.kt:(51,60): info: Generated Viper text for memberFun:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$c$Foo$memberFun$TF$T$c$Foo(this: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -7,13 +7,13 @@ method f$c$Foo$memberFun$TF$T$c$Foo(this: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(this), df$rt$T$c$Foo())
   inhale acc(p$c$Foo$shared(this), wildcard)
   unfold acc(p$c$Foo$shared(this), wildcard)
-  ret$0 := this.bf$public$x
+  ret$0 := this.bf$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /member_functions.kt:(102,115): info: Generated Viper text for callMemberFun:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$c$Foo$callMemberFun$TF$T$c$Foo(this: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -31,7 +31,7 @@ method f$c$Foo$memberFun$TF$T$c$Foo(this: Ref) returns (ret: Ref)
 
 
 /member_functions.kt:(155,166): info: Generated Viper text for siblingCall:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$c$Foo$memberFun$TF$T$c$Foo(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -52,7 +52,7 @@ method f$c$Foo$siblingCall$TF$T$c$Foo$T$c$Foo(this: Ref, p$other: Ref)
 }
 
 /member_functions.kt:(220,238): info: Generated Viper text for outerMemberFunCall:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$c$Foo$memberFun$TF$T$c$Foo(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates.fir.diag.txt
@@ -1,11 +1,11 @@
 /predicates.kt:(203,213): info: Generated Viper text for useClasses:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$next: Ref
+field bf$next: Ref
 
-field bf$public$pf: Ref
+field bf$pf: Ref
 
 predicate p$c$Baz$shared(this: Ref) {
   true
@@ -16,42 +16,42 @@ predicate p$c$Baz$unique(this: Ref) {
 }
 
 predicate p$c$PrimitiveFields$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$PrimitiveFields$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType()) &&
-  acc(this.bf$public$b, write) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType()) &&
+  acc(this.bf$b, write) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType())
 }
 
 predicate p$c$Recursive$shared(this: Ref) {
-  acc(this.bf$public$next, wildcard) &&
-  (this.bf$public$next != df$rt$nullValue() ==>
-  acc(p$c$Recursive$shared(this.bf$public$next), wildcard)) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$next), df$rt$nullable(df$rt$T$c$Recursive()))
+  acc(this.bf$next, wildcard) &&
+  (this.bf$next != df$rt$nullValue() ==>
+  acc(p$c$Recursive$shared(this.bf$next), wildcard)) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$next), df$rt$nullable(df$rt$T$c$Recursive()))
 }
 
 predicate p$c$Recursive$unique(this: Ref) {
-  acc(this.bf$public$next, wildcard) &&
-  (this.bf$public$next != df$rt$nullValue() ==>
-  acc(p$c$Recursive$shared(this.bf$public$next), wildcard)) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$next), df$rt$nullable(df$rt$T$c$Recursive()))
+  acc(this.bf$next, wildcard) &&
+  (this.bf$next != df$rt$nullValue() ==>
+  acc(p$c$Recursive$shared(this.bf$next), wildcard)) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$next), df$rt$nullable(df$rt$T$c$Recursive()))
 }
 
 predicate p$c$ReferenceField$shared(this: Ref) {
-  acc(this.bf$public$pf, wildcard) &&
-  acc(p$c$PrimitiveFields$shared(this.bf$public$pf), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$pf), df$rt$T$c$PrimitiveFields()) &&
+  acc(this.bf$pf, wildcard) &&
+  acc(p$c$PrimitiveFields$shared(this.bf$pf), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$pf), df$rt$T$c$PrimitiveFields()) &&
   acc(p$c$Baz$shared(this), wildcard)
 }
 
 predicate p$c$ReferenceField$unique(this: Ref) {
-  acc(this.bf$public$pf, wildcard) &&
-  acc(p$c$PrimitiveFields$shared(this.bf$public$pf), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$pf), df$rt$T$c$PrimitiveFields()) &&
+  acc(this.bf$pf, wildcard) &&
+  acc(p$c$PrimitiveFields$shared(this.bf$pf), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$pf), df$rt$T$c$PrimitiveFields()) &&
   acc(p$c$Baz$unique(this), write)
 }
 
@@ -68,20 +68,20 @@ method f$useClasses$TF$T$c$ReferenceField$T$c$Recursive(p$rf: Ref, p$rec: Ref)
 }
 
 /predicates.kt:(354,374): info: Generated Viper text for threeLayersHierarchy:
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$intType())
+  acc(this.bf$x, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$intType()) &&
-  acc(this.bf$public$y, write) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$y), df$rt$intType())
+  acc(this.bf$x, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$intType()) &&
+  acc(this.bf$y, write) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$y), df$rt$intType())
 }
 
 predicate p$c$B$shared(this: Ref) {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
@@ -1,49 +1,47 @@
 /predicates_access.kt:(249,272): info: Generated Viper text for accessSuperTypeProperty:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$B$shared(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$shared(this), wildcard)
 }
 
 predicate p$c$B$unique(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$unique(this), write)
 }
 
 predicate p$c$C$shared(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  acc(p$c$A$shared(this.bf$public$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$T$c$A()) &&
+  acc(this.bf$x, wildcard) && acc(p$c$A$shared(this.bf$x), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$T$c$A()) &&
   acc(p$c$D$shared(this), wildcard) &&
   acc(p$c$B$shared(this), wildcard)
 }
 
 predicate p$c$C$unique(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  acc(p$c$A$shared(this.bf$public$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$T$c$A()) &&
-  acc(this.bf$public$y, write) &&
-  acc(p$c$A$shared(this.bf$public$y), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$y), df$rt$T$c$A()) &&
+  acc(this.bf$x, wildcard) && acc(p$c$A$shared(this.bf$x), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$T$c$A()) &&
+  acc(this.bf$y, write) &&
+  acc(p$c$A$shared(this.bf$y), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$y), df$rt$T$c$A()) &&
   acc(p$c$D$unique(this), write) &&
   acc(p$c$B$unique(this), write)
 }
@@ -66,7 +64,7 @@ method f$accessSuperTypeProperty$TF$T$c$C(p$c: Ref) returns (ret$0: Ref)
   unfold acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$B$shared(p$c), wildcard)
   unfold acc(p$c$A$shared(p$c), wildcard)
-  l0$temp := p$c.bf$public$a
+  l0$temp := p$c.bf$a
   label lbl$ret$0
 }
 
@@ -74,51 +72,49 @@ method pg$public$d(this: Ref) returns (ret: Ref)
 
 
 /predicates_access.kt:(306,318): info: Generated Viper text for accessNested:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$B$shared(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$shared(this), wildcard)
 }
 
 predicate p$c$B$unique(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$unique(this), write)
 }
 
 predicate p$c$C$shared(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  acc(p$c$A$shared(this.bf$public$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$T$c$A()) &&
+  acc(this.bf$x, wildcard) && acc(p$c$A$shared(this.bf$x), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$T$c$A()) &&
   acc(p$c$D$shared(this), wildcard) &&
   acc(p$c$B$shared(this), wildcard)
 }
 
 predicate p$c$C$unique(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  acc(p$c$A$shared(this.bf$public$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$T$c$A()) &&
-  acc(this.bf$public$y, write) &&
-  acc(p$c$A$shared(this.bf$public$y), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$y), df$rt$T$c$A()) &&
+  acc(this.bf$x, wildcard) && acc(p$c$A$shared(this.bf$x), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$T$c$A()) &&
+  acc(this.bf$y, write) &&
+  acc(p$c$A$shared(this.bf$y), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$y), df$rt$T$c$A()) &&
   acc(p$c$D$unique(this), write) &&
   acc(p$c$B$unique(this), write)
 }
@@ -140,9 +136,9 @@ method f$accessNested$TF$T$c$C(p$c: Ref) returns (ret$0: Ref)
   inhale acc(p$c$C$shared(p$c), wildcard)
   ret$0 := df$rt$unitValue()
   unfold acc(p$c$C$shared(p$c), wildcard)
-  anon$0 := p$c.bf$public$x
+  anon$0 := p$c.bf$x
   unfold acc(p$c$A$shared(anon$0), wildcard)
-  l0$temp := anon$0.bf$public$a
+  l0$temp := anon$0.bf$a
   label lbl$ret$0
 }
 
@@ -150,16 +146,16 @@ method pg$public$d(this: Ref) returns (ret: Ref)
 
 
 /predicates_access.kt:(354,368): info: Generated Viper text for accessNullable:
-field bf$public$a: Ref
+field bf$a: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 method f$accessNullable$TF$c$A(p$x: Ref) returns (ret$0: Ref)
@@ -171,35 +167,35 @@ method f$accessNullable$TF$c$A(p$x: Ref) returns (ret$0: Ref)
   ret$0 := df$rt$unitValue()
   if (!(p$x == df$rt$nullValue())) {
     unfold acc(p$c$A$shared(p$x), wildcard)
-    l0$n := p$x.bf$public$a
+    l0$n := p$x.bf$a
   }
   label lbl$ret$0
 }
 
 /predicates_access.kt:(442,452): info: Generated Viper text for accessCast:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$B$shared(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$shared(this), wildcard)
 }
 
 predicate p$c$B$unique(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$unique(this), write)
 }
 
@@ -215,34 +211,34 @@ method f$accessCast$TF$T$c$A(p$x: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$B())
   inhale acc(p$c$B$shared(anon$0), wildcard)
   unfold acc(p$c$B$shared(anon$0), wildcard)
-  l0$n := anon$0.bf$public$b
+  l0$n := anon$0.bf$b
   label lbl$ret$0
 }
 
 /predicates_access.kt:(501,515): info: Generated Viper text for accessSafeCast:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$B$shared(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$shared(this), wildcard)
 }
 
 predicate p$c$B$unique(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$unique(this), write)
 }
 
@@ -263,35 +259,35 @@ method f$accessSafeCast$TF$T$c$A(p$x: Ref) returns (ret$0: Ref)
   inhale l0$y != df$rt$nullValue() ==> acc(p$c$B$shared(l0$y), wildcard)
   if (!(l0$y == df$rt$nullValue())) {
     unfold acc(p$c$B$shared(l0$y), wildcard)
-    l0$n := l0$y.bf$public$b
+    l0$n := l0$y.bf$b
   }
   label lbl$ret$0
 }
 
 /predicates_access.kt:(612,627): info: Generated Viper text for accessSmartCast:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
 predicate p$c$A$shared(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$A$unique(this: Ref) {
-  acc(this.bf$public$a, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$a), df$rt$intType())
+  acc(this.bf$a, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$a), df$rt$intType())
 }
 
 predicate p$c$B$shared(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$shared(this), wildcard)
 }
 
 predicate p$c$B$unique(this: Ref) {
-  acc(this.bf$public$b, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$b), df$rt$intType()) &&
+  acc(this.bf$b, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$b), df$rt$intType()) &&
   acc(p$c$A$unique(this), write)
 }
 
@@ -308,7 +304,7 @@ method f$accessSmartCast$TF$T$c$A(p$x: Ref) returns (ret$0: Ref)
     anon$0 := p$x
     inhale acc(p$c$B$shared(anon$0), wildcard)
     unfold acc(p$c$B$shared(anon$0), wildcard)
-    l0$n := anon$0.bf$public$b
+    l0$n := anon$0.bf$b
   }
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
@@ -1,7 +1,7 @@
 /primary_constructors.kt:(70,91): info: Generated Viper text for createPrimitiveFields:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$b: Ref
+field bf$b: Ref
 
 method con$c$PrimitiveFields$T$Int$T$Int(p$a: Ref, p$b: Ref)
   returns (ret: Ref)
@@ -9,8 +9,8 @@ method con$c$PrimitiveFields$T$Int$T$Int(p$a: Ref, p$b: Ref)
   ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveFields$unique(ret), write)
   ensures (unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$a) == df$rt$intFromRef(p$a) &&
-      df$rt$intFromRef(ret.bf$public$b) == df$rt$intFromRef(p$b))
+      df$rt$intFromRef(ret.bf$a) == df$rt$intFromRef(p$a) &&
+      df$rt$intFromRef(ret.bf$b) == df$rt$intFromRef(p$b))
 
 
 method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
@@ -23,14 +23,14 @@ method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
 }
 
 /primary_constructors.kt:(178,193): info: Generated Viper text for createRecursive:
-field bf$public$a: Ref
+field bf$a: Ref
 
 method con$c$Recursive$c$Recursive(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)
   ensures (unfolding acc(p$c$Recursive$shared(ret), wildcard) in
-      ret.bf$public$a == p$a)
+      ret.bf$a == p$a)
 
 
 method f$createRecursive$TF$() returns (ret$0: Ref)
@@ -43,16 +43,16 @@ method f$createRecursive$TF$() returns (ret$0: Ref)
 }
 
 /primary_constructors.kt:(279,296): info: Generated Viper text for createFieldInBody:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$c: Ref
+field bf$c: Ref
 
 method con$c$FieldInBody$T$Int(p$c: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$FieldInBody())
   ensures acc(p$c$FieldInBody$shared(ret), wildcard)
   ensures acc(p$c$FieldInBody$unique(ret), write)
   ensures (unfolding acc(p$c$FieldInBody$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$c) == df$rt$intFromRef(p$c))
+      df$rt$intFromRef(ret.bf$c) == df$rt$intFromRef(p$c))
 
 
 method f$createFieldInBody$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
@@ -1,5 +1,5 @@
 /secondary_constructors.kt:(249,271): info: Generated Viper text for onlySecondConstructors:
-field bf$public$a: Ref
+field bf$a: Ref
 
 method con$c$NoPrimaryConstructor$T$Boolean(p$b: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$NoPrimaryConstructor())
@@ -25,7 +25,7 @@ method f$onlySecondConstructors$TF$() returns (ret$0: Ref)
 }
 
 /secondary_constructors.kt:(365,392): info: Generated Viper text for primaryAndSecondConstructor:
-field bf$public$a: Ref
+field bf$a: Ref
 
 method con$c$BothConstructors$T$Boolean(p$b: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$BothConstructors())
@@ -38,7 +38,7 @@ method con$c$BothConstructors$T$Int(p$a: Ref) returns (ret: Ref)
   ensures acc(p$c$BothConstructors$shared(ret), wildcard)
   ensures acc(p$c$BothConstructors$unique(ret), write)
   ensures (unfolding acc(p$c$BothConstructors$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$a) == df$rt$intFromRef(p$a))
+      df$rt$intFromRef(ret.bf$a) == df$rt$intFromRef(p$a))
 
 
 method f$primaryAndSecondConstructor$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/setters.fir.diag.txt
@@ -1,5 +1,5 @@
 /setters.kt:(103,127): info: Generated Viper text for testPrimitiveFieldSetter:
-field bf$public$a: Ref
+field bf$a: Ref
 
 method f$testPrimitiveFieldSetter$TF$T$c$PrimitiveField(p$pf: Ref)
   returns (ret$0: Ref)
@@ -8,16 +8,16 @@ method f$testPrimitiveFieldSetter$TF$T$c$PrimitiveField(p$pf: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$T$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   ret$0 := df$rt$unitValue()
-  inhale acc(p$pf.bf$public$a, write)
-  p$pf.bf$public$a := df$rt$intToRef(0)
-  exhale acc(p$pf.bf$public$a, write)
+  inhale acc(p$pf.bf$a, write)
+  p$pf.bf$a := df$rt$intToRef(0)
+  exhale acc(p$pf.bf$a, write)
   label lbl$ret$0
 }
 
 /setters.kt:(170,194): info: Generated Viper text for testReferenceFieldSetter:
-field bf$public$a: Ref
+field bf$a: Ref
 
-field bf$public$pf: Ref
+field bf$pf: Ref
 
 method con$c$PrimitiveField$T$Int(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$PrimitiveField())
@@ -34,9 +34,9 @@ method f$testReferenceFieldSetter$TF$T$c$ReferenceField(p$rf: Ref)
   inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
   ret$0 := df$rt$unitValue()
   anon$0 := con$c$PrimitiveField$T$Int(df$rt$intToRef(0))
-  inhale acc(p$rf.bf$public$pf, write)
-  p$rf.bf$public$pf := anon$0
-  exhale acc(p$rf.bf$public$pf, write)
+  inhale acc(p$rf.bf$pf, write)
+  p$rf.bf$pf := anon$0
+  exhale acc(p$rf.bf$pf, write)
   label lbl$ret$0
 }
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
@@ -1,34 +1,34 @@
 /unique_predicates.kt:(269,283): info: Generated Viper text for unique_foo_arg:
-field bf$public$w: Ref
+field bf$w: Ref
 
-field bf$public$x: Ref
+field bf$x: Ref
 
-field bf$public$y: Ref
+field bf$y: Ref
 
-field bf$public$z: Ref
+field bf$z: Ref
 
 predicate p$c$Foo$shared(this: Ref) {
-  acc(this.bf$public$w, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$w), df$rt$intType()) &&
-  acc(this.bf$public$y, wildcard) &&
-  acc(p$c$T$shared(this.bf$public$y), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$y), df$rt$T$c$T()) &&
+  acc(this.bf$w, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$w), df$rt$intType()) &&
+  acc(this.bf$y, wildcard) &&
+  acc(p$c$T$shared(this.bf$y), wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$y), df$rt$T$c$T()) &&
   acc(p$c$S$shared(this), wildcard)
 }
 
 predicate p$c$Foo$unique(this: Ref) {
-  acc(this.bf$public$w, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$w), df$rt$intType()) &&
-  acc(this.bf$public$x, write) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$intType()) &&
-  acc(this.bf$public$y, wildcard) &&
-  acc(p$c$T$shared(this.bf$public$y), wildcard) &&
-  acc(p$c$T$unique(this.bf$public$y), write) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$y), df$rt$T$c$T()) &&
-  acc(this.bf$public$z, write) &&
-  acc(p$c$T$shared(this.bf$public$z), wildcard) &&
-  acc(p$c$T$unique(this.bf$public$z), write) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$z), df$rt$T$c$T()) &&
+  acc(this.bf$w, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$w), df$rt$intType()) &&
+  acc(this.bf$x, write) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$intType()) &&
+  acc(this.bf$y, wildcard) &&
+  acc(p$c$T$shared(this.bf$y), wildcard) &&
+  acc(p$c$T$unique(this.bf$y), write) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$y), df$rt$T$c$T()) &&
+  acc(this.bf$z, write) &&
+  acc(p$c$T$shared(this.bf$z), wildcard) &&
+  acc(p$c$T$unique(this.bf$z), write) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$z), df$rt$T$c$T()) &&
   acc(p$c$S$unique(this), write)
 }
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/exp_side_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/exp_side_effects.fir.diag.txt
@@ -1,5 +1,5 @@
 /exp_side_effects.kt:(185,189): info: Generated Viper text for test:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$getFoo$TF$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
@@ -22,13 +22,13 @@ method f$test$TF$() returns (ret$0: Ref)
   ret$0 := df$rt$unitValue()
   anon$0 := f$getFoo$TF$()
   anon$1 := f$sideEffect$TF$()
-  inhale acc(anon$0.bf$public$x, write)
-  anon$0.bf$public$x := anon$1
-  exhale acc(anon$0.bf$public$x, write)
+  inhale acc(anon$0.bf$x, write)
+  anon$0.bf$x := anon$1
+  exhale acc(anon$0.bf$x, write)
   anon$3 := f$getFoo$TF$()
-  inhale acc(anon$3.bf$public$x, write)
-  anon$2 := anon$3.bf$public$x
-  exhale acc(anon$3.bf$public$x, write)
+  inhale acc(anon$3.bf$x, write)
+  anon$2 := anon$3.bf$x
+  exhale acc(anon$3.bf$x, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   anon$4 := f$sideEffect$TF$()
   l0$y := sp$plusInts(anon$2, anon$4)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -42,7 +42,7 @@ method f$extensionSetterProperty$TF$() returns (ret$0: Ref)
 }
 
 /extension_properties.kt:(414,453): info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method eg$pfValProp$TF$T$c$PrimitiveField(this: Ref) returns (ret: Ref)
 
@@ -63,7 +63,7 @@ method f$extensionGetterPropertyUserDefinedClass$TF$T$c$PrimitiveField(p$pf: Ref
 }
 
 /extension_properties.kt:(508,547): info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method eg$pfVarProp$TF$T$c$PrimitiveField(this: Ref) returns (ret: Ref)
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -188,7 +188,7 @@ domain d$rt  {
   }
 }
 
-field bf$public$x: Ref
+field bf$x: Ref
 
 function sp$andBools(arg1: Ref, arg2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
@@ -270,13 +270,13 @@ function sp$timesInts(arg1: Ref, arg2: Ref): Ref
 
 
 predicate p$c$Foo$shared(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$intType())
+  acc(this.bf$x, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$intType())
 }
 
 predicate p$c$Foo$unique(this: Ref) {
-  acc(this.bf$public$x, wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this.bf$public$x), df$rt$intType())
+  acc(this.bf$x, wildcard) &&
+  df$rt$isSubtype(df$rt$typeOf(this.bf$x), df$rt$intType())
 }
 
 method con$c$Foo$T$Int(p$x: Ref) returns (ret: Ref)
@@ -284,7 +284,7 @@ method con$c$Foo$T$Int(p$x: Ref) returns (ret: Ref)
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)
   ensures (unfolding acc(p$c$Foo$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$public$x) == df$rt$intFromRef(p$x))
+      df$rt$intFromRef(ret.bf$x) == df$rt$intFromRef(p$x))
 
 
 method f$f$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
@@ -1,5 +1,5 @@
 /safe_call.kt:(142,154): info: Generated Viper text for testSafeCall:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$c$Foo$f$TF$T$c$Foo(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
@@ -22,7 +22,7 @@ method f$testSafeCall$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /safe_call.kt:(217,240): info: Generated Viper text for testSafeCallNonNullable:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$c$Foo$f$TF$T$c$Foo(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
@@ -45,7 +45,7 @@ method f$testSafeCallNonNullable$TF$T$c$Foo(p$foo: Ref)
 }
 
 /safe_call.kt:(267,287): info: Generated Viper text for testSafeCallProperty:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$testSafeCallProperty$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
@@ -56,7 +56,7 @@ method f$testSafeCallProperty$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
     unfold acc(p$c$Foo$shared(p$foo), wildcard)
-    anon$0 := p$foo.bf$public$x
+    anon$0 := p$foo.bf$x
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -65,7 +65,7 @@ method f$testSafeCallProperty$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /safe_call.kt:(354,385): info: Generated Viper text for testSafeCallPropertyNonNullable:
-field bf$public$x: Ref
+field bf$x: Ref
 
 method f$testSafeCallPropertyNonNullable$TF$T$c$Foo(p$foo: Ref)
   returns (ret$0: Ref)
@@ -76,7 +76,7 @@ method f$testSafeCallPropertyNonNullable$TF$T$c$Foo(p$foo: Ref)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
     unfold acc(p$c$Foo$shared(p$foo), wildcard)
-    anon$0 := p$foo.bf$public$x
+    anon$0 := p$foo.bf$x
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -85,7 +85,7 @@ method f$testSafeCallPropertyNonNullable$TF$T$c$Foo(p$foo: Ref)
 }
 
 /safe_call.kt:(493,506): info: Generated Viper text for safeCallChain:
-field bf$public$v: Ref
+field bf$v: Ref
 
 method f$c$Rec$nullable$TF$T$c$Rec(this: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$T$c$Rec()))
@@ -111,7 +111,7 @@ method f$safeCallChain$TF$c$Rec(p$rec: Ref) returns (ret$0: Ref)
   if (anon$0 != df$rt$nullValue()) {
     var anon$2: Ref
     unfold acc(p$c$Rec$shared(anon$0), wildcard)
-    anon$2 := anon$0.bf$public$v
+    anon$2 := anon$0.bf$v
     ret$0 := anon$2
   } else {
     ret$0 := df$rt$nullValue()}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
@@ -1,5 +1,5 @@
 /generics.kt:(52,65): info: Generated Viper text for genericMethod:
-field bf$public$t: Ref
+field bf$t: Ref
 
 method f$c$Box$genericMethod$TF$T$c$Box$Any(this: Ref, p$x: Ref)
   returns (ret$0: Ref)
@@ -14,7 +14,7 @@ method f$c$Box$genericMethod$TF$T$c$Box$Any(this: Ref, p$x: Ref)
 }
 
 /generics.kt:(107,116): info: Generated Viper text for createBox:
-field bf$public$t: Ref
+field bf$t: Ref
 
 method con$c$Box$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
@@ -31,16 +31,16 @@ method f$createBox$TF$() returns (ret$0: Ref)
   var l0$intBox: Ref
   var anon$1: Ref
   l0$boolBox := con$c$Box$Any(df$rt$boolToRef(true))
-  inhale acc(l0$boolBox.bf$public$t, write)
-  anon$0 := l0$boolBox.bf$public$t
-  exhale acc(l0$boolBox.bf$public$t, write)
+  inhale acc(l0$boolBox.bf$t, write)
+  anon$0 := l0$boolBox.bf$t
+  exhale acc(l0$boolBox.bf$t, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   l0$b := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
   l0$intBox := con$c$Box$Any(df$rt$intToRef(2))
-  inhale acc(l0$intBox.bf$public$t, write)
-  anon$1 := l0$intBox.bf$public$t
-  exhale acc(l0$intBox.bf$public$t, write)
+  inhale acc(l0$intBox.bf$t, write)
+  anon$1 := l0$intBox.bf$t
+  exhale acc(l0$intBox.bf$t, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$nullable(df$rt$anyType()))
   ret$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -49,7 +49,7 @@ method f$createBox$TF$() returns (ret$0: Ref)
 }
 
 /generics.kt:(227,242): info: Generated Viper text for setGenericField:
-field bf$public$t: Ref
+field bf$t: Ref
 
 method con$c$Box$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
@@ -63,9 +63,9 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
   var l0$box: Ref
   ret$0 := df$rt$unitValue()
   l0$box := con$c$Box$Any(df$rt$intToRef(3))
-  inhale acc(l0$box.bf$public$t, write)
-  l0$box.bf$public$t := df$rt$intToRef(5)
-  exhale acc(l0$box.bf$public$t, write)
+  inhale acc(l0$box.bf$t, write)
+  l0$box.bf$t := df$rt$intToRef(5)
+  exhale acc(l0$box.bf$t, write)
   label lbl$ret$0
 }
 
@@ -96,7 +96,7 @@ method f$genericFun$TF$Any(p$t: Ref) returns (ret: Ref)
 
 
 /generics.kt:(375,395): info: Generated Viper text for genericAsIfCondition:
-field bf$public$t: Ref
+field bf$t: Ref
 
 method f$genericAsIfCondition$TF$T$c$Box(p$box: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -105,9 +105,9 @@ method f$genericAsIfCondition$TF$T$c$Box(p$box: Ref) returns (ret$0: Ref)
   var anon$1: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$T$c$Box())
   inhale acc(p$c$Box$shared(p$box), wildcard)
-  inhale acc(p$box.bf$public$t, write)
-  anon$1 := p$box.bf$public$t
-  exhale acc(p$box.bf$public$t, write)
+  inhale acc(p$box.bf$t, write)
+  anon$1 := p$box.bf$t
+  exhale acc(p$box.bf$t, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$nullable(df$rt$anyType()))
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())


### PR DESCRIPTION
Previously, we maintained scoping information in the name.  This was a bit messy; this PR changes the approach to not give them a scope at all.

We don't remove the special case on public scope yet, since that also impacts public properties.