### PR TITLE
Embed type via builder

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/PretypeBuilder.kt
@@ -44,6 +44,7 @@ class FunctionPretypeBuilder : PretypeBuilder {
     private val paramTypes = mutableListOf<TypeEmbedding>()
     private var receiverType: TypeEmbedding? = null
     private var returnType: TypeEmbedding? = null
+    var returnsUnique: Boolean = false
 
     fun withParam(paramInit: TypeBuilder.() -> PretypeBuilder) {
         paramTypes.add(buildType { paramInit() })
@@ -61,7 +62,7 @@ class FunctionPretypeBuilder : PretypeBuilder {
 
     override fun complete(): TypeEmbedding {
         require(returnType != null) { "Return type not set" }
-        return FunctionTypeEmbedding(receiverType, paramTypes, returnType!!, returnsUnique = false)
+        return FunctionTypeEmbedding(receiverType, paramTypes, returnType!!, returnsUnique)
     }
 }
 
@@ -77,4 +78,9 @@ class ClassPretypeBuilder : PretypeBuilder {
         require(className != null) { "Class name not set" }
         return ClassTypeEmbedding(className!!)
     }
+}
+
+// TODO: ensure we can build the types with the builders, without hacks like this.
+class ExistingPretypeBuilder(val embedding: TypeEmbedding) : PretypeBuilder {
+    override fun complete(): TypeEmbedding = embedding
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeBuilder.kt
@@ -29,6 +29,7 @@ class TypeBuilder {
     fun boolean() = BooleanPretypeBuilder
     fun function(init: FunctionPretypeBuilder.() -> Unit) = FunctionPretypeBuilder().also { it.init() }
     fun klass(init: ClassPretypeBuilder.() -> Unit) = ClassPretypeBuilder().also { it.init() }
+    fun existing(embedding: TypeEmbedding) = ExistingPretypeBuilder(embedding)
 }
 
 fun TypeBuilder.nullableAny(): AnyPretypeBuilder {


### PR DESCRIPTION
We currently build types by hand in `embedType`.  For consistency, and to simplify some of the code, let's use the builder.