### PR TITLE
Two receivers (extension and dispatch) support

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -38,14 +38,8 @@ val FirPropertySymbol.isCustom: Boolean
     }
 
 val FirFunctionCall.functionCallArguments: List<FirExpression>
-    get() {
-        val receiverArg = when {
-            dispatchReceiver != null -> dispatchReceiver
-            extensionReceiver != null -> extensionReceiver
-            else -> null
-        }
-        return listOfNotNull(receiverArg) + argumentList.arguments
-    }
+    get() = listOfNotNull(dispatchReceiver, extensionReceiver) + argumentList.arguments
+
 val FirFunctionSymbol<*>.effects: List<FirEffectDeclaration>
     get() = this.resolvedContractDescription?.effects ?: emptyList()
 val KtSourceElement?.asPosition: Position

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ContractDescriptionConversionVisitor.kt
@@ -158,7 +158,8 @@ class ContractDescriptionConversionVisitor(
             parameterIndex,
             { TODO("old code: data.functionContractOwner.receiverParameter!!.calleeSymbol") }) { data.functionContractOwner.valueParameterSymbols[it] }
 
-    private fun embeddedVarByIndex(ix: Int): VariableEmbedding = resolveByIndex(ix, { signature.receiver!! }) { signature.params[it] }
+    private fun embeddedVarByIndex(ix: Int): VariableEmbedding =
+        resolveByIndex(ix, { signature.dispatchReceiver!! }) { signature.params[it] }
 
     private fun VariableEmbedding.nullCmp(isNegated: Boolean, sourceRole: SourceRole?): ExpEmbedding =
         if (isNegated) NeCmp(this, NullLit, sourceRole)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -40,7 +40,7 @@ interface MethodConversionContext : ProgramConversionContext {
     fun resolveLocal(name: Name): VariableEmbedding
     fun registerLocalProperty(symbol: FirPropertySymbol)
     fun registerLocalVariable(symbol: FirVariableSymbol<*>)
-    fun resolveReceiver(): ExpEmbedding?
+    fun resolveReceiver(isExtension: Boolean): ExpEmbedding?
 
     fun <R> withScopeImpl(scopeDepth: Int, action: () -> R): R
     fun addLoopIdentifier(labelName: String, index: Int)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
@@ -62,7 +62,8 @@ class MethodConverter(
         paramResolver.tryResolveParameter(name) ?: parent?.resolveParameter(name)
         ?: throw IllegalArgumentException("Parameter $name not found in scope.")
 
-    override fun resolveReceiver(): ExpEmbedding? = paramResolver.tryResolveReceiver() ?: parent?.resolveReceiver()
+    override fun resolveReceiver(isExtension: Boolean): ExpEmbedding? =
+        paramResolver.tryResolveReceiver(isExtension) ?: parent?.resolveReceiver(isExtension)
 
     override val defaultResolvedReturnTarget = paramResolver.defaultResolvedReturnTarget
     override fun resolveNamedReturnTarget(sourceName: String): ReturnTarget? {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ParameterResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ParameterResolver.kt
@@ -35,7 +35,7 @@ class RootParameterResolver(
     override val defaultResolvedReturnTarget: ReturnTarget,
 ) : ParameterResolver {
     private val parameters = signature.params.associateBy { it.name }
-    private val receiver = signature.receiver
+    private val receiver = signature.dispatchReceiver
     override fun tryResolveParameter(name: Name): ExpEmbedding? = parameters[name.embedParameterName()]
     override fun tryResolveReceiver() = receiver
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ParameterResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ParameterResolver.kt
@@ -7,9 +7,9 @@ package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.names.ExtraSpecialNames
 import org.jetbrains.kotlin.formver.names.embedParameterName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 /**
@@ -30,14 +30,13 @@ fun ParameterResolver.resolveNamedReturnTarget(returnPointName: String): ReturnT
 
 class RootParameterResolver(
     val ctx: ProgramConversionContext,
-    signature: FunctionSignature,
+    private val signature: FunctionSignature,
     override val sourceName: String?,
     override val defaultResolvedReturnTarget: ReturnTarget,
 ) : ParameterResolver {
     private val parameters = signature.params.associateBy { it.name }
-    private val receiver = signature.dispatchReceiver
     override fun tryResolveParameter(name: Name): ExpEmbedding? = parameters[name.embedParameterName()]
-    override fun tryResolveReceiver() = receiver
+    override fun tryResolveReceiver() = signature.run { dispatchReceiver ?: extensionReceiver }
 }
 
 class InlineParameterResolver(
@@ -46,5 +45,5 @@ class InlineParameterResolver(
     override val defaultResolvedReturnTarget: ReturnTarget,
 ) : ParameterResolver {
     override fun tryResolveParameter(name: Name): ExpEmbedding? = substitutions[name]
-    override fun tryResolveReceiver(): ExpEmbedding? = substitutions[SpecialNames.THIS]
+    override fun tryResolveReceiver(): ExpEmbedding? = substitutions[ExtraSpecialNames.D_THIS] ?: substitutions[ExtraSpecialNames.E_THIS]
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -165,7 +165,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             val receiverType: TypeEmbedding? = type.receiverType(session)?.let { embedType(it) }
             val paramTypes: List<TypeEmbedding> = type.valueParameterTypesWithoutReceivers(session).map(::embedType)
             val returnType: TypeEmbedding = embedType(type.returnType(session))
-            val signature = CallableSignatureData(receiverType, paramTypes, returnType)
+            val signature = CallableSignatureData(receiverType, null, paramTypes, returnType)
             FunctionTypeEmbedding(signature)
         }
         type.isNullable -> NullableTypeEmbedding(embedType(type.withNullability(ConeNullability.NOT_NULL, session.typeContext)))
@@ -217,13 +217,20 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
 
     override fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature {
         val retType = embedType(symbol.resolvedReturnTypeRef.coneType)
-        val receiverType = symbol.receiverType
+        val dispatchReceiverType = symbol.receiverType
         val isReceiverUnique = symbol.receiverParameter?.isUnique(session) ?: false
         val isReceiverBorrowed = symbol.receiverParameter?.isBorrowed(session) ?: false
         return object : FunctionSignature {
             // TODO: figure out whether we want a symbol here and how to get it.
-            override val receiver =
-                receiverType?.let { PlaceholderVariableEmbedding(ThisReceiverName, embedType(it), isReceiverUnique, isReceiverBorrowed) }
+            override val dispatchReceiver = dispatchReceiverType?.let {
+                PlaceholderVariableEmbedding(
+                    ThisReceiverName,
+                    embedType(it),
+                    isReceiverUnique,
+                    isReceiverBorrowed,
+                )
+            }
+            override val extensionReceiver = null
             override val params = symbol.valueParameterSymbols.map {
                 FirVariableEmbedding(it.embedName(), embedType(it.resolvedReturnType), it, it.isUnique(session), it.isBorrowed(session))
             }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -218,19 +218,29 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     override fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature {
         val retType = embedType(symbol.resolvedReturnTypeRef.coneType)
         val dispatchReceiverType = symbol.receiverType
-        val isReceiverUnique = symbol.receiverParameter?.isUnique(session) ?: false
-        val isReceiverBorrowed = symbol.receiverParameter?.isBorrowed(session) ?: false
+        val extensionReceiverType = symbol.extensionReceiverType
+        val isExtensionReceiverUnique = symbol.receiverParameter?.isUnique(session) ?: false
+        val isExtensionReceiverBorrowed = symbol.receiverParameter?.isBorrowed(session) ?: false
         return object : FunctionSignature {
             // TODO: figure out whether we want a symbol here and how to get it.
             override val dispatchReceiver = dispatchReceiverType?.let {
                 PlaceholderVariableEmbedding(
-                    ThisReceiverName,
+                    DispatchReceiverName,
                     embedType(it),
-                    isReceiverUnique,
-                    isReceiverBorrowed,
+                    isUnique = false,
+                    isBorrowed = false,
                 )
             }
-            override val extensionReceiver = null
+
+            override val extensionReceiver = extensionReceiverType?.let {
+                PlaceholderVariableEmbedding(
+                    ExtensionReceiverName,
+                    embedType(it),
+                    isExtensionReceiverUnique,
+                    isExtensionReceiverBorrowed,
+                )
+            }
+
             override val params = symbol.valueParameterSymbols.map {
                 FirVariableEmbedding(it.embedName(), embedType(it.resolvedReturnType), it, it.isUnique(session), it.isBorrowed(session))
             }
@@ -298,14 +308,17 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         }
     }
 
-    private val FirFunctionSymbol<*>.receiverType: ConeKotlinType?
-        get() {
-            val symbol = when (this) {
-                is FirPropertyAccessorSymbol -> propertySymbol
-                else -> this
-            }
-            return symbol.dispatchReceiverType ?: symbol.resolvedReceiverTypeRef?.coneType
+    private val FirFunctionSymbol<*>.containingPropertyOrSelf
+        get() = when (this) {
+            is FirPropertyAccessorSymbol -> propertySymbol
+            else -> this
         }
+
+    private val FirFunctionSymbol<*>.receiverType: ConeKotlinType?
+        get() = containingPropertyOrSelf.dispatchReceiverType
+
+    private val FirFunctionSymbol<*>.extensionReceiverType: ConeKotlinType?
+        get() = containingPropertyOrSelf.resolvedReceiverTypeRef?.coneType
 
     /**
      * Construct and register the field embedding for this property's backing field, if any exists.

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -23,7 +23,7 @@ sealed interface StdLibReceiverInterface {
 sealed interface PresentInterface : StdLibReceiverInterface {
     val interfaceName: String
     override fun match(function: NamedFunctionSignature): Boolean =
-        function.receiverType?.isInheritorOfCollectionTypeNamed(interfaceName) ?: false
+        function.dispatchReceiverType?.isInheritorOfCollectionTypeNamed(interfaceName) ?: false
 }
 
 data object CollectionInterface : PresentInterface {
@@ -82,7 +82,7 @@ sealed interface StdLibPostcondition : StdLibCondition {
 
 data object GetPrecondition : StdLibPrecondition {
     override fun getEmbeddings(function: NamedFunctionSignature): List<ExpEmbedding> {
-        val receiver = function.receiver!!
+        val receiver = function.dispatchReceiver!!
         val indexArg = function.formalArgs[1]
         return listOf(
             GeCmp(
@@ -104,7 +104,7 @@ data object GetPrecondition : StdLibPrecondition {
 
 data object SubListPrecondition : StdLibPrecondition {
     override fun getEmbeddings(function: NamedFunctionSignature): List<ExpEmbedding> {
-        val receiver = function.receiver!!
+        val receiver = function.dispatchReceiver!!
         val fromIndexArg = function.formalArgs[1]
         val toIndexArg = function.formalArgs[2]
         return listOf(
@@ -131,7 +131,7 @@ data object EmptyListPostcondition : StdLibPostcondition {
 
 data object IsEmptyPostcondition : StdLibPostcondition {
     override fun getEmbeddings(returnVariable: VariableEmbedding, function: NamedFunctionSignature): List<ExpEmbedding> {
-        val receiver = function.receiver!!
+        val receiver = function.dispatchReceiver!!
         return listOf(
             receiver.sameSize(),
             Implies(returnVariable, EqCmp(FieldAccess(receiver, ListSizeFieldEmbedding), IntLit(0))),
@@ -145,7 +145,7 @@ data object IsEmptyPostcondition : StdLibPostcondition {
 
 data object GetPostcondition : StdLibPostcondition {
     override fun getEmbeddings(returnVariable: VariableEmbedding, function: NamedFunctionSignature): List<ExpEmbedding> {
-        return listOf(function.receiver!!.sameSize())
+        return listOf(function.dispatchReceiver!!.sameSize())
     }
 
     override val stdLibInterface = ListInterface
@@ -157,7 +157,7 @@ data object SubListPostcondition : StdLibPostcondition {
         val fromIndexArg = function.formalArgs[1]
         val toIndexArg = function.formalArgs[2]
         return listOf(
-            function.receiver!!.sameSize(),
+            function.dispatchReceiver!!.sameSize(),
             EqCmp(FieldAccess(returnVariable, ListSizeFieldEmbedding), Sub(toIndexArg, fromIndexArg))
         )
     }
@@ -168,7 +168,7 @@ data object SubListPostcondition : StdLibPostcondition {
 
 data object AddPostcondition : StdLibPostcondition {
     override fun getEmbeddings(returnVariable: VariableEmbedding, function: NamedFunctionSignature): List<ExpEmbedding> {
-        return listOf(function.receiver!!.increasedSize(1))
+        return listOf(function.dispatchReceiver!!.increasedSize(1))
     }
 
     override val stdLibInterface = MutableListInterface

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.fir.expressions.impl.FirElseIfTrueCondition
 import org.jetbrains.kotlin.fir.references.FirThisReference
 import org.jetbrains.kotlin.fir.references.toResolvedSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.resolvedType
@@ -285,7 +286,12 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         thisReceiverExpression: FirThisReceiverExpression,
         data: StmtConversionContext,
     ): ExpEmbedding {
-        return data.resolveReceiver()
+        val isExtensionReceiver = when (thisReceiverExpression.calleeReference.boundSymbol) {
+            is FirClassSymbol<*> -> false
+            is FirFunctionSymbol<*> -> true
+            else -> error("Unsupported receiver expression type.")
+        }
+        return data.resolveReceiver(isExtensionReceiver)
             ?: throw IllegalArgumentException("Can't resolve the 'this' receiver since the function does not have one.")
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassPredicateBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassPredicateBuilder.kt
@@ -8,14 +8,14 @@ package org.jetbrains.kotlin.formver.embeddings
 import org.jetbrains.kotlin.formver.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.linearization.pureToViper
-import org.jetbrains.kotlin.formver.names.ThisReceiverName
+import org.jetbrains.kotlin.formver.names.DispatchReceiverName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Predicate
 import org.jetbrains.kotlin.utils.addIfNotNull
 
 internal class ClassPredicateBuilder private constructor(private val details: ClassEmbeddingDetails) {
-    private val subject = PlaceholderVariableEmbedding(ThisReceiverName, details.type)
+    private val subject = PlaceholderVariableEmbedding(DispatchReceiverName, details.type)
     private val body = mutableListOf<ExpEmbedding>()
 
     companion object {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
@@ -43,16 +43,22 @@ object BooleanPretypeBuilder : PretypeBuilder {
 
 class FunctionPretypeBuilder : PretypeBuilder {
     private val paramTypes = mutableListOf<TypeEmbedding>()
-    private var receiverType: TypeEmbedding? = null
+    private var extensionReceiverType: TypeEmbedding? = null
+    private var dispatchReceiverType: TypeEmbedding? = null
     private var returnType: TypeEmbedding? = null
 
     fun withParam(paramInit: TypeBuilder.() -> PretypeBuilder) {
         paramTypes.add(buildType { paramInit() })
     }
 
-    fun withReceiver(receiverInit: TypeBuilder.() -> PretypeBuilder) {
-        require(receiverType == null) { "Receiver already set" }
-        receiverType = buildType { receiverInit() }
+    fun withDispatchReceiver(receiverInit: TypeBuilder.() -> PretypeBuilder) {
+        require(dispatchReceiverType == null) { "Receiver already set" }
+        dispatchReceiverType = buildType { receiverInit() }
+    }
+
+    fun withExtensionReceiver(receiverInit: TypeBuilder.() -> PretypeBuilder) {
+        require(extensionReceiverType == null) { "Receiver already set" }
+        extensionReceiverType = buildType { receiverInit() }
     }
 
     fun withReturnType(returnTypeInit: TypeBuilder.() -> PretypeBuilder) {
@@ -62,7 +68,7 @@ class FunctionPretypeBuilder : PretypeBuilder {
 
     override fun complete(): TypeEmbedding {
         require(returnType != null) { "Return type not set" }
-        return FunctionTypeEmbedding(CallableSignatureData(receiverType, paramTypes, returnType!!))
+        return FunctionTypeEmbedding(CallableSignatureData(dispatchReceiverType, extensionReceiverType, paramTypes, returnType!!))
     }
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableSignature.kt
@@ -12,7 +12,8 @@ import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
  */
 
 interface CallableSignature {
-    val receiverType: TypeEmbedding?
+    val dispatchReceiverType: TypeEmbedding?
+    val extensionReceiverType: TypeEmbedding?
     val paramTypes: List<TypeEmbedding>
     val returnType: TypeEmbedding
     val returnsUnique: Boolean
@@ -25,17 +26,18 @@ interface CallableSignature {
      * `Foo.(Int) -> Int --> (Foo, Int) -> Int`
      */
     val formalArgTypes: List<TypeEmbedding>
-        get() = listOfNotNull(receiverType) + paramTypes
+        get() = listOfNotNull(dispatchReceiverType, extensionReceiverType) + paramTypes
 }
 
 /**
  * An instance of `CallableSignature` that is guaranteed to be `data`.
  */
 data class CallableSignatureData(
-    override val receiverType: TypeEmbedding?,
+    override val dispatchReceiverType: TypeEmbedding?,
+    override val extensionReceiverType: TypeEmbedding?,
     override val paramTypes: List<TypeEmbedding>,
     override val returnType: TypeEmbedding,
 ) : CallableSignature
 
 val CallableSignature.asData: CallableSignatureData
-    get() = CallableSignatureData(receiverType, paramTypes, returnType)
+    get() = CallableSignatureData(dispatchReceiverType, extensionReceiverType, paramTypes, returnType)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
@@ -49,8 +49,9 @@ abstract class PropertyAccessorFunctionSignature(
 ) : FullNamedFunctionSignature {
     override fun getPreconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
     override fun getPostconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
-    override val receiver: VariableEmbedding
+    override val dispatchReceiver: VariableEmbedding
         get() = PlaceholderVariableEmbedding(ThisReceiverName, buildType { nullableAny() })
+    override val extensionReceiver = null
     override val declarationSource: KtSourceElement? = symbol.source
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.nullableAny
 import org.jetbrains.kotlin.formver.linearization.pureToViper
 import org.jetbrains.kotlin.formver.names.SetterValueName
-import org.jetbrains.kotlin.formver.names.ThisReceiverName
+import org.jetbrains.kotlin.formver.names.DispatchReceiverName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 import org.jetbrains.kotlin.formver.viper.ast.UserMethod
@@ -50,7 +50,7 @@ abstract class PropertyAccessorFunctionSignature(
     override fun getPreconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
     override fun getPostconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
     override val dispatchReceiver: VariableEmbedding
-        get() = PlaceholderVariableEmbedding(ThisReceiverName, buildType { nullableAny() })
+        get() = PlaceholderVariableEmbedding(DispatchReceiverName, buildType { nullableAny() })
     override val extensionReceiver = null
     override val declarationSource: KtSourceElement? = symbol.source
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FunctionSignature.kt
@@ -10,17 +10,21 @@ import org.jetbrains.kotlin.formver.embeddings.expression.FirVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
 
 interface FunctionSignature : CallableSignature {
-    val receiver: VariableEmbedding?
+    val dispatchReceiver: VariableEmbedding?
+    val extensionReceiver: VariableEmbedding?
+
     val params: List<FirVariableEmbedding>
 
     val sourceName: String?
         get() = null
 
     val formalArgs: List<VariableEmbedding>
-        get() = listOfNotNull(receiver) + params
+        get() = listOfNotNull(dispatchReceiver, extensionReceiver) + params
 
-    override val receiverType: TypeEmbedding?
-        get() = receiver?.type
+    override val dispatchReceiverType: TypeEmbedding?
+        get() = dispatchReceiver?.type
+    override val extensionReceiverType: TypeEmbedding?
+        get() = extensionReceiver?.type
     override val paramTypes: List<TypeEmbedding>
         get() = params.map { it.type }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
@@ -22,14 +22,17 @@ class InlineNamedFunction(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext,
     ): ExpEmbedding {
-        val paramNames = listOfNotNull(receiver?.let { SpecialNames.THIS }) + symbol.valueParameterSymbols.map { it.name }
+        val paramNames = listOfNotNull(dispatchReceiver?.let { SpecialNames.THIS }) + symbol.valueParameterSymbols.map { it.name }
         return ctx.insertInlineFunctionCall(signature, paramNames, args, firBody, signature.sourceName)
     }
 
     override fun toViperMethodHeader(): Nothing? = null
 
-    override val receiverType: TypeEmbedding?
-        get() = signature.receiverType
+    override val dispatchReceiverType: TypeEmbedding?
+        get() = signature.dispatchReceiverType
+
+    override val extensionReceiverType: TypeEmbedding?
+        get() = signature.extensionReceiverType
 
     override val paramTypes: List<TypeEmbedding>
         get() = signature.paramTypes

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.conversion.insertInlineFunctionCall
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.formver.names.ExtraSpecialNames
 
 class InlineNamedFunction(
     val signature: FullNamedFunctionSignature,
@@ -22,7 +22,13 @@ class InlineNamedFunction(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext,
     ): ExpEmbedding {
-        val paramNames = listOfNotNull(dispatchReceiver?.let { SpecialNames.THIS }) + symbol.valueParameterSymbols.map { it.name }
+        val paramNames = buildList {
+            if (dispatchReceiverType != null)
+                add(ExtraSpecialNames.D_THIS)
+            if (extensionReceiverType != null)
+                add(ExtraSpecialNames.E_THIS)
+            addAll(symbol.valueParameterSymbols.map { it.name })
+        }
         return ctx.insertInlineFunctionCall(signature, paramNames, args, firBody, signature.sourceName)
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
@@ -22,8 +22,11 @@ class NonInlineNamedFunction(val signature: FullNamedFunctionSignature) : RichCa
     override fun toViperMethodHeader(): Method =
         signature.toViperMethod(null, PlaceholderVariableEmbedding(PlaceholderReturnVariableName, signature.returnType))
 
-    override val receiverType: TypeEmbedding?
-        get() = signature.receiverType
+    override val dispatchReceiverType: TypeEmbedding?
+        get() = signature.dispatchReceiverType
+
+    override val extensionReceiverType: TypeEmbedding?
+        get() = signature.extensionReceiverType
 
     override val paramTypes: List<TypeEmbedding>
         get() = signature.paramTypes

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -47,11 +47,12 @@ object KotlinContractFunction : SpecialKotlinFunction {
         packageScope(packageName)
         ClassKotlinName(listOf("ContractBuilder"))
     }
-    override val receiverType: TypeEmbedding? = null
+    override val dispatchReceiverType = null
+    override val extensionReceiverType = null
     override val paramTypes: List<TypeEmbedding> =
         listOf(buildType {
             function {
-                withReceiver {
+                withDispatchReceiver {
                     klass {
                         withName(contractBuilderTypeName)
                     }
@@ -71,7 +72,8 @@ abstract class KotlinIntSpecialFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin")
     override val className: String? = "Int"
 
-    override val receiverType: TypeEmbedding = buildType { int() }
+    override val dispatchReceiverType: TypeEmbedding = buildType { int() }
+    override val extensionReceiverType = null
     override val paramTypes: List<TypeEmbedding> = listOf(buildType { int() })
     override val returnType: TypeEmbedding = buildType { int() }
 }
@@ -116,7 +118,8 @@ abstract class KotlinBooleanSpecialFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin")
     override val className: String? = "Boolean"
 
-    override val receiverType: TypeEmbedding = buildType { boolean() }
+    override val dispatchReceiverType: TypeEmbedding = buildType { boolean() }
+    override val extensionReceiverType = null
     override val paramTypes: List<TypeEmbedding> = emptyList()
     override val returnType: TypeEmbedding = buildType { boolean() }
 }
@@ -141,7 +144,8 @@ object SpecialVerifyFunction : SpecialKotlinFunction {
         return Assert(args[0])
     }
 
-    override val receiverType: TypeEmbedding? = null
+    override val dispatchReceiverType = null
+    override val extensionReceiverType = null
     override val paramTypes: List<TypeEmbedding> = listOf(buildType { boolean() })
     override val returnType: TypeEmbedding = buildType { unit() }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.formver.embeddings.callables.asData
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
-import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.formver.names.ExtraSpecialNames
 
 class LambdaExp(
     val signature: FunctionSignature,
@@ -37,7 +37,8 @@ class LambdaExp(
     ): ExpEmbedding {
         val inlineBody = function.body ?: throw IllegalArgumentException("Lambda $function has a null body.")
         val nonReceiverParamNames = function.valueParameters.map { it.name }
-        val receiverParamNames = if (function.receiverParameter != null) listOf(SpecialNames.THIS) else emptyList()
+        //TODO: can lambdas have dispatch receiver?
+        val receiverParamNames = if (function.receiverParameter != null) listOf(ExtraSpecialNames.E_THIS) else emptyList()
         return ctx.insertInlineFunctionCall(
             signature,
             receiverParamNames + nonReceiverParamNames,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ExtraSpecialNames.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ExtraSpecialNames.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.names
+
+import org.jetbrains.kotlin.name.Name
+
+object ExtraSpecialNames {
+    @JvmField
+    val E_THIS = Name.special("<E_THIS>")
+
+    @JvmField
+    val D_THIS = Name.special("<D_THIS>")
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/FreshNames.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/FreshNames.kt
@@ -38,9 +38,14 @@ data class ReturnVariableName(val n: Int) : MangledName {
         get() = n.toString()
 }
 
-data object ThisReceiverName : MangledName {
+data object DispatchReceiverName : MangledName {
     override val mangledBaseName: String
-        get() = "this"
+        get() = "this\$dispatch"
+}
+
+data object ExtensionReceiverName : MangledName {
+    override val mangledBaseName: String
+        get() = "this\$extension"
 }
 
 data object SetterValueName : MangledName {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.fir.diag.txt
@@ -1,0 +1,51 @@
+/multiple_receivers.kt:(247,257): info: Generated Viper text for applyDelta:
+field bf$delta: Ref
+
+method f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension(this: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var anon$0: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(this), df$rt$T$c$ClassWithExtension())
+  inhale acc(p$c$ClassWithExtension$shared(this), wildcard)
+  unfold acc(p$c$ClassWithExtension$shared(this), wildcard)
+  anon$0 := this.bf$delta
+  ret$0 := sp$plusInts(this, anon$0)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/multiple_receivers.kt:(379,402): info: Generated Viper text for checkClassWithExtension:
+field bf$delta: Ref
+
+method con$c$ClassWithExtension$T$Int(p$delta: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$ClassWithExtension())
+  ensures acc(p$c$ClassWithExtension$shared(ret), wildcard)
+  ensures acc(p$c$ClassWithExtension$unique(ret), write)
+  ensures (unfolding acc(p$c$ClassWithExtension$shared(ret), wildcard) in
+      df$rt$intFromRef(ret.bf$delta) == df$rt$intFromRef(p$delta))
+
+
+method f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension(this: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+
+
+method f$checkClassWithExtension$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var ret$1: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  var ret$2: Ref
+  ret$0 := df$rt$unitValue()
+  anon$0 := con$c$ClassWithExtension$T$Int(df$rt$intToRef(42))
+  ret$2 := f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension(anon$0)
+  goto lbl$ret$2
+  label lbl$ret$2
+  anon$1 := ret$2
+  ret$1 := anon$1
+  goto lbl$ret$1
+  label lbl$ret$1
+  label lbl$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.kt
@@ -1,0 +1,25 @@
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+
+class ClassWithExtension(val delta: Int) {
+    fun Int.<!VIPER_TEXT!>applyDelta<!>() = this + delta
+    fun <!VIPER_TEXT!>returnDelta<!>() = delta
+}
+
+fun ClassWithExtension.<!VIPER_TEXT!>extensionReturnDelta<!>() = delta
+
+@NeverConvert
+public inline fun <T, R> T.copiedRun(block: T.() -> R): R = block()
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>checkClassWithExtension<!>() {
+    ClassWithExtension(42).copiedRun {
+        42.applyDelta()
+        returnDelta()
+        extensionReturnDelta()
+    }
+}
+
+

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.kt
@@ -1,10 +1,16 @@
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.verify
 import org.jetbrains.kotlin.formver.plugin.NeverConvert
 
 class ClassWithExtension(val delta: Int) {
-    fun Int.<!VIPER_TEXT!>applyDelta<!>() = this + delta
+    @AlwaysVerify
+    fun Int.<!VIPER_TEXT!>applyDelta<!>() {
+        val withoutLabels = this + delta
+        val withLabels = this@ClassWithExtension.delta + this@applyDelta
+        verify(withoutLabels == withLabels)
+    }
     fun <!VIPER_TEXT!>returnDelta<!>() = delta
 }
 

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -158,6 +158,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("multiple_receivers.kt")
+    public void testMultiple_receivers() {
+      runTest("plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.kt");
+    }
+
+    @Test
     @TestMetadata("nullability.kt")
     public void testNullability() {
       runTest("plugins/formal-verification/testData/diagnostics/good_contracts/nullability.kt");


### PR DESCRIPTION
- This PR allows to correctly convert methods like
```kotlin
class Class {
  fun OtherClass.extensionMember() { }
}
```
(into function with two arguments).
- It also supports lookup of `this` which chooses dispatch/extension receiver, but does not take into consideration `this` parameters from outer scopes.
- It does not do the same thing for properties although it should be done eventually