### PR TITLE
Nullable type embedding name fix

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -85,8 +85,6 @@ data class NullableTypeEmbedding(val elementType: TypeEmbedding) : TypeEmbedding
     override val name = object : MangledName {
         override val mangledScope: String?
             get() = elementType.name.mangledScope
-        override val mangledType: String?
-            get() = elementType.name.mangledType
         override val mangledBaseName: String
             get() = elementType.name.mangledBaseName.let { "N\$$it" }
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/TypeEmbedding.kt
@@ -84,9 +84,11 @@ data class NullableTypeEmbedding(val elementType: TypeEmbedding) : TypeEmbedding
     override val runtimeType = RuntimeTypeDomain.nullable(elementType.runtimeType)
     override val name = object : MangledName {
         override val mangledScope: String?
-            get() = elementType.name.mangledScope?.let { "N$it" }
+            get() = elementType.name.mangledScope
+        override val mangledType: String?
+            get() = elementType.name.mangledType
         override val mangledBaseName: String
-            get() = elementType.name.mangledBaseName
+            get() = elementType.name.mangledBaseName.let { "N\$$it" }
     }
 
     override fun accessInvariants(): List<TypeInvariantEmbedding> = elementType.accessInvariants().map { IfNonNullInvariant(it) }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
@@ -12,7 +12,7 @@ method f$compoundConditionalEffect$TF$T$Boolean(p$b: Ref)
 /cond_effects.kt:(190,220): warning: Cannot verify that if the function returns then (b && false).
 
 /cond_effects.kt:(271,287): info: Generated Viper text for mayReturnNonNull:
-method f$mayReturnNonNull$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$mayReturnNonNull$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 == df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
@@ -26,7 +26,7 @@ method f$mayReturnNonNull$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(328,360): warning: Cannot verify that if a null value is returned then x is Int.
 
 /cond_effects.kt:(424,437): info: Generated Viper text for mayReturnNull:
-method f$mayReturnNull$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$mayReturnNull$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
@@ -40,7 +40,7 @@ method f$mayReturnNull$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(478,513): warning: Cannot verify that if a non-null value is returned then x is Int.
 
 /cond_effects.kt:(723,741): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$T$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
+method f$isNullOrEmptyWrong$TF$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==> p$seq != df$rt$nullValue()
@@ -69,7 +69,7 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /cond_effects.kt:(925,942): info: Generated Viper text for recursiveContract:
 field bf$length: Ref
 
-method f$recursiveContract$TF$T$Int$T$N$Any(p$n: Ref, p$x: Ref)
+method f$recursiveContract$TF$T$Int$N$Any(p$n: Ref, p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
@@ -80,7 +80,7 @@ method f$recursiveContract$TF$T$Int$T$N$Any(p$n: Ref, p$x: Ref)
   if (df$rt$intFromRef(p$n) == 0) {
     ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
   } else {
-    ret$0 := f$recursiveContract$TF$T$Int$T$N$Any(sp$minusInts(p$n, df$rt$intToRef(1)),
+    ret$0 := f$recursiveContract$TF$T$Int$N$Any(sp$minusInts(p$n, df$rt$intToRef(1)),
       p$x)}
   goto lbl$ret$0
   label lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
@@ -12,7 +12,7 @@ method f$compoundConditionalEffect$TF$T$Boolean(p$b: Ref)
 /cond_effects.kt:(190,220): warning: Cannot verify that if the function returns then (b && false).
 
 /cond_effects.kt:(271,287): info: Generated Viper text for mayReturnNonNull:
-method f$mayReturnNonNull$TF$Any(p$x: Ref) returns (ret$0: Ref)
+method f$mayReturnNonNull$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 == df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
@@ -26,7 +26,7 @@ method f$mayReturnNonNull$TF$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(328,360): warning: Cannot verify that if a null value is returned then x is Int.
 
 /cond_effects.kt:(424,437): info: Generated Viper text for mayReturnNull:
-method f$mayReturnNull$TF$Any(p$x: Ref) returns (ret$0: Ref)
+method f$mayReturnNull$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
@@ -40,7 +40,7 @@ method f$mayReturnNull$TF$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(478,513): warning: Cannot verify that if a non-null value is returned then x is Int.
 
 /cond_effects.kt:(723,741): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$c$pkg$kotlin$CharSequence(p$seq: Ref)
+method f$isNullOrEmptyWrong$TF$T$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==> p$seq != df$rt$nullValue()
@@ -69,7 +69,7 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /cond_effects.kt:(925,942): info: Generated Viper text for recursiveContract:
 field bf$length: Ref
 
-method f$recursiveContract$TF$T$Int$Any(p$n: Ref, p$x: Ref)
+method f$recursiveContract$TF$T$Int$T$N$Any(p$n: Ref, p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
@@ -80,7 +80,7 @@ method f$recursiveContract$TF$T$Int$Any(p$n: Ref, p$x: Ref)
   if (df$rt$intFromRef(p$n) == 0) {
     ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
   } else {
-    ret$0 := f$recursiveContract$TF$T$Int$Any(sp$minusInts(p$n, df$rt$intToRef(1)),
+    ret$0 := f$recursiveContract$TF$T$Int$T$N$Any(sp$minusInts(p$n, df$rt$intToRef(1)),
       p$x)}
   goto lbl$ret$0
   label lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -1,7 +1,7 @@
 /is_type_contract.kt:(151,172): info: Generated Viper text for unverifiableTypeCheck:
 field bf$length: Ref
 
-method f$unverifiableTypeCheck$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$unverifiableTypeCheck$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
 {
@@ -17,7 +17,7 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /is_type_contract.kt:(216,245): warning: Cannot verify that if the function returns then x is Unit.
 
 /is_type_contract.kt:(319,341): info: Generated Viper text for nullableNotNonNullable:
-method f$nullableNotNonNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$nullableNotNonNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
 {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -1,7 +1,7 @@
 /is_type_contract.kt:(151,172): info: Generated Viper text for unverifiableTypeCheck:
 field bf$length: Ref
 
-method f$unverifiableTypeCheck$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$unverifiableTypeCheck$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
 {
@@ -17,7 +17,7 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /is_type_contract.kt:(216,245): warning: Cannot verify that if the function returns then x is Unit.
 
 /is_type_contract.kt:(319,341): info: Generated Viper text for nullableNotNonNullable:
-method f$nullableNotNonNullable$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$nullableNotNonNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
 {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
@@ -1,6 +1,5 @@
 /returns_null.kt:(121,146): info: Generated Viper text for returns_null_unverifiable:
-method f$returns_null_unverifiable$TF$T$N$Int(p$x: Ref)
-  returns (ret$0: Ref)
+method f$returns_null_unverifiable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures true ==> false
 {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,6 @@
 /returns_null.kt:(121,146): info: Generated Viper text for returns_null_unverifiable:
-method f$returns_null_unverifiable$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$returns_null_unverifiable$TF$T$N$Int(p$x: Ref)
+  returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures true ==> false
 {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -24,7 +24,7 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$receiverNotNullProved$TF$c$X(p$x: Ref) returns (ret$0: Ref)
+method f$receiverNotNullProved$TF$T$N$c$X(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> p$x != df$rt$nullValue()
 {
@@ -48,7 +48,8 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableGet$TF$c$NullableX(p$x: Ref) returns (ret$0: Ref)
+method f$cascadeNullableGet$TF$T$N$c$NullableX(p$x: Ref)
+  returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
@@ -76,7 +77,7 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableSmartcastGet$TF$c$NullableX(p$x: Ref)
+method f$cascadeNullableSmartcastGet$TF$T$N$c$NullableX(p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -24,7 +24,7 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$receiverNotNullProved$TF$T$N$c$X(p$x: Ref) returns (ret$0: Ref)
+method f$receiverNotNullProved$TF$N$c$X(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> p$x != df$rt$nullValue()
 {
@@ -48,8 +48,7 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableGet$TF$T$N$c$NullableX(p$x: Ref)
-  returns (ret$0: Ref)
+method f$cascadeNullableGet$TF$N$c$NullableX(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
@@ -77,7 +76,7 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableSmartcastGet$TF$T$N$c$NullableX(p$x: Ref)
+method f$cascadeNullableSmartcastGet$TF$N$c$NullableX(p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,7 +1,7 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
 field bf$length: Ref
 
-method f$isString$TF$Any(p$x: Ref) returns (ret$0: Ref)
+method f$isString$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$pkg$kotlin$String())

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,7 +1,7 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
 field bf$length: Ref
 
-method f$isString$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$isString$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$pkg$kotlin$String())

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -191,7 +191,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
 /list.kt:(670,683): info: Generated Viper text for nullable_list:
 field sp$size: Ref
 
-method f$nullable_list$TF$T$N$c$pkg$kotlin_collections$List(p$l: Ref)
+method f$nullable_list$TF$N$c$pkg$kotlin_collections$List(p$l: Ref)
   returns (ret$0: Ref)
   requires p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   requires p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -191,7 +191,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
 /list.kt:(670,683): info: Generated Viper text for nullable_list:
 field sp$size: Ref
 
-method f$nullable_list$TF$c$pkg$kotlin_collections$List(p$l: Ref)
+method f$nullable_list$TF$T$N$c$pkg$kotlin_collections$List(p$l: Ref)
   returns (ret$0: Ref)
   requires p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   requires p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -88,7 +88,7 @@ method f$call_fun_with_contracts$TF$T$Boolean(p$b: Ref)
 /returns_booleans.kt:(1467,1480): info: Generated Viper text for isNullOrEmpty:
 field sp$size: Ref
 
-method f$isNullOrEmpty$TF$c$pkg$kotlin_collections$Collection(p$collection: Ref)
+method f$isNullOrEmpty$TF$T$N$c$pkg$kotlin_collections$Collection(p$collection: Ref)
   returns (ret$0: Ref)
   requires p$collection != df$rt$nullValue() ==>
     acc(p$collection.sp$size, write)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -88,7 +88,7 @@ method f$call_fun_with_contracts$TF$T$Boolean(p$b: Ref)
 /returns_booleans.kt:(1467,1480): info: Generated Viper text for isNullOrEmpty:
 field sp$size: Ref
 
-method f$isNullOrEmpty$TF$T$N$c$pkg$kotlin_collections$Collection(p$collection: Ref)
+method f$isNullOrEmpty$TF$N$c$pkg$kotlin_collections$Collection(p$collection: Ref)
   returns (ret$0: Ref)
   requires p$collection != df$rt$nullValue() ==>
     acc(p$collection.sp$size, write)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_null.kt:(121,140): info: Generated Viper text for simple_returns_null:
-method f$simple_returns_null$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$simple_returns_null$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> false
@@ -11,7 +11,7 @@ method f$simple_returns_null$TF$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /returns_null.kt:(300,320): info: Generated Viper text for returns_null_implies:
-method f$returns_null_implies$TF$Boolean(p$x: Ref) returns (ret$0: Ref)
+method f$returns_null_implies$TF$T$N$Boolean(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$boolType()))
   ensures ret$0 == df$rt$nullValue() ==> p$x == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
@@ -23,7 +23,8 @@ method f$returns_null_implies$TF$Boolean(p$x: Ref) returns (ret$0: Ref)
 }
 
 /returns_null.kt:(511,531): info: Generated Viper text for returns_null_with_if:
-method f$returns_null_with_if$TF$Int$Int$Int(p$x: Ref, p$y: Ref, p$z: Ref)
+method f$returns_null_with_if$TF$T$N$Int$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref,
+  p$z: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==>

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_null.kt:(121,140): info: Generated Viper text for simple_returns_null:
-method f$simple_returns_null$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$simple_returns_null$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> false
@@ -11,7 +11,7 @@ method f$simple_returns_null$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /returns_null.kt:(300,320): info: Generated Viper text for returns_null_implies:
-method f$returns_null_implies$TF$T$N$Boolean(p$x: Ref) returns (ret$0: Ref)
+method f$returns_null_implies$TF$N$Boolean(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$boolType()))
   ensures ret$0 == df$rt$nullValue() ==> p$x == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
@@ -23,8 +23,7 @@ method f$returns_null_implies$TF$T$N$Boolean(p$x: Ref) returns (ret$0: Ref)
 }
 
 /returns_null.kt:(511,531): info: Generated Viper text for returns_null_with_if:
-method f$returns_null_with_if$TF$T$N$Int$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref,
-  p$z: Ref)
+method f$returns_null_with_if$TF$N$Int$N$Int$N$Int(p$x: Ref, p$y: Ref, p$z: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==>

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.fir.diag.txt
@@ -1,5 +1,5 @@
 /unit_return_type.kt:(171,176): info: Generated Viper text for idFun:
-method f$idFun$TF$Any(p$t: Ref) returns (ret$0: Ref)
+method f$idFun$TF$T$N$Any(p$t: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
@@ -19,7 +19,7 @@ method f$directReturns$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
   } else {
     var anon$0: Ref
     var anon$1: Ref
-    anon$1 := f$idFun$TF$Any(p$b)
+    anon$1 := f$idFun$TF$T$N$Any(p$b)
     anon$0 := anon$1
     inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
     if (df$rt$boolFromRef(anon$0)) {
@@ -31,12 +31,12 @@ method f$directReturns$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$Any(p$t: Ref) returns (ret: Ref)
+method f$idFun$TF$T$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /unit_return_type.kt:(374,387): info: Generated Viper text for useInlineUnit:
-method f$idFun$TF$Any(p$t: Ref) returns (ret: Ref)
+method f$idFun$TF$T$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -58,7 +58,7 @@ method f$useInlineUnit$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
     var anon$2: Ref
     var anon$3: Ref
     l4$tmp := df$rt$intToRef(42)
-    anon$3 := f$idFun$TF$Any(l4$tmp)
+    anon$3 := f$idFun$TF$T$N$Any(l4$tmp)
     anon$2 := anon$3
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.fir.diag.txt
@@ -1,5 +1,5 @@
 /unit_return_type.kt:(171,176): info: Generated Viper text for idFun:
-method f$idFun$TF$T$N$Any(p$t: Ref) returns (ret$0: Ref)
+method f$idFun$TF$N$Any(p$t: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
@@ -19,7 +19,7 @@ method f$directReturns$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
   } else {
     var anon$0: Ref
     var anon$1: Ref
-    anon$1 := f$idFun$TF$T$N$Any(p$b)
+    anon$1 := f$idFun$TF$N$Any(p$b)
     anon$0 := anon$1
     inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
     if (df$rt$boolFromRef(anon$0)) {
@@ -31,12 +31,12 @@ method f$directReturns$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$T$N$Any(p$t: Ref) returns (ret: Ref)
+method f$idFun$TF$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /unit_return_type.kt:(374,387): info: Generated Viper text for useInlineUnit:
-method f$idFun$TF$T$N$Any(p$t: Ref) returns (ret: Ref)
+method f$idFun$TF$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -58,7 +58,7 @@ method f$useInlineUnit$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
     var anon$2: Ref
     var anon$3: Ref
     l4$tmp := df$rt$intToRef(42)
-    anon$3 := f$idFun$TF$T$N$Any(l4$tmp)
+    anon$3 := f$idFun$TF$N$Any(l4$tmp)
     anon$2 := anon$3
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.fir.diag.txt
@@ -1,5 +1,5 @@
 /viper_casts_while_inlining.kt:(250,255): info: Generated Viper text for idFun:
-method f$idFun$TF$Any(p$arg: Ref) returns (ret$0: Ref)
+method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
@@ -43,7 +43,7 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   l0$obj := con$c$ClassWithMember$T$Int(df$rt$intToRef(42))
   inhale df$rt$isSubtype(df$rt$typeOf(l0$obj), df$rt$nullable(df$rt$anyType()))
   anon$0 := l0$obj
-  anon$7 := f$idFun$TF$Any(anon$0)
+  anon$7 := f$idFun$TF$T$N$Any(anon$0)
   anon$1 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$ClassWithMember())
   inhale acc(p$c$ClassWithMember$shared(anon$1), wildcard)
@@ -80,14 +80,14 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /viper_casts_while_inlining.kt:(895,919): info: Generated Viper text for checkGenericMemberAccess:
 field bf$wrapped: Ref
 
-method con$c$Box$Any(p$wrapped: Ref) returns (ret: Ref)
+method con$c$Box$T$N$Any(p$wrapped: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -120,7 +120,7 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   inhale acc(p$c$Box$shared(p$box), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$box
-  anon$4 := f$idFun$TF$Any(anon$0)
+  anon$4 := f$idFun$TF$T$N$Any(anon$0)
   anon$1 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$Box())
   inhale acc(p$c$Box$shared(anon$1), wildcard)
@@ -133,7 +133,7 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   label lbl$ret$1
   unfold acc(p$c$Box$shared(p$box), wildcard)
   anon$8 := p$box.bf$wrapped
-  anon$7 := con$c$Box$Any(anon$8)
+  anon$7 := con$c$Box$T$N$Any(anon$8)
   anon$2 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$T$c$Box())
@@ -157,7 +157,7 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -253,14 +253,14 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   anon$1 := anon$0
   unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
   anon$9 := anon$1.bf$i
-  anon$8 := f$idFun$TF$Any(anon$9)
+  anon$8 := f$idFun$TF$T$N$Any(anon$9)
   anon$7 := anon$8
   inhale df$rt$isSubtype(df$rt$typeOf(anon$7), df$rt$intType())
   inhale acc(anon$1.bf$b, write)
   anon$12 := anon$1.bf$b
   exhale acc(anon$1.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$12), df$rt$boolType())
-  anon$11 := f$idFun$TF$Any(anon$12)
+  anon$11 := f$idFun$TF$T$N$Any(anon$12)
   anon$10 := anon$11
   inhale df$rt$isSubtype(df$rt$typeOf(anon$10), df$rt$boolType())
   unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
@@ -278,20 +278,20 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   inhale acc(p$c$ClassWithVar$shared(anon$4), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
   anon$2 := p$m
-  anon$16 := f$idFun$TF$Any(anon$2)
+  anon$16 := f$idFun$TF$T$N$Any(anon$2)
   anon$3 := anon$16
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$T$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(anon$3), wildcard)
   unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
   anon$19 := anon$3.bf$i
-  anon$18 := f$idFun$TF$Any(anon$19)
+  anon$18 := f$idFun$TF$T$N$Any(anon$19)
   anon$17 := anon$18
   inhale df$rt$isSubtype(df$rt$typeOf(anon$17), df$rt$intType())
   inhale acc(anon$3.bf$b, write)
   anon$22 := anon$3.bf$b
   exhale acc(anon$3.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$22), df$rt$boolType())
-  anon$21 := f$idFun$TF$Any(anon$22)
+  anon$21 := f$idFun$TF$T$N$Any(anon$22)
   anon$20 := anon$21
   inhale df$rt$isSubtype(df$rt$typeOf(anon$20), df$rt$boolType())
   unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
@@ -311,7 +311,7 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.fir.diag.txt
@@ -1,5 +1,5 @@
 /viper_casts_while_inlining.kt:(250,255): info: Generated Viper text for idFun:
-method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret$0: Ref)
+method f$idFun$TF$N$Any(p$arg: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
@@ -43,7 +43,7 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   l0$obj := con$c$ClassWithMember$T$Int(df$rt$intToRef(42))
   inhale df$rt$isSubtype(df$rt$typeOf(l0$obj), df$rt$nullable(df$rt$anyType()))
   anon$0 := l0$obj
-  anon$7 := f$idFun$TF$T$N$Any(anon$0)
+  anon$7 := f$idFun$TF$N$Any(anon$0)
   anon$1 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$ClassWithMember())
   inhale acc(p$c$ClassWithMember$shared(anon$1), wildcard)
@@ -80,14 +80,14 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$N$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /viper_casts_while_inlining.kt:(895,919): info: Generated Viper text for checkGenericMemberAccess:
 field bf$wrapped: Ref
 
-method con$c$Box$T$N$Any(p$wrapped: Ref) returns (ret: Ref)
+method con$c$Box$N$Any(p$wrapped: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -120,7 +120,7 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   inhale acc(p$c$Box$shared(p$box), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$box
-  anon$4 := f$idFun$TF$T$N$Any(anon$0)
+  anon$4 := f$idFun$TF$N$Any(anon$0)
   anon$1 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$Box())
   inhale acc(p$c$Box$shared(anon$1), wildcard)
@@ -133,7 +133,7 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   label lbl$ret$1
   unfold acc(p$c$Box$shared(p$box), wildcard)
   anon$8 := p$box.bf$wrapped
-  anon$7 := con$c$Box$T$N$Any(anon$8)
+  anon$7 := con$c$Box$N$Any(anon$8)
   anon$2 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$T$c$Box())
@@ -157,7 +157,7 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$N$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -253,14 +253,14 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   anon$1 := anon$0
   unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
   anon$9 := anon$1.bf$i
-  anon$8 := f$idFun$TF$T$N$Any(anon$9)
+  anon$8 := f$idFun$TF$N$Any(anon$9)
   anon$7 := anon$8
   inhale df$rt$isSubtype(df$rt$typeOf(anon$7), df$rt$intType())
   inhale acc(anon$1.bf$b, write)
   anon$12 := anon$1.bf$b
   exhale acc(anon$1.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$12), df$rt$boolType())
-  anon$11 := f$idFun$TF$T$N$Any(anon$12)
+  anon$11 := f$idFun$TF$N$Any(anon$12)
   anon$10 := anon$11
   inhale df$rt$isSubtype(df$rt$typeOf(anon$10), df$rt$boolType())
   unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
@@ -278,20 +278,20 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   inhale acc(p$c$ClassWithVar$shared(anon$4), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
   anon$2 := p$m
-  anon$16 := f$idFun$TF$T$N$Any(anon$2)
+  anon$16 := f$idFun$TF$N$Any(anon$2)
   anon$3 := anon$16
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$T$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(anon$3), wildcard)
   unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
   anon$19 := anon$3.bf$i
-  anon$18 := f$idFun$TF$T$N$Any(anon$19)
+  anon$18 := f$idFun$TF$N$Any(anon$19)
   anon$17 := anon$18
   inhale df$rt$isSubtype(df$rt$typeOf(anon$17), df$rt$intType())
   inhale acc(anon$3.bf$b, write)
   anon$22 := anon$3.bf$b
   exhale acc(anon$3.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$22), df$rt$boolType())
-  anon$21 := f$idFun$TF$T$N$Any(anon$22)
+  anon$21 := f$idFun$TF$N$Any(anon$22)
   anon$20 := anon$21
   inhale df$rt$isSubtype(df$rt$typeOf(anon$20), df$rt$boolType())
   unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
@@ -311,7 +311,7 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$T$N$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$N$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
@@ -162,7 +162,7 @@ predicate p$c$A$unique(this$dispatch: Ref) {
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-method f$accessNullable$TF$c$A(p$x: Ref) returns (ret$0: Ref)
+method f$accessNullable$TF$T$N$c$A(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
@@ -162,7 +162,7 @@ predicate p$c$A$unique(this$dispatch: Ref) {
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-method f$accessNullable$TF$T$N$c$A(p$x: Ref) returns (ret$0: Ref)
+method f$accessNullable$TF$N$c$A(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
@@ -25,7 +25,7 @@ method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
 /primary_constructors.kt:(178,193): info: Generated Viper text for createRecursive:
 field bf$a: Ref
 
-method con$c$Recursive$T$N$c$Recursive(p$a: Ref) returns (ret: Ref)
+method con$c$Recursive$N$c$Recursive(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)
@@ -37,7 +37,7 @@ method f$createRecursive$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret$0), wildcard)
 {
-  ret$0 := con$c$Recursive$T$N$c$Recursive(df$rt$nullValue())
+  ret$0 := con$c$Recursive$N$c$Recursive(df$rt$nullValue())
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
@@ -25,7 +25,7 @@ method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
 /primary_constructors.kt:(178,193): info: Generated Viper text for createRecursive:
 field bf$a: Ref
 
-method con$c$Recursive$c$Recursive(p$a: Ref) returns (ret: Ref)
+method con$c$Recursive$T$N$c$Recursive(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)
@@ -37,7 +37,7 @@ method f$createRecursive$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret$0), wildcard)
 {
-  ret$0 := con$c$Recursive$c$Recursive(df$rt$nullValue())
+  ret$0 := con$c$Recursive$T$N$c$Recursive(df$rt$nullValue())
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/subtyping.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/subtyping.fir.diag.txt
@@ -1,5 +1,5 @@
 /subtyping.kt:(80,89): info: Generated Viper text for smartCast:
-method f$smartCast$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$smartCast$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -38,10 +38,10 @@ method f$functionParameterSubtyping$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  anon$0 := f$nullableParameter$TF$Boolean(df$rt$boolToRef(false))
+  anon$0 := f$nullableParameter$TF$T$N$Boolean(df$rt$boolToRef(false))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$nullableParameter$TF$Boolean(p$b: Ref) returns (ret: Ref)
+method f$nullableParameter$TF$T$N$Boolean(p$b: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/subtyping.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/subtyping.fir.diag.txt
@@ -1,5 +1,5 @@
 /subtyping.kt:(80,89): info: Generated Viper text for smartCast:
-method f$smartCast$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$smartCast$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -38,10 +38,10 @@ method f$functionParameterSubtyping$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  anon$0 := f$nullableParameter$TF$T$N$Boolean(df$rt$boolToRef(false))
+  anon$0 := f$nullableParameter$TF$N$Boolean(df$rt$boolToRef(false))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$nullableParameter$TF$T$N$Boolean(p$b: Ref) returns (ret: Ref)
+method f$nullableParameter$TF$N$Boolean(p$b: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
@@ -67,7 +67,7 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$nullable_unique_arg$TF$T$N$c$T(p$t: Ref) returns (ret$0: Ref)
+method f$nullable_unique_arg$TF$N$c$T(p$t: Ref) returns (ret$0: Ref)
   requires p$t != df$rt$nullValue() ==> acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
@@ -67,7 +67,7 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$nullable_unique_arg$TF$c$T(p$t: Ref) returns (ret$0: Ref)
+method f$nullable_unique_arg$TF$T$N$c$T(p$t: Ref) returns (ret$0: Ref)
   requires p$t != df$rt$nullValue() ==> acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -62,7 +62,25 @@ method f$fakePrint$TF$T$Boolean(p$truth: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/function_overloading.kt:(219,245): info: Generated Viper text for testGlobalScopeOverloading:
+/function_overloading.kt:(219,238): info: Generated Viper text for differInNullability:
+method f$differInNullability$TF$T$Int(p$i: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/function_overloading.kt:(256,275): info: Generated Viper text for differInNullability:
+method f$differInNullability$TF$T$N$Int(p$i: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$nullable(df$rt$intType()))
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/function_overloading.kt:(295,321): info: Generated Viper text for testGlobalScopeOverloading:
 method con$c$Bar$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Bar())
   ensures acc(p$c$Bar$shared(ret), wildcard)
@@ -110,7 +128,7 @@ method f$testGlobalScopeOverloading$TF$() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/function_overloading.kt:(337,365): info: Generated Viper text for testClassFunctionOverloading:
+/function_overloading.kt:(413,441): info: Generated Viper text for testClassFunctionOverloading:
 method con$c$Bar$() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Bar())
   ensures acc(p$c$Bar$shared(ret), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -72,7 +72,7 @@ method f$differInNullability$TF$T$Int(p$i: Ref) returns (ret$0: Ref)
 }
 
 /function_overloading.kt:(256,275): info: Generated Viper text for differInNullability:
-method f$differInNullability$TF$T$N$Int(p$i: Ref) returns (ret$0: Ref)
+method f$differInNullability$TF$N$Int(p$i: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$nullable(df$rt$intType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.kt
@@ -11,6 +11,9 @@ fun <!VIPER_TEXT!>fakePrint<!>(f: Foo) {  }
 fun <!VIPER_TEXT!>fakePrint<!>(value: Int) {  }
 fun <!VIPER_TEXT!>fakePrint<!>(truth: Boolean) {  }
 
+fun <!VIPER_TEXT!>differInNullability<!>(i: Int) {  }
+fun <!VIPER_TEXT!>differInNullability<!>(i: Int?) {  }
+
 fun <!VIPER_TEXT!>testGlobalScopeOverloading<!>() {
     fakePrint(42)
     fakePrint(true)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/as_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/as_operator.fir.diag.txt
@@ -13,7 +13,7 @@ method f$testAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(97,111): info: Generated Viper text for testNullableAs:
-method f$testNullableAs$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testNullableAs$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
@@ -49,7 +49,7 @@ method f$testSafeAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(194,212): info: Generated Viper text for testNullableSafeAs:
-method f$testNullableSafeAs$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testNullableSafeAs$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/as_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/as_operator.fir.diag.txt
@@ -13,7 +13,7 @@ method f$testAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(97,111): info: Generated Viper text for testNullableAs:
-method f$testNullableAs$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testNullableAs$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
@@ -49,7 +49,7 @@ method f$testSafeAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(194,212): info: Generated Viper text for testNullableSafeAs:
-method f$testNullableSafeAs$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testNullableSafeAs$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/elvis.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/elvis.fir.diag.txt
@@ -1,5 +1,5 @@
 /elvis.kt:(121,134): info: Generated Viper text for elvisOperator:
-method f$elvisOperator$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperator$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -12,30 +12,30 @@ method f$elvisOperator$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /elvis.kt:(176,196): info: Generated Viper text for elvisOperatorComplex:
-method f$elvisOperator$TF$T$N$Int(p$x: Ref) returns (ret: Ref)
+method f$elvisOperator$TF$N$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$elvisOperatorComplex$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperatorComplex$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  anon$0 := f$id$TF$T$N$Int(p$x)
+  anon$0 := f$id$TF$N$Int(p$x)
   if (anon$0 != df$rt$nullValue()) {
     ret$0 := anon$0
   } else {
-    ret$0 := f$elvisOperator$TF$T$N$Int(df$rt$intToRef(2))}
+    ret$0 := f$elvisOperator$TF$N$Int(df$rt$intToRef(2))}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$id$TF$T$N$Int(p$x: Ref) returns (ret: Ref)
+method f$id$TF$N$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /elvis.kt:(257,276): info: Generated Viper text for elvisOperatorReturn:
-method f$elvisOperatorReturn$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperatorReturn$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/elvis.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/elvis.fir.diag.txt
@@ -1,5 +1,5 @@
 /elvis.kt:(121,134): info: Generated Viper text for elvisOperator:
-method f$elvisOperator$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperator$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -12,30 +12,30 @@ method f$elvisOperator$TF$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /elvis.kt:(176,196): info: Generated Viper text for elvisOperatorComplex:
-method f$elvisOperator$TF$Int(p$x: Ref) returns (ret: Ref)
+method f$elvisOperator$TF$T$N$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$elvisOperatorComplex$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperatorComplex$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  anon$0 := f$id$TF$Int(p$x)
+  anon$0 := f$id$TF$T$N$Int(p$x)
   if (anon$0 != df$rt$nullValue()) {
     ret$0 := anon$0
   } else {
-    ret$0 := f$elvisOperator$TF$Int(df$rt$intToRef(2))}
+    ret$0 := f$elvisOperator$TF$T$N$Int(df$rt$intToRef(2))}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$id$TF$Int(p$x: Ref) returns (ret: Ref)
+method f$id$TF$T$N$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /elvis.kt:(257,276): info: Generated Viper text for elvisOperatorReturn:
-method f$elvisOperatorReturn$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperatorReturn$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/is_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/is_operator.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_operator.kt:(23,36): info: Generated Viper text for isNonNullable:
-method f$isNonNullable$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$isNonNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -9,7 +9,7 @@ method f$isNonNullable$TF$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_operator.kt:(84,97): info: Generated Viper text for notIsNullable:
-method f$notIsNullable$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$notIsNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -19,7 +19,7 @@ method f$notIsNullable$TF$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_operator.kt:(150,159): info: Generated Viper text for smartCast:
-method f$smartCast$TF$Any(p$x: Ref) returns (ret$0: Ref)
+method f$smartCast$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/is_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/is_operator.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_operator.kt:(23,36): info: Generated Viper text for isNonNullable:
-method f$isNonNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$isNonNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -9,7 +9,7 @@ method f$isNonNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_operator.kt:(84,97): info: Generated Viper text for notIsNullable:
-method f$notIsNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$notIsNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -19,7 +19,7 @@ method f$notIsNullable$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_operator.kt:(150,159): info: Generated Viper text for smartCast:
-method f$smartCast$TF$T$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$smartCast$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
@@ -5,7 +5,7 @@ method f$c$Foo$f$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testSafeCall$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testSafeCall$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
@@ -47,7 +47,7 @@ method f$testSafeCallNonNullable$TF$T$c$Foo(p$foo: Ref)
 /safe_call.kt:(267,287): info: Generated Viper text for testSafeCallProperty:
 field bf$x: Ref
 
-method f$testSafeCallProperty$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testSafeCallProperty$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
@@ -92,7 +92,7 @@ method f$c$Rec$nullable$TF$T$c$Rec(this$dispatch: Ref) returns (ret: Ref)
   ensures ret != df$rt$nullValue() ==> acc(p$c$Rec$shared(ret), wildcard)
 
 
-method f$safeCallChain$TF$T$N$c$Rec(p$rec: Ref) returns (ret$0: Ref)
+method f$safeCallChain$TF$N$c$Rec(p$rec: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
@@ -5,7 +5,7 @@ method f$c$Foo$f$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testSafeCall$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testSafeCall$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
@@ -47,7 +47,7 @@ method f$testSafeCallNonNullable$TF$T$c$Foo(p$foo: Ref)
 /safe_call.kt:(267,287): info: Generated Viper text for testSafeCallProperty:
 field bf$x: Ref
 
-method f$testSafeCallProperty$TF$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testSafeCallProperty$TF$T$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
@@ -92,7 +92,7 @@ method f$c$Rec$nullable$TF$T$c$Rec(this$dispatch: Ref) returns (ret: Ref)
   ensures ret != df$rt$nullValue() ==> acc(p$c$Rec$shared(ret), wildcard)
 
 
-method f$safeCallChain$TF$c$Rec(p$rec: Ref) returns (ret$0: Ref)
+method f$safeCallChain$TF$T$N$c$Rec(p$rec: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
@@ -1,7 +1,7 @@
 /generics.kt:(52,65): info: Generated Viper text for genericMethod:
 field bf$t: Ref
 
-method f$c$Box$genericMethod$TF$T$c$Box$Any(this$dispatch: Ref, p$x: Ref)
+method f$c$Box$genericMethod$TF$T$c$Box$T$N$Any(this$dispatch: Ref, p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
@@ -16,7 +16,7 @@ method f$c$Box$genericMethod$TF$T$c$Box$Any(this$dispatch: Ref, p$x: Ref)
 /generics.kt:(107,116): info: Generated Viper text for createBox:
 field bf$t: Ref
 
-method con$c$Box$Any(p$t: Ref) returns (ret: Ref)
+method con$c$Box$T$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -30,14 +30,14 @@ method f$createBox$TF$() returns (ret$0: Ref)
   var anon$0: Ref
   var l0$intBox: Ref
   var anon$1: Ref
-  l0$boolBox := con$c$Box$Any(df$rt$boolToRef(true))
+  l0$boolBox := con$c$Box$T$N$Any(df$rt$boolToRef(true))
   inhale acc(l0$boolBox.bf$t, write)
   anon$0 := l0$boolBox.bf$t
   exhale acc(l0$boolBox.bf$t, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   l0$b := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
-  l0$intBox := con$c$Box$Any(df$rt$intToRef(2))
+  l0$intBox := con$c$Box$T$N$Any(df$rt$intToRef(2))
   inhale acc(l0$intBox.bf$t, write)
   anon$1 := l0$intBox.bf$t
   exhale acc(l0$intBox.bf$t, write)
@@ -51,7 +51,7 @@ method f$createBox$TF$() returns (ret$0: Ref)
 /generics.kt:(227,242): info: Generated Viper text for setGenericField:
 field bf$t: Ref
 
-method con$c$Box$Any(p$t: Ref) returns (ret: Ref)
+method con$c$Box$T$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -61,7 +61,7 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$box: Ref
-  l0$box := con$c$Box$Any(df$rt$intToRef(3))
+  l0$box := con$c$Box$T$N$Any(df$rt$intToRef(3))
   inhale acc(l0$box.bf$t, write)
   l0$box.bf$t := df$rt$intToRef(5)
   exhale acc(l0$box.bf$t, write)
@@ -70,7 +70,7 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
 }
 
 /generics.kt:(293,303): info: Generated Viper text for genericFun:
-method f$genericFun$TF$Any(p$t: Ref) returns (ret$0: Ref)
+method f$genericFun$TF$T$N$Any(p$t: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
@@ -85,14 +85,14 @@ method f$callGenericFunc$TF$() returns (ret$0: Ref)
 {
   var l0$x: Ref
   var anon$0: Ref
-  anon$0 := f$genericFun$TF$Any(df$rt$intToRef(3))
+  anon$0 := f$genericFun$TF$T$N$Any(df$rt$intToRef(3))
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$genericFun$TF$Any(p$t: Ref) returns (ret: Ref)
+method f$genericFun$TF$T$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
@@ -1,7 +1,7 @@
 /generics.kt:(52,65): info: Generated Viper text for genericMethod:
 field bf$t: Ref
 
-method f$c$Box$genericMethod$TF$T$c$Box$T$N$Any(this$dispatch: Ref, p$x: Ref)
+method f$c$Box$genericMethod$TF$T$c$Box$N$Any(this$dispatch: Ref, p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
@@ -16,7 +16,7 @@ method f$c$Box$genericMethod$TF$T$c$Box$T$N$Any(this$dispatch: Ref, p$x: Ref)
 /generics.kt:(107,116): info: Generated Viper text for createBox:
 field bf$t: Ref
 
-method con$c$Box$T$N$Any(p$t: Ref) returns (ret: Ref)
+method con$c$Box$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -30,14 +30,14 @@ method f$createBox$TF$() returns (ret$0: Ref)
   var anon$0: Ref
   var l0$intBox: Ref
   var anon$1: Ref
-  l0$boolBox := con$c$Box$T$N$Any(df$rt$boolToRef(true))
+  l0$boolBox := con$c$Box$N$Any(df$rt$boolToRef(true))
   inhale acc(l0$boolBox.bf$t, write)
   anon$0 := l0$boolBox.bf$t
   exhale acc(l0$boolBox.bf$t, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   l0$b := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
-  l0$intBox := con$c$Box$T$N$Any(df$rt$intToRef(2))
+  l0$intBox := con$c$Box$N$Any(df$rt$intToRef(2))
   inhale acc(l0$intBox.bf$t, write)
   anon$1 := l0$intBox.bf$t
   exhale acc(l0$intBox.bf$t, write)
@@ -51,7 +51,7 @@ method f$createBox$TF$() returns (ret$0: Ref)
 /generics.kt:(227,242): info: Generated Viper text for setGenericField:
 field bf$t: Ref
 
-method con$c$Box$T$N$Any(p$t: Ref) returns (ret: Ref)
+method con$c$Box$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -61,7 +61,7 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$box: Ref
-  l0$box := con$c$Box$T$N$Any(df$rt$intToRef(3))
+  l0$box := con$c$Box$N$Any(df$rt$intToRef(3))
   inhale acc(l0$box.bf$t, write)
   l0$box.bf$t := df$rt$intToRef(5)
   exhale acc(l0$box.bf$t, write)
@@ -70,7 +70,7 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
 }
 
 /generics.kt:(293,303): info: Generated Viper text for genericFun:
-method f$genericFun$TF$T$N$Any(p$t: Ref) returns (ret$0: Ref)
+method f$genericFun$TF$N$Any(p$t: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
@@ -85,14 +85,14 @@ method f$callGenericFunc$TF$() returns (ret$0: Ref)
 {
   var l0$x: Ref
   var anon$0: Ref
-  anon$0 := f$genericFun$TF$T$N$Any(df$rt$intToRef(3))
+  anon$0 := f$genericFun$TF$N$Any(df$rt$intToRef(3))
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$genericFun$TF$T$N$Any(p$t: Ref) returns (ret: Ref)
+method f$genericFun$TF$N$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/nullable.fir.diag.txt
@@ -1,5 +1,5 @@
 /nullable.kt:(80,96): info: Generated Viper text for useNullableTwice:
-method f$useNullableTwice$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$useNullableTwice$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$a: Ref
@@ -13,23 +13,23 @@ method f$useNullableTwice$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /nullable.kt:(162,183): info: Generated Viper text for passNullableParameter:
-method f$passNullableParameter$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$passNullableParameter$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  anon$0 := f$useNullableTwice$TF$T$N$Int(p$x)
+  anon$0 := f$useNullableTwice$TF$N$Int(p$x)
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$useNullableTwice$TF$T$N$Int(p$x: Ref) returns (ret: Ref)
+method f$useNullableTwice$TF$N$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /nullable.kt:(245,271): info: Generated Viper text for nullableNullableComparison:
-method f$nullableNullableComparison$TF$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref)
+method f$nullableNullableComparison$TF$N$Int$N$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
@@ -41,7 +41,7 @@ method f$nullableNullableComparison$TF$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref)
 }
 
 /nullable.kt:(326,355): info: Generated Viper text for nullableNonNullableComparison:
-method f$nullableNonNullableComparison$TF$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref)
+method f$nullableNonNullableComparison$TF$N$Int$N$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
@@ -53,7 +53,7 @@ method f$nullableNonNullableComparison$TF$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref)
 }
 
 /nullable.kt:(410,424): info: Generated Viper text for nullComparison:
-method f$nullComparison$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$nullComparison$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/nullable.fir.diag.txt
@@ -1,5 +1,5 @@
 /nullable.kt:(80,96): info: Generated Viper text for useNullableTwice:
-method f$useNullableTwice$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$useNullableTwice$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$a: Ref
@@ -13,23 +13,23 @@ method f$useNullableTwice$TF$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /nullable.kt:(162,183): info: Generated Viper text for passNullableParameter:
-method f$passNullableParameter$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$passNullableParameter$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  anon$0 := f$useNullableTwice$TF$Int(p$x)
+  anon$0 := f$useNullableTwice$TF$T$N$Int(p$x)
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$useNullableTwice$TF$Int(p$x: Ref) returns (ret: Ref)
+method f$useNullableTwice$TF$T$N$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /nullable.kt:(245,271): info: Generated Viper text for nullableNullableComparison:
-method f$nullableNullableComparison$TF$Int$Int(p$x: Ref, p$y: Ref)
+method f$nullableNullableComparison$TF$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
@@ -41,7 +41,7 @@ method f$nullableNullableComparison$TF$Int$Int(p$x: Ref, p$y: Ref)
 }
 
 /nullable.kt:(326,355): info: Generated Viper text for nullableNonNullableComparison:
-method f$nullableNonNullableComparison$TF$Int$Int(p$x: Ref, p$y: Ref)
+method f$nullableNonNullableComparison$TF$T$N$Int$T$N$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
@@ -53,7 +53,7 @@ method f$nullableNonNullableComparison$TF$Int$Int(p$x: Ref, p$y: Ref)
 }
 
 /nullable.kt:(410,424): info: Generated Viper text for nullComparison:
-method f$nullComparison$TF$Int(p$x: Ref) returns (ret$0: Ref)
+method f$nullComparison$TF$T$N$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/smartcast.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/smartcast.fir.diag.txt
@@ -1,5 +1,5 @@
 /smartcast.kt:(23,38): info: Generated Viper text for smartcastReturn:
-method f$smartcastReturn$TF$Int(p$n: Ref) returns (ret$0: Ref)
+method f$smartcastReturn$TF$T$N$Int(p$n: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
@@ -12,7 +12,7 @@ method f$smartcastReturn$TF$Int(p$n: Ref) returns (ret$0: Ref)
 }
 
 /smartcast.kt:(88,106): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$c$pkg$kotlin$CharSequence(p$seq: Ref)
+method f$isNullOrEmptyWrong$TF$T$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/smartcast.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/smartcast.fir.diag.txt
@@ -1,5 +1,5 @@
 /smartcast.kt:(23,38): info: Generated Viper text for smartcastReturn:
-method f$smartcastReturn$TF$T$N$Int(p$n: Ref) returns (ret$0: Ref)
+method f$smartcastReturn$TF$N$Int(p$n: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
@@ -12,7 +12,7 @@ method f$smartcastReturn$TF$T$N$Int(p$n: Ref) returns (ret$0: Ref)
 }
 
 /smartcast.kt:(88,106): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$T$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
+method f$isNullOrEmptyWrong$TF$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {


### PR DESCRIPTION
We didn't put `'T'` tag to the nullable type names apparently and only added `'N'` prefix when scope name was not null which sounds very strange. I tried to configure a more plausible name for that case, but I'm still open to suggestions (collisions are pretty easy to find currently in function names).
Also added a test when functions only differ in the nullability of their argument (it's allowed on JVM).  