### PR TITLE
Contracts with receivers

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/SourceRole.kt
@@ -5,7 +5,10 @@
 
 package org.jetbrains.kotlin.formver.embeddings
 
+import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.viper.ast.Info
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/SourceRoleConditionPrettyPrinter.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/reporting/SourceRoleConditionPrettyPrinter.kt
@@ -7,6 +7,8 @@ package org.jetbrains.kotlin.formver.reporting
 
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.renderReadable
 import org.jetbrains.kotlin.formver.embeddings.SourceRole
 
@@ -26,6 +28,13 @@ object SourceRoleConditionPrettyPrinter {
         return "($lhsExpr && $rhsExpr)"
     }
 
+    private val FirBasedSymbol<*>.shownName: String
+        get() = when (this) {
+            is FirValueParameterSymbol -> showFirSymbol()
+            is FirFunctionSymbol<*> -> "this"
+            else -> error("Variable must be either value parameter or function itself in case of receiver.")
+        }
+
     private fun SourceRole.Condition.Disjunction.showDisjunction(): String {
         val lhsExpr = lhs.prettyPrint()
         val rhsExpr = rhs.prettyPrint()
@@ -33,7 +42,7 @@ object SourceRoleConditionPrettyPrinter {
     }
 
     private fun SourceRole.Condition.IsNull.showIsNull(): String = buildString {
-        append(targetVariable.showFirSymbol())
+        append(targetVariable.shownName)
         when (negated) {
             true -> append(" != ")
             false -> append(" == ")
@@ -42,7 +51,7 @@ object SourceRoleConditionPrettyPrinter {
     }
 
     private fun SourceRole.Condition.IsType.showIsType(): String = buildString {
-        append(targetVariable.showFirSymbol())
+        append(targetVariable.shownName)
         when (negated) {
             true -> append(" !is ")
             false -> append(" is ")

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.fir.diag.txt
@@ -1,0 +1,48 @@
+/contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
+method f$c$Class$is2$TF$T$c$Class(this$dispatch: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true ==>
+    df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl1())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl2()))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/contracts_with_receivers.kt:(196,239): warning: Cannot verify that if a true value is returned then this is Impl1.
+
+/contracts_with_receivers.kt:(341,359): info: Generated Viper text for is1butWithDispatch:
+method f$c$Class$is1butWithDispatch$TF$T$c$Class$T$c$Class(this$dispatch: Ref,
+  this$extension: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true ==>
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl2())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/contracts_with_receivers.kt:(404,460): warning: Cannot verify that if a true value is returned then this is Impl2.
+
+/contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
+method f$is1$TF$T$c$Class(this$extension: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true ==>
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl2())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/contracts_with_receivers.kt:(658,699): warning: Cannot verify that if a true value is returned then this is Impl2.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.kt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.kt
@@ -1,0 +1,31 @@
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+open class Class {
+    @OptIn(ExperimentalContracts::class)
+    fun <!VIPER_TEXT!>is2<!>(): Boolean {
+        contract {
+            <!CONDITIONAL_EFFECT_ERROR!>returns(true) implies (this@Class is Impl1)<!>
+        }
+        return this is Impl2
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    fun Class.<!VIPER_TEXT!>is1butWithDispatch<!>(): Boolean {
+        contract {
+            <!CONDITIONAL_EFFECT_ERROR!>returns(true) implies (this@is1butWithDispatch is Impl2)<!>
+        }
+        return this@is1butWithDispatch is Impl1
+    }
+}
+
+class Impl1: Class()
+class Impl2: Class()
+
+@OptIn(ExperimentalContracts::class)
+fun Class.<!VIPER_TEXT!>is1<!>(): Boolean {
+    contract {
+        <!CONDITIONAL_EFFECT_ERROR!>returns(true) implies (this@is1 is Impl2)<!>
+    }
+    return this is Impl1
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.fir.diag.txt
@@ -1,0 +1,42 @@
+/contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
+method f$c$Class$is2$TF$T$c$Class(this$dispatch: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true ==>
+    df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl2())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl2()))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/contracts_with_receivers.kt:(341,359): info: Generated Viper text for is1butWithDispatch:
+method f$c$Class$is1butWithDispatch$TF$T$c$Class$T$c$Class(this$dispatch: Ref,
+  this$extension: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true ==>
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
+method f$is1$TF$T$c$Class(this$extension: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true ==>
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.kt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.kt
@@ -1,0 +1,31 @@
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+open class Class {
+    @OptIn(ExperimentalContracts::class)
+    fun <!VIPER_TEXT!>is2<!>(): Boolean {
+        contract {
+            returns(true) implies (this@Class is Impl2)
+        }
+        return this is Impl2
+    }
+
+    @OptIn(ExperimentalContracts::class)
+    fun Class.<!VIPER_TEXT!>is1butWithDispatch<!>(): Boolean {
+        contract {
+            returns(true) implies (this@is1butWithDispatch is Impl1)
+        }
+        return this@is1butWithDispatch is Impl1
+    }
+}
+
+class Impl1: Class()
+class Impl2: Class()
+
+@OptIn(ExperimentalContracts::class)
+fun Class.<!VIPER_TEXT!>is1<!>(): Boolean {
+    contract {
+        returns(true) implies (this@is1 is Impl1)
+    }
+    return this is Impl1
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -122,6 +122,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("contracts_with_receivers.kt")
+    public void testContracts_with_receivers() {
+      runTest("plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.kt");
+    }
+
+    @Test
     @TestMetadata("custom_list.kt")
     public void testCustom_list() {
       runTest("plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.kt");
@@ -200,6 +206,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("stdlib_replacement_tests.kt")
+    public void testStdlib_replacement_tests() {
+      runTest("plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt");
+    }
+
+    @Test
     @TestMetadata("unit_return_type.kt")
     public void testUnit_return_type() {
       runTest("plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.kt");
@@ -209,12 +221,6 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     @TestMetadata("viper_casts_while_inlining.kt")
     public void testViper_casts_while_inlining() {
       runTest("plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.kt");
-    }
-
-    @Test
-    @TestMetadata("stdlib_replacement_tests.kt")
-    public void testStdlib_replacement_tests() {
-      runTest("plugins/formal-verification/testData/diagnostics/good_contracts/stdlib_replacement_tests.kt");
     }
   }
 

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -52,6 +52,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("contracts_with_receivers.kt")
+    public void testContracts_with_receivers() {
+      runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.kt");
+    }
+
+    @Test
     @TestMetadata("do_not_verify.kt")
     public void testDo_not_verify() {
       runTest("plugins/formal-verification/testData/diagnostics/bad_contracts/do_not_verify.kt");


### PR DESCRIPTION
Supported member and extension contracts:
```kotlin
open class Class
class Impl: Class()

fun Class.isImpl(): Boolean {
  contract {
    returns(true) implies (this@isImpl is Impl)
  }
  return this is Impl
}
```

Note that in contract description only the references to direct receiver are allowed. In particular, that means that in presence of extension receiver we cannot access the dispatch one. Hence, no special worries about distinguishing them.