### PR TITLE
Split `TypeEmbedding` into a `PretypeEmbedding` and flags.

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.PlaceholderVariableEmbedding

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.formver.embeddings.callables.FunctionEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.names.CatchLabelName
 import org.jetbrains.kotlin.formver.names.TryExitLabelName
 
@@ -36,7 +37,7 @@ interface ProgramConversionContext {
     fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding
     fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): FunctionSignature
     fun embedType(type: ConeKotlinType): TypeEmbedding
-    fun embedType(symbol: FirFunctionSymbol<*>): TypeEmbedding
+    fun embedFunctionPretype(symbol: FirFunctionSymbol<*>): FunctionTypeEmbedding
     fun embedType(exp: FirExpression): TypeEmbedding = embedType(exp.resolvedType)
     fun embedProperty(symbol: FirPropertySymbol): PropertyEmbedding
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.ErrorCollector
 import org.jetbrains.kotlin.formver.PluginConfiguration
 import org.jetbrains.kotlin.formver.embeddings.PropertyEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -21,6 +21,15 @@ import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.callables.*
 import org.jetbrains.kotlin.formver.embeddings.expression.*
+import org.jetbrains.kotlin.formver.embeddings.types.ClassEmbeddingDetails
+import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionPretypeBuilder
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.PretypeBuilder
+import org.jetbrains.kotlin.formver.embeddings.types.TypeBuilder
+import org.jetbrains.kotlin.formver.embeddings.types.buildClassPretype
+import org.jetbrains.kotlin.formver.embeddings.types.buildFunctionPretype
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.Linearizer
 import org.jetbrains.kotlin.formver.linearization.SeqnBuilder
 import org.jetbrains.kotlin.formver.linearization.SharedLinearizationState
@@ -122,9 +131,9 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     private fun embedClass(symbol: FirRegularClassSymbol): ClassTypeEmbedding {
         val className = symbol.classId.embedName()
         val embedding = classes.getOrPut(className) {
-            buildType {
-                klass { withName(className) }
-            } as ClassTypeEmbedding
+            buildClassPretype {
+                withName(className)
+            }
         }
         if (embedding.hasDetails) return embedding
 
@@ -142,7 +151,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         // `ProgramConverter`.
 
         // Phase 1
-        newDetails.initSuperTypes(symbol.resolvedSuperTypes.map(::embedType))
+        newDetails.initSuperTypes(symbol.resolvedSuperTypes.map { embedType(it).pretype })
 
         // Phase 2
         val properties = symbol.propertySymbols
@@ -157,20 +166,8 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     override fun embedType(type: ConeKotlinType): TypeEmbedding = buildType { embedTypeWithBuilder(type) }
 
     // Note: keep in mind that this function is necessary to resolve the name of the function!
-    override fun embedType(symbol: FirFunctionSymbol<*>): FunctionTypeEmbedding = buildFunctionType {
-        symbol.receiverType?.let {
-            withDispatchReceiver { embedTypeWithBuilder(it) }
-        }
-        symbol.extensionReceiverType?.let {
-            withExtensionReceiver { embedTypeWithBuilder(it) }
-        }
-        symbol.valueParameterSymbols.forEach { param ->
-            withParam {
-                embedTypeWithBuilder(param.resolvedReturnType)
-            }
-        }
-        withReturnType { embedTypeWithBuilder(symbol.resolvedReturnType) }
-        returnsUnique = symbol.isUnique(session) || symbol is FirConstructorSymbol
+    override fun embedFunctionPretype(symbol: FirFunctionSymbol<*>): FunctionTypeEmbedding = buildFunctionPretype {
+        embedFunctionPretypeWithBuilder(symbol)
     }
 
     override fun embedProperty(symbol: FirPropertySymbol): PropertyEmbedding = if (symbol.isExtension) {
@@ -210,7 +207,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
         val isExtensionReceiverUnique = symbol.receiverParameter?.isUnique(session) ?: false
         val isExtensionReceiverBorrowed = symbol.receiverParameter?.isBorrowed(session) ?: false
         return object : FunctionSignature {
-            override val type: FunctionTypeEmbedding = embedType(symbol)
+            override val callableType: FunctionTypeEmbedding = embedFunctionPretype(symbol)
 
             // TODO: figure out whether we want a symbol here and how to get it.
             override val dispatchReceiver = dispatchReceiverType?.let {
@@ -272,7 +269,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                 addAll(returnVariable.pureInvariants())
                 addAll(returnVariable.provenInvariants())
                 addAll(returnVariable.allAccessInvariants())
-                if (subSignature.type.returnsUnique) {
+                if (subSignature.callableType.returnsUnique) {
                     addIfNotNull(returnVariable.uniquePredicateAccessInvariant())
                 }
                 addAll(contractVisitor.getPostconditions(ContractVisitorContext(returnVariable, symbol)))
@@ -384,7 +381,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
 
     private fun convertMethodWithBody(declaration: FirSimpleFunction, signature: FullNamedFunctionSignature): FunctionBodyEmbedding? {
         val firBody = declaration.body ?: return null
-        val returnTarget = returnTargetProducer.getFresh(signature.type.returnType)
+        val returnTarget = returnTargetProducer.getFresh(signature.callableType.returnType)
         val methodCtx =
             MethodConverter(
                 this,
@@ -434,6 +431,22 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
             }
         }
         else -> unimplementedTypeEmbedding(type)
+    }
+
+    private fun FunctionPretypeBuilder.embedFunctionPretypeWithBuilder(symbol: FirFunctionSymbol<*>) {
+        symbol.receiverType?.let {
+            withDispatchReceiver { embedTypeWithBuilder(it) }
+        }
+        symbol.extensionReceiverType?.let {
+            withExtensionReceiver { embedTypeWithBuilder(it) }
+        }
+        symbol.valueParameterSymbols.forEach { param ->
+            withParam {
+                embedTypeWithBuilder(param.resolvedReturnType)
+            }
+        }
+        withReturnType { embedTypeWithBuilder(symbol.resolvedReturnType) }
+        returnsUnique = symbol.isUnique(session) || symbol is FirConstructorSymbol
     }
 
     private fun TypeBuilder.unimplementedTypeEmbedding(type: ConeKotlinType): PretypeBuilder =

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.callables.*
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.embeddings.types.ClassEmbeddingDetails
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.FunctionPretypeBuilder
 import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.formver.conversion
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.FirVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
 import org.jetbrains.kotlin.formver.names.embedScopedLocalName

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/SpecialFields.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.conversion
 
 import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.names.SpecialName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Type

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StdLibConverter.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.conversion
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.*
+import org.jetbrains.kotlin.formver.embeddings.types.isInheritorOfCollectionTypeNamed
 import org.jetbrains.kotlin.formver.names.NameMatcher
 
 private fun VariableEmbedding.sameSize(): ExpEmbedding =
@@ -23,7 +24,7 @@ sealed interface StdLibReceiverInterface {
 sealed interface PresentInterface : StdLibReceiverInterface {
     val interfaceName: String
     override fun match(function: NamedFunctionSignature): Boolean =
-        function.type.dispatchReceiverType?.isInheritorOfCollectionTypeNamed(interfaceName) ?: false
+        function.callableType.dispatchReceiverType?.pretype?.isInheritorOfCollectionTypeNamed(interfaceName) ?: false
 }
 
 data object CollectionInterface : PresentInterface {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.formver.embeddings.*
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.isCustom

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.isCustom
@@ -175,8 +176,8 @@ fun StmtConversionContext.insertInlineFunctionCall(
     parentCtx: MethodConversionContext? = null,
 ): ExpEmbedding {
     // TODO: It seems like it may be possible to avoid creating a local here, but it is not clear how.
-    val returnTarget = returnTargetProducer.getFresh(calleeSignature.type.returnType)
-    val (declarations, callArgs) = getInlineFunctionCallArgs(args, calleeSignature.type.formalArgTypes)
+    val returnTarget = returnTargetProducer.getFresh(calleeSignature.callableType.returnType)
+    val (declarations, callArgs) = getInlineFunctionCallArgs(args, calleeSignature.callableType.formalArgTypes)
     val subs = paramNames.zip(callArgs).toMap()
     val methodCtxFactory = MethodContextFactory(
         calleeSignature,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.fir.types.isUnit
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.formver.UnsupportedFeatureBehaviour
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.callables.insertCall
 import org.jetbrains.kotlin.formver.embeddings.expression.*

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -21,10 +21,10 @@ import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.formver.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.callables.insertCall
 import org.jetbrains.kotlin.formver.embeddings.expression.*
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.functionCallArguments
 import org.jetbrains.kotlin.text
 import org.jetbrains.kotlin.types.ConstantValueKind
@@ -88,7 +88,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
 
     override fun visitIntegerLiteralOperatorCall(
         integerLiteralOperatorCall: FirIntegerLiteralOperatorCall,
-        data: StmtConversionContext
+        data: StmtConversionContext,
     ): ExpEmbedding {
         return visitFunctionCall(integerLiteralOperatorCall, data)
     }
@@ -287,7 +287,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
 
     override fun visitBooleanOperatorExpression(
         booleanOperatorExpression: FirBooleanOperatorExpression,
-        data: StmtConversionContext
+        data: StmtConversionContext,
     ): ExpEmbedding {
         val left = data.convert(booleanOperatorExpression.leftOperand)
         val right = data.convert(booleanOperatorExpression.rightOperand)
@@ -327,7 +327,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 proven = true
                 access = true
             }
-            FirOperation.SAFE_AS -> SafeCast(argument, conversionType).withInvariants{
+            FirOperation.SAFE_AS -> SafeCast(argument, conversionType).withInvariants {
                 proven = true
                 access = true
             }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/RuntimeTypeDomain.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/domains/RuntimeTypeDomain.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.formver.domains
 
-import org.jetbrains.kotlin.formver.embeddings.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.*
 import org.jetbrains.kotlin.formver.viper.mangled

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassPropertyAccess.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/ClassPropertyAccess.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.embeddings
 
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.withNewTypeInvariants
 
 // We assume that thanks to the checks done by the Kotlin compiler, a property with a

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/CustomAccessors.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/CustomAccessors.kt
@@ -14,7 +14,7 @@ class CustomGetter(val getterMethod: CallableEmbedding) : GetterEmbedding {
     override fun getValue(
         receiver: ExpEmbedding,
         ctx: StmtConversionContext,
-    ): ExpEmbedding = getterMethod.insertCall(listOf(receiver), ctx, getterMethod.type.returnType)
+    ): ExpEmbedding = getterMethod.insertCall(listOf(receiver), ctx, getterMethod.callableType.returnType)
 }
 
 class CustomSetter(val setterMethod: CallableEmbedding) : SetterEmbedding {
@@ -22,5 +22,5 @@ class CustomSetter(val setterMethod: CallableEmbedding) : SetterEmbedding {
         receiver: ExpEmbedding,
         value: ExpEmbedding,
         ctx: StmtConversionContext,
-    ): ExpEmbedding = setterMethod.insertCall(listOf(receiver, value), ctx, setterMethod.type.returnType)
+    ): ExpEmbedding = setterMethod.insertCall(listOf(receiver, value), ctx, setterMethod.callableType.returnType)
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -11,6 +11,11 @@ import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.FieldAccess
 import org.jetbrains.kotlin.formver.embeddings.expression.GeCmp
 import org.jetbrains.kotlin.formver.embeddings.expression.IntLit
+import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.FieldAccessTypeInvariantEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeInvariantEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.isCollectionInheritor
 import org.jetbrains.kotlin.formver.names.NameMatcher
 import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 import org.jetbrains.kotlin.formver.names.SpecialName

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/FieldEmbedding.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.formver.embeddings.types.FieldAccessTypeInvariantEmb
 import org.jetbrains.kotlin.formver.embeddings.types.TypeInvariantEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.embeddings.types.isCollectionInheritor
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.names.NameMatcher
 import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 import org.jetbrains.kotlin.formver.names.SpecialName

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.withNewTypeInvariants
 import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/CallableEmbedding.kt
@@ -6,16 +6,16 @@
 package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.withNewTypeInvariants
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
 
 /**
  * Kotlin entity that can be called.
  */
 interface CallableEmbedding {
-    val type: FunctionTypeEmbedding
+    val callableType: FunctionTypeEmbedding
     fun insertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
@@ -8,13 +8,13 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.buildFunctionType
-import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.PlaceholderVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
-import org.jetbrains.kotlin.formver.embeddings.nullableAny
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.buildFunctionPretype
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.nullableAny
 import org.jetbrains.kotlin.formver.linearization.pureToViper
 import org.jetbrains.kotlin.formver.names.DispatchReceiverName
 import org.jetbrains.kotlin.formver.viper.MangledName
@@ -56,7 +56,7 @@ abstract class PropertyAccessorFunctionSignature(
 
 class GetterFunctionSignature(name: MangledName, symbol: FirPropertySymbol) :
     PropertyAccessorFunctionSignature(name, symbol) {
-    override val type: FunctionTypeEmbedding = buildFunctionType {
+    override val callableType: FunctionTypeEmbedding = buildFunctionPretype {
         withDispatchReceiver { nullableAny() }
         withReturnType { nullableAny() }
     }
@@ -64,13 +64,12 @@ class GetterFunctionSignature(name: MangledName, symbol: FirPropertySymbol) :
 
 class SetterFunctionSignature(name: MangledName, symbol: FirPropertySymbol) :
     PropertyAccessorFunctionSignature(name, symbol) {
-    override val type: FunctionTypeEmbedding = buildFunctionType {
+    override val callableType: FunctionTypeEmbedding = buildFunctionPretype {
         withDispatchReceiver { nullableAny() }
         withParam { nullableAny() }
         withReturnType { unit() }
     }
 }
-
 
 fun FullNamedFunctionSignature.toViperMethod(
     body: Stmt.Seqn?,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FunctionSignature.kt
@@ -5,15 +5,15 @@
 
 package org.jetbrains.kotlin.formver.embeddings.callables
 
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.PlaceholderVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.names.AnonymousName
 import org.jetbrains.kotlin.formver.names.DispatchReceiverName
 import org.jetbrains.kotlin.formver.names.ExtensionReceiverName
 
 interface FunctionSignature {
-    val type: FunctionTypeEmbedding
+    val callableType: FunctionTypeEmbedding
     val dispatchReceiver: VariableEmbedding?
     val extensionReceiver: VariableEmbedding?
 
@@ -28,11 +28,11 @@ interface FunctionSignature {
 
 abstract class GenericFunctionSignatureMixin : FunctionSignature {
     override val dispatchReceiver: VariableEmbedding?
-        get() = type.dispatchReceiverType?.let { PlaceholderVariableEmbedding(DispatchReceiverName, it) }
+        get() = callableType.dispatchReceiverType?.let { PlaceholderVariableEmbedding(DispatchReceiverName, it) }
 
     override val extensionReceiver: VariableEmbedding?
-        get() = type.extensionReceiverType?.let { PlaceholderVariableEmbedding(ExtensionReceiverName, it)}
+        get() = callableType.extensionReceiverType?.let { PlaceholderVariableEmbedding(ExtensionReceiverName, it) }
 
     override val params: List<VariableEmbedding>
-        get() = type.paramTypes.mapIndexed { ix, type -> PlaceholderVariableEmbedding(AnonymousName(ix), type) }
+        get() = callableType.paramTypes.mapIndexed { ix, type -> PlaceholderVariableEmbedding(AnonymousName(ix), type) }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/InlineNamedFunction.kt
@@ -22,9 +22,9 @@ class InlineNamedFunction(
         ctx: StmtConversionContext,
     ): ExpEmbedding {
         val paramNames = buildList {
-            if (type.dispatchReceiverType != null)
+            if (callableType.dispatchReceiverType != null)
                 add(ExtraSpecialNames.DISPATCH_THIS)
-            if (type.extensionReceiverType != null)
+            if (callableType.extensionReceiverType != null)
                 add(ExtraSpecialNames.EXTENSION_THIS)
             addAll(symbol.valueParameterSymbols.map { it.name })
         }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/NonInlineNamedFunction.kt
@@ -19,5 +19,5 @@ class NonInlineNamedFunction(val signature: FullNamedFunctionSignature) : RichCa
     ): ExpEmbedding = MethodCall(signature, args)
 
     override fun toViperMethodHeader(): Method =
-        signature.toViperMethod(null, PlaceholderVariableEmbedding(PlaceholderReturnVariableName, signature.type.returnType))
+        signature.toViperMethod(null, PlaceholderVariableEmbedding(PlaceholderReturnVariableName, signature.callableType.returnType))
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/SpecialKotlinFunction.kt
@@ -6,9 +6,9 @@
 package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.buildFunctionType
 import org.jetbrains.kotlin.formver.embeddings.expression.*
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.buildFunctionPretype
 import org.jetbrains.kotlin.formver.names.ClassKotlinName
 import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 import org.jetbrains.kotlin.formver.names.buildName
@@ -36,7 +36,7 @@ interface SpecialKotlinFunction : FunctionEmbedding {
 val SpecialKotlinFunction.callableId: CallableId
     get() = CallableId(FqName.fromSegments(packageName), className?.let { FqName(it) }, Name.identifier(name))
 
-fun SpecialKotlinFunction.embedName(): ScopedKotlinName = callableId.embedFunctionName(type)
+fun SpecialKotlinFunction.embedName(): ScopedKotlinName = callableId.embedFunctionName(callableType)
 
 object KotlinContractFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin", "contracts")
@@ -47,7 +47,7 @@ object KotlinContractFunction : SpecialKotlinFunction {
         ClassKotlinName(listOf("ContractBuilder"))
     }
 
-    override val type: FunctionTypeEmbedding = buildFunctionType {
+    override val callableType: FunctionTypeEmbedding = buildFunctionPretype {
         withParam {
             function {
                 withDispatchReceiver {
@@ -71,12 +71,11 @@ abstract class KotlinIntSpecialFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin")
     override val className: String? = "Int"
 
-    override val type: FunctionTypeEmbedding = buildFunctionType {
+    override val callableType: FunctionTypeEmbedding = buildFunctionPretype {
         withDispatchReceiver { int() }
         withParam { int() }
         withReturnType { int() }
     }
-
 }
 
 object KotlinIntPlusFunctionImplementation : KotlinIntSpecialFunction() {
@@ -122,7 +121,7 @@ abstract class KotlinBooleanSpecialFunction : SpecialKotlinFunction {
     override val packageName: List<String> = listOf("kotlin")
     override val className: String? = "Boolean"
 
-    override val type: FunctionTypeEmbedding = buildFunctionType {
+    override val callableType: FunctionTypeEmbedding = buildFunctionPretype {
         withDispatchReceiver { boolean() }
         withReturnType { boolean() }
     }
@@ -148,7 +147,7 @@ object SpecialVerifyFunction : SpecialKotlinFunction {
         return Assert(args[0])
     }
 
-    override val type: FunctionTypeEmbedding = buildFunctionType {
+    override val callableType: FunctionTypeEmbedding = buildFunctionPretype {
         withParam { boolean() }
         withReturnType { unit() }
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Arithmetic.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Arithmetic.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 
 sealed interface IntArithmeticExpression : OperationBaseExpEmbedding {
     override val type

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Boolean.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Boolean.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.embeddings.asInfo
-import org.jetbrains.kotlin.formver.embeddings.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Comparison.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.formver.domains.InjectionImageFunction
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.embeddings.asInfo
-import org.jetbrains.kotlin.formver.embeddings.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.EqAny
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -89,7 +89,6 @@ data class EqCmp(
     override val right: ExpEmbedding,
     override val sourceRole: SourceRole? = null,
 ) : AnyComparisonExpression {
-
     override val comparisonOperation = EqAny
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -6,14 +6,14 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.asInfo
-import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.callables.toMethodCall
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.*
+import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.addLabel
 import org.jetbrains.kotlin.formver.linearization.freshAnonVar
@@ -166,7 +166,7 @@ data class UnfoldingClassPredicateEmbedding(val predicated: VariableEmbedding, o
     UnaryDirectResultExpEmbedding {
     override val type: TypeEmbedding = inner.type
     private fun toViperImpl(ctx: LinearizationContext, action: ExpEmbedding.() -> Exp): Exp {
-        val predicatedType = predicated.type
+        val predicatedType = predicated.type.pretype
         check(predicatedType is ClassTypeEmbedding) {
             "Built-in types do not have predicates."
         }
@@ -193,7 +193,7 @@ data class UnfoldingClassPredicateEmbedding(val predicated: VariableEmbedding, o
 
 // Note: this is always a *real* Viper method call.
 data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbedding>) : StoredResultExpEmbedding {
-    override val type: TypeEmbedding = method.type.returnType
+    override val type: TypeEmbedding = method.callableType.returnType
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         ctx.addStatement {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.asInfo
 import org.jetbrains.kotlin.formver.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -11,7 +11,9 @@ import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.*
 import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.injectionOr
 import org.jetbrains.kotlin.formver.linearization.InhaleExhaleStmtModifier
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.pureToViper

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.*
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.*
+import org.jetbrains.kotlin.formver.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.InhaleExhaleStmtModifier
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.pureToViper
@@ -19,7 +21,7 @@ import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 import org.jetbrains.kotlin.formver.viper.mangled
 
-sealed interface ExpEmbedding {
+sealed interface ExpEmbedding : DebugPrintable {
     val type: TypeEmbedding
 
     /**
@@ -74,8 +76,6 @@ sealed interface ExpEmbedding {
     // TODO: Come up with a better way to solve the problem these `ignoring` functions solve...
     // Probably either virtual functions or a visitor.
     fun ignoringCastsAndMetaNodes(): ExpEmbedding = this
-
-    val debugTreeView: TreeView
 }
 
 sealed class ToViperBuiltinMisuseError(msg: String) : RuntimeException(msg)
@@ -375,7 +375,7 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
     }
 
     private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
-        val hierarchyPath = (receiver.type as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field)
+        val hierarchyPath = (receiver.type.pretype as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field)
         hierarchyPath?.forEach { classType ->
             val predAcc = classType.sharedPredicateAccessInvariant().fillHole(receiverWrapper)
                 .pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Invariant.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Invariant.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.formver.conversion.MethodConversionContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.conversion.insertInlineFunctionCall
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/LambdaExp.kt
@@ -9,11 +9,12 @@ import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.formver.conversion.MethodConversionContext
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.conversion.insertInlineFunctionCall
-import org.jetbrains.kotlin.formver.embeddings.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
+import org.jetbrains.kotlin.formver.embeddings.types.asTypeEmbedding
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.names.ExtraSpecialNames
 
@@ -23,7 +24,8 @@ class LambdaExp(
     private val parentCtx: MethodConversionContext,
 ) : CallableEmbedding, StoredResultExpEmbedding,
     FunctionSignature by signature {
-    override val type: FunctionTypeEmbedding = signature.type
+    override val type: TypeEmbedding
+        get() = callableType.asTypeEmbedding()
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         TODO("create new function object with counter, duplicable (requires toViper restructuring)")

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Literal.kt
@@ -10,9 +10,9 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.embeddings.asInfo
-import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Meta.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Meta.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.NamedBranchingNode
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Meta.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Meta.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.NamedBranchingNode
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.buildType
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.formver.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -11,9 +11,11 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.asSourceRole
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.*
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.NamedBranchingNode
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
+import org.jetbrains.kotlin.formver.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.names.AnonymousName
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.*
@@ -83,8 +85,7 @@ class FirVariableEmbedding(
     val symbol: FirBasedSymbol<*>,
     override val isUnique: Boolean = false,
     override val isBorrowed: Boolean = false,
-) :
-    VariableEmbedding {
+) : VariableEmbedding {
     override val sourceRole: SourceRole
         get() = symbol.asSourceRole
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/VariableEmbedding.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.asSourceRole
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.*
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.NamedBranchingNode
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/DebugPrintable.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/DebugPrintable.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.expression.debug
+
+interface DebugPrintable {
+    val debugTreeView: TreeView
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/Utils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/debug/Utils.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.formver.embeddings.expression.debug
 
 import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.callables.NamedFunctionSignature
 import org.jetbrains.kotlin.formver.viper.ast.Label
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -23,9 +22,5 @@ val PermExp.debugTreeView: TreeView
         is PermExp.WildcardPerm -> PlaintextLeaf("wildcard")
         is PermExp.FullPerm -> PlaintextLeaf("write")
     }
-
-// TODO: implement something nicer for types.
-val TypeEmbedding.debugTreeView: TreeView
-    get() = PlaintextLeaf(name.mangled)
 
 fun TreeView.withDesignation(name: String) = designatedNode(name, this)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassEmbeddingDetails.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassEmbeddingDetails.kt
@@ -3,23 +3,24 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
 
+import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
 import org.jetbrains.kotlin.formver.names.*
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Predicate
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boolean) : TypeInvariantHolder {
-    private var _superTypes: List<TypeEmbedding>? = null
-    val superTypes: List<TypeEmbedding>
-        get() = _superTypes ?: error("Super types of ${type.className} have not been initialised yet.")
+    private var _superTypes: List<PretypeEmbedding>? = null
+    val superTypes: List<PretypeEmbedding>
+        get() = _superTypes ?: error("Super types of ${type.name} have not been initialised yet.")
 
     private val classSuperTypes: List<ClassTypeEmbedding>
-        get() = superTypes.filterIsInstance<ClassTypeEmbedding>()
+        get() = superTypes.mapNotNull { it as? ClassTypeEmbedding }
 
-    fun initSuperTypes(newSuperTypes: List<TypeEmbedding>) {
-        check(_superTypes == null) { "Super types of ${type.className} are already initialised." }
+    fun initSuperTypes(newSuperTypes: List<PretypeEmbedding>) {
+        check(_superTypes == null) { "Super types of ${type.name} are already initialised." }
         _superTypes = newSuperTypes
     }
 
@@ -27,16 +28,16 @@ class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boole
     private var _sharedPredicate: Predicate? = null
     private var _uniquePredicate: Predicate? = null
     val fields: Map<SimpleKotlinName, FieldEmbedding>
-        get() = _fields ?: error("Fields of ${type.className} have not been initialised yet.")
+        get() = _fields ?: error("Fields of ${type.name} have not been initialised yet.")
     val sharedPredicate: Predicate
-        get() = _sharedPredicate ?: error("Predicate of ${type.className} has not been initialised yet.")
+        get() = _sharedPredicate ?: error("Predicate of ${type.name} has not been initialised yet.")
     val uniquePredicate: Predicate
-        get() = _uniquePredicate ?: error("Unique Predicate of ${type.className} has not been initialised yet.")
+        get() = _uniquePredicate ?: error("Unique Predicate of ${type.name} has not been initialised yet.")
 
     fun initFields(newFields: Map<SimpleKotlinName, FieldEmbedding>) {
-        check(_fields == null) { "Fields of ${type.className} are already initialised." }
+        check(_fields == null) { "Fields of ${type.name} are already initialised." }
         _fields = newFields
-        _sharedPredicate = ClassPredicateBuilder.build(this, sharedPredicateName) {
+        _sharedPredicate = ClassPredicateBuilder.Companion.build(this, sharedPredicateName) {
             forEachField {
                 if (isAlwaysReadable) {
                     addAccessPermissions(PermExp.WildcardPerm())
@@ -50,7 +51,7 @@ class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boole
                 addAccessToSharedPredicate()
             }
         }
-        _uniquePredicate = ClassPredicateBuilder.build(this, uniquePredicateName) {
+        _uniquePredicate = ClassPredicateBuilder.Companion.build(this, uniquePredicateName) {
             forEachField {
                 if (isAlwaysReadable) {
                     addAccessPermissions(PermExp.WildcardPerm())
@@ -71,8 +72,8 @@ class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boole
         }
     }
 
-    private val sharedPredicateName = ScopedKotlinName(type.className.asScope(), PredicateKotlinName("shared"))
-    private val uniquePredicateName = ScopedKotlinName(type.className.asScope(), PredicateKotlinName("unique"))
+    private val sharedPredicateName = ScopedKotlinName(type.name.asScope(), PredicateKotlinName("shared"))
+    private val uniquePredicateName = ScopedKotlinName(type.name.asScope(), PredicateKotlinName("unique"))
 
     /**
      * Find an embedding of a backing field by this name amongst the ancestors of this type.
@@ -97,20 +98,20 @@ class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boole
     override fun uniquePredicateAccessInvariant() =
         PredicateAccessTypeInvariantEmbedding(uniquePredicateName, PermExp.FullPerm())
 
+    override fun subTypeInvariant(): TypeInvariantEmbedding = type.subTypeInvariant()
+
     // Returns the sequence of classes in a hierarchy that need to be unfolded in order to access the given field
     fun hierarchyUnfoldPath(field: FieldEmbedding): Sequence<ClassTypeEmbedding> = sequence {
-        val className = field.containingClass?.className
+        val className = field.containingClass?.name
         require(className != null) { "Cannot find hierarchy unfold path of a field with no class information" }
-        if (className == type.className) {
+        if (className == type.name) {
             yield(this@ClassEmbeddingDetails.type)
         } else {
-            val sup = superTypes.firstOrNull { it is ClassTypeEmbedding && !it.details.isInterface }
-            if (sup is ClassTypeEmbedding) {
-                yield(this@ClassEmbeddingDetails.type)
-                yieldAll(sup.details.hierarchyUnfoldPath(field))
-            } else {
-                throw IllegalArgumentException("Reached top of the hierarchy without finding the field")
-            }
+            val sup = classSuperTypes.firstOrNull { !it.details.isInterface }
+                ?: throw IllegalArgumentException("Reached top of the hierarchy without finding the field")
+
+            yield(this@ClassEmbeddingDetails.type)
+            yieldAll(sup.details.hierarchyUnfoldPath(field))
         }
     }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassEmbeddingDetails.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassEmbeddingDetails.kt
@@ -17,7 +17,7 @@ class ClassEmbeddingDetails(val type: ClassTypeEmbedding, val isInterface: Boole
         get() = _superTypes ?: error("Super types of ${type.name} have not been initialised yet.")
 
     private val classSuperTypes: List<ClassTypeEmbedding>
-        get() = superTypes.mapNotNull { it as? ClassTypeEmbedding }
+        get() = superTypes.filterIsInstance<ClassTypeEmbedding>()
 
     fun initSuperTypes(newSuperTypes: List<PretypeEmbedding>) {
         check(_superTypes == null) { "Super types of ${type.name} are already initialised." }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassPredicateBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassPredicateBuilder.kt
@@ -3,9 +3,11 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
 
 import org.jetbrains.kotlin.formver.conversion.AccessPolicy
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.UserFieldEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.linearization.pureToViper
 import org.jetbrains.kotlin.formver.names.DispatchReceiverName
@@ -15,7 +17,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Predicate
 import org.jetbrains.kotlin.utils.addIfNotNull
 
 internal class ClassPredicateBuilder private constructor(private val details: ClassEmbeddingDetails) {
-    private val subject = PlaceholderVariableEmbedding(DispatchReceiverName, details.type)
+    private val subject = PlaceholderVariableEmbedding(DispatchReceiverName, details.type.asTypeEmbedding())
     private val body = mutableListOf<ExpEmbedding>()
 
     companion object {
@@ -42,7 +44,7 @@ internal class ClassPredicateBuilder private constructor(private val details: Cl
 
     fun forEachSuperType(action: TypeInvariantsBuilder.() -> Unit) =
         details.superTypes.forEach { type ->
-            val builder = TypeInvariantsBuilder(type)
+            val builder = TypeInvariantsBuilder(type.asTypeEmbedding())
             builder.action()
             body.addAll(builder.toInvariantsList().fillHoles(subject))
         }
@@ -78,6 +80,6 @@ class TypeInvariantsBuilder(private val type: TypeEmbedding) {
     )
 
     fun includeSubTypeInvariants() = invariants.add(
-        type.subTypeInvariant()
+        SubTypeInvariantEmbedding(type)
     )
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassPredicateBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassPredicateBuilder.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.formver.embeddings.types
 
 import org.jetbrains.kotlin.formver.conversion.AccessPolicy
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.UserFieldEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.linearization.pureToViper

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassTypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassTypeEmbedding.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.types
+
+import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
+import org.jetbrains.kotlin.formver.names.NameMatcher
+import org.jetbrains.kotlin.formver.names.ScopedKotlinName
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+
+// TODO: incorporate generic parameters.
+data class ClassTypeEmbedding(override val name: ScopedKotlinName) : PretypeEmbedding {
+    private var _details: ClassEmbeddingDetails? = null
+    val details: ClassEmbeddingDetails
+        get() = _details ?: error("Details of $name have not been initialised yet.")
+
+    fun initDetails(details: ClassEmbeddingDetails) {
+        require(_details == null) { "Class details already initialized" }
+        _details = details
+    }
+
+    val hasDetails: Boolean
+        get() = _details != null
+
+    val runtimeTypeFunc = RuntimeTypeDomain.Companion.classTypeFunc(name)
+    override val runtimeType: Exp = runtimeTypeFunc()
+
+    override fun accessInvariants(): List<TypeInvariantEmbedding> = details.accessInvariants()
+
+    // Note: this function will replace accessInvariants when nested unfold will be implemented
+    override fun sharedPredicateAccessInvariant() = details.sharedPredicateAccessInvariant()
+
+    override fun uniquePredicateAccessInvariant() = details.uniquePredicateAccessInvariant()
+}
+
+fun PretypeEmbedding.isInheritorOfCollectionTypeNamed(name: String): Boolean {
+    val classEmbedding = this as? ClassTypeEmbedding ?: return false
+    return isCollectionTypeNamed(name) || classEmbedding.details.superTypes.any {
+        it.isInheritorOfCollectionTypeNamed(name)
+    }
+}
+
+val PretypeEmbedding.isCollectionInheritor
+    get() = isInheritorOfCollectionTypeNamed("Collection")
+
+private fun PretypeEmbedding.isCollectionTypeNamed(name: String): Boolean {
+    val classEmbedding = this as? ClassTypeEmbedding ?: return false
+    NameMatcher.Companion.matchGlobalScope(classEmbedding.name) {
+        ifInCollectionsPkg {
+            ifClassName(name) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/FunctionTypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/FunctionTypeEmbedding.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.formver.embeddings.types
 
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.names.PretypeName
 import org.jetbrains.kotlin.formver.viper.mangled
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/FunctionTypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/FunctionTypeEmbedding.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.types
+
+import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.names.PretypeName
+import org.jetbrains.kotlin.formver.viper.mangled
+
+data class FunctionTypeEmbedding(
+    val dispatchReceiverType: TypeEmbedding?,
+    val extensionReceiverType: TypeEmbedding?,
+    val paramTypes: List<TypeEmbedding>,
+    val returnType: TypeEmbedding,
+    val returnsUnique: Boolean,
+) : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.functionType()
+    override val name = PretypeName(formalArgTypes.joinToString("$") { it.name.mangled })
+
+    /**
+     * The flattened structure of the callable parameters: in case the callable has a receiver
+     * it becomes the first argument of the function.
+     *
+     * `Foo.(Int) -> Int --> (Foo, Int) -> Int`
+     */
+    val formalArgTypes: List<TypeEmbedding>
+        get() = listOfNotNull(dispatchReceiverType, extensionReceiverType) + paramTypes
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeBuilder.kt
@@ -3,8 +3,9 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
 
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 
 /**
@@ -17,27 +18,27 @@ interface PretypeBuilder {
      *
      * We allow this deferral so that the build can be done in any order.
      */
-    fun complete(): TypeEmbedding
+    fun complete(): PretypeEmbedding
 }
 
 object UnitPretypeBuilder : PretypeBuilder {
-    override fun complete(): TypeEmbedding = UnitTypeEmbedding
+    override fun complete() = UnitTypeEmbedding
 }
 
 object NothingPretypeBuilder : PretypeBuilder {
-    override fun complete(): TypeEmbedding = NothingTypeEmbedding
+    override fun complete() = NothingTypeEmbedding
 }
 
 object AnyPretypeBuilder : PretypeBuilder {
-    override fun complete(): TypeEmbedding = AnyTypeEmbedding
+    override fun complete() = AnyTypeEmbedding
 }
 
 object IntPretypeBuilder : PretypeBuilder {
-    override fun complete(): TypeEmbedding = IntTypeEmbedding
+    override fun complete() = IntTypeEmbedding
 }
 
 object BooleanPretypeBuilder : PretypeBuilder {
-    override fun complete(): TypeEmbedding = BooleanTypeEmbedding
+    override fun complete() = BooleanTypeEmbedding
 }
 
 class FunctionPretypeBuilder : PretypeBuilder {
@@ -66,11 +67,14 @@ class FunctionPretypeBuilder : PretypeBuilder {
         returnType = buildType { returnTypeInit() }
     }
 
-    override fun complete(): TypeEmbedding {
+    override fun complete(): FunctionTypeEmbedding {
         require(returnType != null) { "Return type not set" }
         return FunctionTypeEmbedding(dispatchReceiverType, extensionReceiverType, paramTypes, returnType!!, returnsUnique)
     }
 }
+
+fun buildFunctionPretype(init: FunctionPretypeBuilder.() -> Unit): FunctionTypeEmbedding =
+    FunctionPretypeBuilder().apply(init).complete()
 
 class ClassPretypeBuilder : PretypeBuilder {
     private var className: ScopedKotlinName? = null
@@ -80,13 +84,16 @@ class ClassPretypeBuilder : PretypeBuilder {
         className = name
     }
 
-    override fun complete(): TypeEmbedding {
+    override fun complete(): ClassTypeEmbedding {
         require(className != null) { "Class name not set" }
         return ClassTypeEmbedding(className!!)
     }
 }
 
+fun buildClassPretype(init: ClassPretypeBuilder.() -> Unit): ClassTypeEmbedding =
+    ClassPretypeBuilder().apply(init).complete()
+
 // TODO: ensure we can build the types with the builders, without hacks like this.
-class ExistingPretypeBuilder(val embedding: TypeEmbedding) : PretypeBuilder {
-    override fun complete(): TypeEmbedding = embedding
+class ExistingPretypeBuilder(val embedding: PretypeEmbedding) : PretypeBuilder {
+    override fun complete() = embedding
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeBuilder.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.formver.embeddings.types
 
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
 import org.jetbrains.kotlin.formver.names.ScopedKotlinName
 
 /**

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeEmbedding.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.formver.embeddings.types
 
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbeddingFlags
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.names.PretypeName
@@ -21,6 +19,8 @@ import org.jetbrains.kotlin.formver.viper.mangled
  * every `PretypeEmbedding` as a `TypeEmbedding`: the goal of the separation into types and pretypes is to avoid
  * one showing up where the other is expected.  For example, the naming systems are different, and the equality
  * comparisons would not work.
+ *
+ * All pretype embeddings must be `data` classes or objects!
  */
 interface PretypeEmbedding : RuntimeTypeHolder, TypeInvariantHolder {
     val name: MangledName
@@ -58,5 +58,5 @@ data object BooleanTypeEmbedding : PretypeEmbedding {
     override val name = PretypeName("Boolean")
 }
 
-fun PretypeEmbedding.asTypeEmbedding() = TypeEmbedding(this, TypeEmbeddingFlags(false))
+fun PretypeEmbedding.asTypeEmbedding() = TypeEmbedding(this, TypeEmbeddingFlags(nullable = false))
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeEmbedding.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.types
+
+import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbeddingFlags
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
+import org.jetbrains.kotlin.formver.names.PretypeName
+import org.jetbrains.kotlin.formver.viper.MangledName
+import org.jetbrains.kotlin.formver.viper.mangled
+
+/**
+ * A representation of a Kotlin type without nullability and uniqueness information.
+ *
+ * We explicitly choose not to make this a subtype of `TypeEmbedding`, even though there is a simple way of treating
+ * every `PretypeEmbedding` as a `TypeEmbedding`: the goal of the separation into types and pretypes is to avoid
+ * one showing up where the other is expected.  For example, the naming systems are different, and the equality
+ * comparisons would not work.
+ */
+interface PretypeEmbedding : RuntimeTypeHolder, TypeInvariantHolder {
+    val name: MangledName
+
+    override val debugTreeView: TreeView
+        get() = PlaintextLeaf(name.mangled)
+
+    override fun subTypeInvariant(): TypeInvariantEmbedding = SubTypeInvariantEmbedding(this)
+}
+
+data object UnitTypeEmbedding : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.unitType()
+    override val name = PretypeName("Unit")
+}
+
+data object NothingTypeEmbedding : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.nothingType()
+    override val name = PretypeName("Nothing")
+
+    override fun pureInvariants(): List<TypeInvariantEmbedding> = listOf(FalseTypeInvariant)
+}
+
+data object AnyTypeEmbedding : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.anyType()
+    override val name = PretypeName("Any")
+}
+
+data object IntTypeEmbedding : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.intType()
+    override val name = PretypeName("Int")
+}
+
+data object BooleanTypeEmbedding : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.boolType()
+    override val name = PretypeName("Boolean")
+}
+
+fun PretypeEmbedding.asTypeEmbedding() = TypeEmbedding(this, TypeEmbeddingFlags(false))
+

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/RuntimeTypeHolder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/RuntimeTypeHolder.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.types
+
+import org.jetbrains.kotlin.formver.embeddings.expression.debug.DebugPrintable
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+
+interface RuntimeTypeHolder : DebugPrintable {
+    /**
+     * A Viper expression with the runtime representation of the type.
+     *
+     * The Viper values are defined in RuntimeTypeDomain and are used for casting, subtyping and the `is` operator.
+     */
+    val runtimeType: Exp
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeBuilder.kt
@@ -3,7 +3,10 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
+
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.TypeEmbeddingFlags
 
 /**
  * Builder for a `TypeEmbedding`.
@@ -19,7 +22,7 @@ class TypeBuilder {
 
     private fun completeWithPretypeBuilder(subBuilder: PretypeBuilder): TypeEmbedding {
         val subResult = subBuilder.complete()
-        return if (isNullable) NullableTypeEmbedding(subResult) else subResult
+        return TypeEmbedding(subResult, TypeEmbeddingFlags(isNullable))
     }
 
     fun unit() = UnitPretypeBuilder
@@ -29,7 +32,7 @@ class TypeBuilder {
     fun boolean() = BooleanPretypeBuilder
     fun function(init: FunctionPretypeBuilder.() -> Unit) = FunctionPretypeBuilder().also { it.init() }
     fun klass(init: ClassPretypeBuilder.() -> Unit) = ClassPretypeBuilder().also { it.init() }
-    fun existing(embedding: TypeEmbedding) = ExistingPretypeBuilder(embedding)
+    fun existing(embedding: PretypeEmbedding) = ExistingPretypeBuilder(embedding)
 }
 
 fun TypeBuilder.nullableAny(): AnyPretypeBuilder {
@@ -40,7 +43,3 @@ fun TypeBuilder.nullableAny(): AnyPretypeBuilder {
 fun buildType(init: TypeBuilder.() -> PretypeBuilder): TypeEmbedding = TypeBuilder().complete(init)
 
 fun TypeEmbedding.equalToType(init: TypeBuilder.() -> PretypeBuilder) = equals(buildType { init() })
-
-fun buildFunctionType(init: FunctionPretypeBuilder.() -> Unit): FunctionTypeEmbedding =
-    buildType { function { init() } } as FunctionTypeEmbedding
-

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeBuilder.kt
@@ -5,8 +5,6 @@
 
 package org.jetbrains.kotlin.formver.embeddings.types
 
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbeddingFlags
 
 /**
  * Builder for a `TypeEmbedding`.

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeEmbedding.kt
@@ -3,20 +3,12 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
 
 import org.jetbrains.kotlin.formver.domains.Injection
 import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.TreeView
-import org.jetbrains.kotlin.formver.embeddings.types.BooleanTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.types.IfNonNullInvariant
-import org.jetbrains.kotlin.formver.embeddings.types.IntTypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.types.PretypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.types.RuntimeTypeHolder
-import org.jetbrains.kotlin.formver.embeddings.types.SubTypeInvariantEmbedding
-import org.jetbrains.kotlin.formver.embeddings.types.TypeInvariantEmbedding
-import org.jetbrains.kotlin.formver.embeddings.types.TypeInvariantHolder
 import org.jetbrains.kotlin.formver.names.*
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -26,8 +18,6 @@ import org.jetbrains.kotlin.formver.viper.mangled
  * Represents our representation of a Kotlin type.
  *
  * Due to name mangling, the mapping between Kotlin types and TypeEmbeddings must be 1:1.
- *
- * All type embeddings must be `data` classes or objects!
  */
 data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbeddingFlags) : RuntimeTypeHolder, TypeInvariantHolder {
     /**

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeInvariantEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeInvariantEmbedding.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
 
+import org.jetbrains.kotlin.formver.embeddings.FieldEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -25,7 +26,7 @@ data object FalseTypeInvariant : TypeInvariantEmbedding {
     override fun fillHole(exp: ExpEmbedding): ExpEmbedding = BooleanLit(false)
 }
 
-data class SubTypeInvariantEmbedding(val type: TypeEmbedding) : TypeInvariantEmbedding {
+data class SubTypeInvariantEmbedding(val type: RuntimeTypeHolder) : TypeInvariantEmbedding {
     override fun fillHole(exp: ExpEmbedding): ExpEmbedding = Is(exp, type)
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeInvariantHolder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeInvariantHolder.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
-package org.jetbrains.kotlin.formver.embeddings
+package org.jetbrains.kotlin.formver.embeddings.types
 
 /**
  * Representation of an entity that, in Viper, should have invariants associated with it.
@@ -23,4 +23,6 @@ interface TypeInvariantHolder {
      * once they have been established once.
      */
     fun pureInvariants(): List<TypeInvariantEmbedding> = emptyList()
+
+    fun subTypeInvariant(): TypeInvariantEmbedding
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.PretypeBuilder
 import org.jetbrains.kotlin.formver.embeddings.types.TypeBuilder

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -6,11 +6,11 @@
 package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.formver.embeddings.PretypeBuilder
-import org.jetbrains.kotlin.formver.embeddings.TypeBuilder
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
-import org.jetbrains.kotlin.formver.embeddings.buildType
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.PretypeBuilder
+import org.jetbrains.kotlin.formver.embeddings.types.TypeBuilder
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Label
 import org.jetbrains.kotlin.formver.viper.ast.Stmt

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.asPosition
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Position

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.debug.print

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SharedLinearizationState.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/SharedLinearizationState.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.linearization
 
 import org.jetbrains.kotlin.formver.conversion.FreshEntityProducer
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.AnonymousVariableEmbedding
 
 class SharedLinearizationState(private val producer: FreshEntityProducer<AnonymousVariableEmbedding, TypeEmbedding>) {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/FreshNames.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/FreshNames.kt
@@ -65,7 +65,3 @@ data class ContinueLabelName(val n: Int) : NumberedLabelName("continue", n)
 data class CatchLabelName(val n: Int) : NumberedLabelName("catch", n)
 data class TryExitLabelName(val n: Int) : NumberedLabelName("try_exit", n)
 
-data class TypeName(override val mangledBaseName: String) : MangledName {
-    override val mangledType: String
-        get() = "T"
-}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
@@ -6,6 +6,9 @@
 package org.jetbrains.kotlin.formver.names
 
 import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.PretypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.asTypeEmbedding
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.mangled
 import org.jetbrains.kotlin.name.FqName
@@ -31,7 +34,10 @@ abstract class TypedKotlinNameWithType(override val mangledType: String, name: N
     override val mangledBaseName: String = "${name.asStringStripSpecialMarkers()}\$${type.name.mangled}"
 }
 
-data class FunctionKotlinName(val name: Name, val type: TypeEmbedding) : TypedKotlinNameWithType("f", name, type)
+data class FunctionKotlinName(val name: Name, val type: FunctionTypeEmbedding) : TypedKotlinNameWithType(
+    "f", name,
+    type.asTypeEmbedding()
+)
 
 /**
  * This name will never occur in the viper output, but rather is used to lookup properties.
@@ -40,11 +46,11 @@ data class PropertyKotlinName(val name: Name) : TypedKotlinName("pp", name)
 data class BackingFieldKotlinName(val name: Name) : TypedKotlinName("bf", name)
 data class GetterKotlinName(val name: Name) : TypedKotlinName("pg", name)
 data class SetterKotlinName(val name: Name) : TypedKotlinName("ps", name)
-data class ExtensionSetterKotlinName(val name: Name, val type: TypeEmbedding) :
-    TypedKotlinNameWithType("es", name, type)
+data class ExtensionSetterKotlinName(val name: Name, val type: FunctionTypeEmbedding) :
+    TypedKotlinNameWithType("es", name, type.asTypeEmbedding())
 
-data class ExtensionGetterKotlinName(val name: Name, val type: TypeEmbedding) :
-    TypedKotlinNameWithType("eg", name, type)
+data class ExtensionGetterKotlinName(val name: Name, val type: FunctionTypeEmbedding) :
+    TypedKotlinNameWithType("eg", name, type.asTypeEmbedding())
 
 data class ClassKotlinName(val name: FqName) : KotlinName {
     override val mangledType: String
@@ -54,7 +60,7 @@ data class ClassKotlinName(val name: FqName) : KotlinName {
     constructor(classSegments: List<String>) : this(FqName.fromSegments(classSegments))
 }
 
-data class ConstructorKotlinName(val type: TypeEmbedding) : KotlinName {
+data class ConstructorKotlinName(val type: FunctionTypeEmbedding) : KotlinName {
     override val mangledType: String
         get() = "con"
     override val mangledBaseName: String
@@ -66,4 +72,13 @@ data class ConstructorKotlinName(val type: TypeEmbedding) : KotlinName {
 data class PredicateKotlinName(override val mangledBaseName: String) : KotlinName {
     override val mangledType: String
         get() = "p"
+}
+
+data class PretypeName(override val mangledBaseName: String) : KotlinName
+
+data class TypeName(val pretype: PretypeEmbedding, val nullable: Boolean) : KotlinName {
+    override val mangledBaseName: String
+        get() = pretype.name.mangledBaseName
+    override val mangledType: String
+        get() = listOfNotNull(if (nullable) "N" else null, "T", if (pretype is FunctionTypeEmbedding) "F" else null).joinToString("")
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/KotlinName.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.formver.names
 
-import org.jetbrains.kotlin.formver.embeddings.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.PretypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.asTypeEmbedding

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/as_type_contract.fir.diag.txt
@@ -4,15 +4,15 @@ field bf$x: Ref
 method f$getX$TF$T$Any(p$a: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue() ==>
-    !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$T$c$IntHolder())
+    !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
-  if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$T$c$IntHolder())) {
+  if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())) {
     anon$0 := p$a
   } else {
     anon$0 := df$rt$nullValue()}
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$T$c$IntHolder()))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$c$IntHolder()))
   inhale anon$0 != df$rt$nullValue() ==>
     acc(p$c$IntHolder$shared(anon$0), wildcard)
   if (anon$0 != df$rt$nullValue()) {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
@@ -1,8 +1,7 @@
 /binary_search.kt:(90,110): info: Generated Viper text for mid_increased_by_one:
 field sp$size: Ref
 
-method f$mid_increased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
-  p$target: Ref)
+method f$mid_increased_by_one$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -15,7 +14,7 @@ method f$mid_increased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Re
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
@@ -25,31 +24,27 @@ method f$mid_increased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Re
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
   anon$0 := sp$divInts(anon$1, df$rt$intToRef(2))
   l0$mid := sp$plusInts(anon$0, df$rt$intToRef(1))
-  anon$2 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(p$arr)
+  anon$2 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
   if (df$rt$boolFromRef(anon$2)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$3: Ref
-    anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-      l0$mid)
+    anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
     if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(p$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$4: Ref
-      anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-        l0$mid)
+      anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
       if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(p$target)) {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_increased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$5,
-          p$target)
+        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int(anon$5, p$target)
       } else {
         var anon$6: Ref
-        anon$6 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$6 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$mid_increased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$6,
-          p$target)
+        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int(anon$6, p$target)
       }
     }
   }
@@ -57,7 +52,7 @@ method f$mid_increased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Re
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -72,7 +67,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -87,7 +82,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
   p$fromIndex: Ref, p$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -98,7 +93,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -113,8 +108,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
 /binary_search.kt:(511,531): info: Generated Viper text for mid_decreased_by_one:
 field sp$size: Ref
 
-method f$mid_decreased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
-  p$target: Ref)
+method f$mid_decreased_by_one$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -127,7 +121,7 @@ method f$mid_decreased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Re
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
@@ -137,31 +131,27 @@ method f$mid_decreased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Re
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
   anon$0 := sp$divInts(anon$1, df$rt$intToRef(2))
   l0$mid := sp$minusInts(anon$0, df$rt$intToRef(1))
-  anon$2 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(p$arr)
+  anon$2 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
   if (df$rt$boolFromRef(anon$2)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$3: Ref
-    anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-      l0$mid)
+    anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
     if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(p$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$4: Ref
-      anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-        l0$mid)
+      anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
       if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(p$target)) {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_decreased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$5,
-          p$target)
+        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int(anon$5, p$target)
       } else {
         var anon$6: Ref
-        anon$6 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$6 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$mid_decreased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$6,
-          p$target)
+        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int(anon$6, p$target)
       }
     }
   }
@@ -169,7 +159,7 @@ method f$mid_decreased_by_one$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Re
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -184,7 +174,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -199,7 +189,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
   p$fromIndex: Ref, p$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -210,7 +200,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -225,8 +215,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
 /binary_search.kt:(932,964): info: Generated Viper text for mid_decreased_by_one_in_rec_call:
 field sp$size: Ref
 
-method f$mid_decreased_by_one_in_rec_call$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
-  p$target: Ref)
+method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -238,7 +227,7 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$c$pkg$kotlin_collections$List$T$I
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
@@ -247,30 +236,28 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$c$pkg$kotlin_collections$List$T$I
   anon$0 := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$divInts(anon$0, df$rt$intToRef(2))
-  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(p$arr)
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
   if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-      l0$mid)
+    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
     if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$3: Ref
-      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-        l0$mid)
+      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
       if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
         var anon$4: Ref
-        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_decreased_by_one_in_rec_call$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$4,
+        ret$0 := f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int(anon$4,
           p$target)
       } else {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           df$rt$intToRef(0), sp$minusInts(l0$mid, df$rt$intToRef(1)))
-        ret$0 := f$mid_decreased_by_one_in_rec_call$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$5,
+        ret$0 := f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int(anon$5,
           p$target)
       }
     }
@@ -279,7 +266,7 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$c$pkg$kotlin_collections$List$T$I
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -294,7 +281,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -309,7 +296,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
   p$fromIndex: Ref, p$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -320,7 +307,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -335,7 +322,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
 /binary_search.kt:(1405,1425): info: Generated Viper text for unsafe_binary_search:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -350,8 +337,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$unsafe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$Int(p$arr: Ref,
-  p$target: Ref, p$left: Ref, p$right: Ref)
+method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int(p$arr: Ref, p$target: Ref,
+  p$left: Ref, p$right: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -362,7 +349,7 @@ method f$unsafe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$I
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
@@ -374,20 +361,18 @@ method f$unsafe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$I
   inhale 2 != 0
   anon$0 := sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2))
   l0$mid := sp$plusInts(p$left, anon$0)
-  anon$1 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-    l0$mid)
+  anon$1 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
   if (df$rt$intFromRef(anon$1) == df$rt$intFromRef(p$target)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-      l0$mid)
+    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
     if (df$rt$intFromRef(anon$2) < df$rt$intFromRef(p$target)) {
-      ret$0 := f$unsafe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$Int(p$arr,
-        p$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
+      ret$0 := f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int(p$arr, p$target,
+        sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
     } else {
-      ret$0 := f$unsafe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$Int(p$arr,
-        p$target, p$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
+      ret$0 := f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int(p$arr, p$target,
+        p$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
   }
   goto lbl$ret$0
   label lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
@@ -12,7 +12,7 @@ method f$compoundConditionalEffect$TF$T$Boolean(p$b: Ref)
 /cond_effects.kt:(190,220): warning: Cannot verify that if the function returns then (b && false).
 
 /cond_effects.kt:(271,287): info: Generated Viper text for mayReturnNonNull:
-method f$mayReturnNonNull$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$mayReturnNonNull$TF$NT$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 == df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
@@ -26,7 +26,7 @@ method f$mayReturnNonNull$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(328,360): warning: Cannot verify that if a null value is returned then x is Int.
 
 /cond_effects.kt:(424,437): info: Generated Viper text for mayReturnNull:
-method f$mayReturnNull$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$mayReturnNull$TF$NT$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
@@ -40,12 +40,12 @@ method f$mayReturnNull$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(478,513): warning: Cannot verify that if a non-null value is returned then x is Int.
 
 /cond_effects.kt:(723,741): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
+method f$isNullOrEmptyWrong$TF$NT$CharSequence(p$seq: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==> p$seq != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$T$c$pkg$kotlin$CharSequence()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   inhale p$seq != df$rt$nullValue() ==>
     acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   if (!(p$seq == df$rt$nullValue())) {
@@ -69,18 +69,18 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /cond_effects.kt:(925,942): info: Generated Viper text for recursiveContract:
 field bf$length: Ref
 
-method f$recursiveContract$TF$T$Int$N$Any(p$n: Ref, p$x: Ref)
+method f$recursiveContract$TF$T$Int$NT$Any(p$n: Ref, p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$pkg$kotlin$String())
+    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$pkg$kotlin$String())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   if (df$rt$intFromRef(p$n) == 0) {
     ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
   } else {
-    ret$0 := f$recursiveContract$TF$T$Int$N$Any(sp$minusInts(p$n, df$rt$intToRef(1)),
+    ret$0 := f$recursiveContract$TF$T$Int$NT$Any(sp$minusInts(p$n, df$rt$intToRef(1)),
       p$x)}
   goto lbl$ret$0
   label lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/contracts_with_receivers.fir.diag.txt
@@ -1,12 +1,12 @@
 /contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
-method f$c$Class$is2$TF$T$c$Class(this$dispatch: Ref) returns (ret$0: Ref)
+method f$c$Class$is2$TF$T$Class(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl1())
+    df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl1())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl2()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -14,18 +14,17 @@ method f$c$Class$is2$TF$T$c$Class(this$dispatch: Ref) returns (ret$0: Ref)
 /contracts_with_receivers.kt:(196,239): warning: Cannot verify that if a true value is returned then this is Impl1.
 
 /contracts_with_receivers.kt:(341,359): info: Generated Viper text for is1butWithDispatch:
-method f$c$Class$is1butWithDispatch$TF$T$c$Class$T$c$Class(this$dispatch: Ref,
-  this$extension: Ref)
+method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class(this$dispatch: Ref, this$extension: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl2())
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -33,14 +32,14 @@ method f$c$Class$is1butWithDispatch$TF$T$c$Class$T$c$Class(this$dispatch: Ref,
 /contracts_with_receivers.kt:(404,460): warning: Cannot verify that if a true value is returned then this is Impl2.
 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
-method f$is1$TF$T$c$Class(this$extension: Ref) returns (ret$0: Ref)
+method f$is1$TF$T$Class(this$extension: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl2())
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -1,12 +1,12 @@
 /is_type_contract.kt:(151,172): info: Generated Viper text for unverifiableTypeCheck:
 field bf$length: Ref
 
-method f$unverifiableTypeCheck$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$unverifiableTypeCheck$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$pkg$kotlin$String()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$pkg$kotlin$String()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -17,7 +17,7 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /is_type_contract.kt:(216,245): warning: Cannot verify that if the function returns then x is Unit.
 
 /is_type_contract.kt:(319,341): info: Generated Viper text for nullableNotNonNullable:
-method f$nullableNotNonNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$nullableNotNonNullable$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
 {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/list.fir.diag.txt
@@ -7,13 +7,12 @@ method f$empty_list_expr_get$TF$() returns (ret$0: Ref)
   var l0$s: Ref
   var anon$0: Ref
   anon$0 := f$pkg$kotlin_collections$emptyList$TF$()
-  l0$s := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$0,
-    df$rt$intToRef(0))
+  l0$s := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(anon$0, df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -29,7 +28,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
 
 
 method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -47,13 +46,12 @@ method f$empty_list_get$TF$() returns (ret$0: Ref)
   var l0$myList: Ref
   var l0$s: Ref
   l0$myList := f$pkg$kotlin_collections$emptyList$TF$()
-  l0$s := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(l0$myList,
-    df$rt$intToRef(0))
+  l0$s := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(l0$myList, df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -69,7 +67,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
 
 
 method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -81,7 +79,7 @@ method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
 /list.kt:(270,281): info: Generated Viper text for unsafe_last:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -96,8 +94,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$unsafe_last$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
-  returns (ret$0: Ref)
+method f$unsafe_last$TF$T$List(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   ensures acc(p$l.sp$size, write)
@@ -105,12 +102,12 @@ method f$unsafe_last$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   anon$0 := p$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
-  ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$l,
-    sp$minusInts(anon$0, df$rt$intToRef(1)))
+  ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$l, sp$minusInts(anon$0,
+    df$rt$intToRef(1)))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -120,8 +117,7 @@ method f$unsafe_last$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
 /list.kt:(350,357): info: Generated Viper text for add_get:
 field sp$size: Ref
 
-method f$add_get$TF$T$c$pkg$kotlin_collections$MutableList(p$l: Ref)
-  returns (ret$0: Ref)
+method f$add_get$TF$T$MutableList(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   ensures acc(p$l.sp$size, write)
@@ -130,17 +126,17 @@ method f$add_get$TF$T$c$pkg$kotlin_collections$MutableList(p$l: Ref)
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$T$c$pkg$kotlin_collections$MutableList())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
   inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
-  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(p$l,
+  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int(p$l,
     df$rt$intToRef(1))
-  l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(p$l,
+  l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int(p$l,
     df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$MutableList$add$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int(this$dispatch: Ref,
   p$element: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -152,7 +148,7 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$c$pkg$kotlin_collections$
     old(df$rt$intFromRef(this$dispatch.sp$size)) + 1
 
 
-method f$pkg$kotlin_collections$c$MutableList$get$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -178,13 +174,13 @@ method f$empty_list_sub$TF$() returns (ret$0: Ref)
   var l0$l: Ref
   var anon$0: Ref
   anon$0 := f$pkg$kotlin_collections$emptyList$TF$()
-  l0$l := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(anon$0,
+  l0$l := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(anon$0,
     df$rt$intToRef(0), df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
   p$fromIndex: Ref, p$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -195,7 +191,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -206,7 +202,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
 
 
 method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -224,13 +220,13 @@ method f$empty_list_sub_negative$TF$() returns (ret$0: Ref)
   var l0$l: Ref
   var anon$0: Ref
   anon$0 := f$pkg$kotlin_collections$emptyList$TF$()
-  l0$l := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(anon$0,
+  l0$l := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(anon$0,
     df$rt$intToRef(-1), df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
   p$fromIndex: Ref, p$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -241,7 +237,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -252,7 +248,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
 
 
 method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_null.kt:(121,146): info: Generated Viper text for returns_null_unverifiable:
-method f$returns_null_unverifiable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$returns_null_unverifiable$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures true ==> false
 {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/as_type_contract.fir.diag.txt
@@ -1,12 +1,12 @@
 /as_type_contract.kt:(152,162): info: Generated Viper text for asOperator:
-method f$asOperator$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Bar())
+method f$asOperator$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret$0), wildcard)
-  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Bar())
+  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$foo), wildcard)
   ret$0 := p$foo
   goto lbl$ret$0
@@ -14,16 +14,16 @@ method f$asOperator$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_type_contract.kt:(307,321): info: Generated Viper text for safeAsOperator:
-method f$safeAsOperator$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
+method f$safeAsOperator$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==>
-    df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Bar())
+    df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Bar()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(p$foo), wildcard)
   ret$0 := p$foo
@@ -37,17 +37,17 @@ field bf$x: Ref
 method f$getX$TF$T$Any(p$a: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue() ==>
-    df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$T$c$IntHolder())
+    df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
   ensures ret$0 == df$rt$nullValue() ==>
-    !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$T$c$IntHolder())
+    !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
-  if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$T$c$IntHolder())) {
+  if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())) {
     anon$0 := p$a
   } else {
     anon$0 := df$rt$nullValue()}
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$T$c$IntHolder()))
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$c$IntHolder()))
   inhale anon$0 != df$rt$nullValue() ==>
     acc(p$c$IntHolder$shared(anon$0), wildcard)
   if (anon$0 != df$rt$nullValue()) {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/backing_field_getters.fir.diag.txt
@@ -3,13 +3,13 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeGet$TF$T$c$X(p$x: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Z())
+method f$cascadeGet$TF$T$X(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Z())
   ensures acc(p$c$Z$shared(ret$0), wildcard)
   ensures true
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$X())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
   inhale acc(p$c$X$shared(p$x), wildcard)
   unfold acc(p$c$X$shared(p$x), wildcard)
   anon$0 := p$x.bf$y
@@ -24,12 +24,12 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$receiverNotNullProved$TF$N$c$X(p$x: Ref) returns (ret$0: Ref)
+method f$receiverNotNullProved$TF$NT$X(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> p$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$T$c$X()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$X()))
   inhale p$x != df$rt$nullValue() ==> acc(p$c$X$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
     var anon$1: Ref
@@ -48,13 +48,13 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableGet$TF$N$c$NullableX(p$x: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
+method f$cascadeNullableGet$TF$NT$NullableX(p$x: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$T$c$NullableX()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
   inhale p$x != df$rt$nullValue() ==>
     acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
@@ -76,13 +76,13 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableSmartcastGet$TF$N$c$NullableX(p$x: Ref)
+method f$cascadeNullableSmartcastGet$TF$NT$NullableX(p$x: Ref)
   returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Z()))
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$T$c$NullableX()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
   inhale p$x != df$rt$nullValue() ==>
     acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x == df$rt$nullValue()) {
@@ -113,7 +113,7 @@ method f$cascadeNullableSmartcastGet$TF$N$c$NullableX(p$x: Ref)
 field bf$x: Ref
 
 method con$c$Baz$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Baz())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Baz())
   ensures acc(p$c$Baz$shared(ret), wildcard)
   ensures acc(p$c$Baz$unique(ret), write)
 
@@ -165,7 +165,7 @@ method f$nullableReceiverNullSafeGet$TF$() returns (ret$0: Ref)
 field bf$x: Ref
 
 method con$c$Baz$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Baz())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Baz())
   ensures acc(p$c$Baz$shared(ret), wildcard)
   ensures acc(p$c$Baz$unique(ret), write)
 
@@ -197,7 +197,7 @@ field bf$y: Ref
 field bf$z: Ref
 
 method con$c$ClassI$T$Int$T$Int(p$x: Ref, p$y: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$ClassI())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassI())
   ensures acc(p$c$ClassI$shared(ret), wildcard)
   ensures acc(p$c$ClassI$unique(ret), write)
   ensures (unfolding acc(p$c$ClassI$shared(ret), wildcard) in
@@ -205,8 +205,8 @@ method con$c$ClassI$T$Int$T$Int(p$x: Ref, p$y: Ref) returns (ret: Ref)
       df$rt$intFromRef(ret.bf$y) == df$rt$intFromRef(p$y))
 
 
-method con$c$ClassII$T$c$Z(p$z: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$ClassII())
+method con$c$ClassII$T$Z(p$z: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassII())
   ensures acc(p$c$ClassII$shared(ret), wildcard)
   ensures acc(p$c$ClassII$unique(ret), write)
   ensures (unfolding acc(p$c$ClassII$shared(ret), wildcard) in
@@ -214,7 +214,7 @@ method con$c$ClassII$T$c$Z(p$z: Ref) returns (ret: Ref)
 
 
 method con$c$Z$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Z())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Z())
   ensures acc(p$c$Z$shared(ret), wildcard)
   ensures acc(p$c$Z$unique(ret), write)
 
@@ -246,7 +246,7 @@ method f$checkPrimary$TF$T$Int$T$Int(p$x: Ref, p$y: Ref)
   if (df$rt$boolFromRef(anon$0)) {
     var anon$3: Ref
     var anon$4: Ref
-    anon$4 := con$c$ClassII$T$c$Z(l0$z)
+    anon$4 := con$c$ClassII$T$Z(l0$z)
     unfold acc(p$c$ClassII$shared(anon$4), wildcard)
     anon$3 := anon$4.bf$z
     ret$0 := df$rt$boolToRef(anon$3 == l0$z)

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/binary_search.fir.diag.txt
@@ -1,7 +1,7 @@
 /binary_search.kt:(90,108): info: Generated Viper text for safe_binary_search:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -16,7 +16,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -31,7 +31,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
   p$fromIndex: Ref, p$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -42,7 +42,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -52,8 +52,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$Lis
     df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
 
 
-method f$safe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
-  p$target: Ref)
+method f$safe_binary_search$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -65,7 +64,7 @@ method f$safe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
@@ -74,31 +73,27 @@ method f$safe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
   anon$0 := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$divInts(anon$0, df$rt$intToRef(2))
-  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(p$arr)
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
   if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-      l0$mid)
+    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
     if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$3: Ref
-      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-        l0$mid)
+      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
       if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
         var anon$4: Ref
-        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$safe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$4,
-          p$target)
+        ret$0 := f$safe_binary_search$TF$T$List$T$Int(anon$4, p$target)
       } else {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$safe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int(anon$5,
-          p$target)
+        ret$0 := f$safe_binary_search$TF$T$List$T$Int(anon$5, p$target)
       }
     }
   }
@@ -109,7 +104,7 @@ method f$safe_binary_search$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr: Ref,
 /binary_search.kt:(537,563): info: Generated Viper text for unsafe_binary_search_fixed:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -124,7 +119,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$unsafe_binary_search_fixed$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$Int(p$arr: Ref,
+method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int(p$arr: Ref,
   p$target: Ref, p$left: Ref, p$right: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
@@ -138,7 +133,7 @@ method f$unsafe_binary_search_fixed$TF$T$c$pkg$kotlin_collections$List$T$Int$T$I
   var l0$mid: Ref
   var anon$3: Ref
   var anon$4: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
@@ -162,19 +157,17 @@ method f$unsafe_binary_search_fixed$TF$T$c$pkg$kotlin_collections$List$T$Int$T$I
   inhale 2 != 0
   anon$3 := sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2))
   l0$mid := sp$plusInts(p$left, anon$3)
-  anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-    l0$mid)
+  anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
   if (df$rt$intFromRef(anon$4) == df$rt$intFromRef(p$target)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
     var anon$5: Ref
-    anon$5 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$arr,
-      l0$mid)
+    anon$5 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
     if (df$rt$intFromRef(anon$5) < df$rt$intFromRef(p$target)) {
-      ret$0 := f$unsafe_binary_search_fixed$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$Int(p$arr,
+      ret$0 := f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int(p$arr,
         p$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
     } else {
-      ret$0 := f$unsafe_binary_search_fixed$TF$T$c$pkg$kotlin_collections$List$T$Int$T$Int$T$Int(p$arr,
+      ret$0 := f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int(p$arr,
         p$target, p$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
   }
   goto lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/contracts_with_receivers.fir.diag.txt
@@ -1,42 +1,41 @@
 /contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
-method f$c$Class$is2$TF$T$c$Class(this$dispatch: Ref) returns (ret$0: Ref)
+method f$c$Class$is2$TF$T$Class(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl2())
+    df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Impl2()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /contracts_with_receivers.kt:(341,359): info: Generated Viper text for is1butWithDispatch:
-method f$c$Class$is1butWithDispatch$TF$T$c$Class$T$c$Class(this$dispatch: Ref,
-  this$extension: Ref)
+method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class(this$dispatch: Ref, this$extension: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1())
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
-method f$is1$TF$T$c$Class(this$extension: Ref) returns (ret$0: Ref)
+method f$is1$TF$T$Class(this$extension: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1())
+    df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Class())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$Impl1()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/custom_list.fir.diag.txt
@@ -3,7 +3,7 @@ field bf$c$CustomList$private$value: Ref
 
 field sp$size: Ref
 
-method f$c$CustomList$get$TF$T$c$CustomList$T$Int(this$dispatch: Ref, p$index: Ref)
+method f$c$CustomList$get$TF$T$CustomList$T$Int(this$dispatch: Ref, p$index: Ref)
   returns (ret$0: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -16,7 +16,7 @@ method f$c$CustomList$get$TF$T$c$CustomList$T$Int(this$dispatch: Ref, p$index: R
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$CustomList())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
   inhale acc(p$c$CustomList$shared(this$dispatch), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   unfold acc(p$c$CustomList$shared(this$dispatch), wildcard)
@@ -32,14 +32,14 @@ field sp$size: Ref
 
 method con$c$CustomList$T$Int$T$Int(p$size: Ref, p$value: Ref)
   returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$CustomList())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CustomList())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$c$CustomList$shared(ret), wildcard)
   ensures acc(p$c$CustomList$unique(ret), write)
 
 
-method f$c$CustomList$get$TF$T$c$CustomList$T$Int(this$dispatch: Ref, p$index: Ref)
+method f$c$CustomList$get$TF$T$CustomList$T$Int(this$dispatch: Ref, p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -53,7 +53,7 @@ method f$c$CustomList$get$TF$T$c$CustomList$T$Int(this$dispatch: Ref, p$index: R
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$c$CustomList$isEmpty$TF$T$c$CustomList(this$dispatch: Ref)
+method f$c$CustomList$isEmpty$TF$T$CustomList(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -75,16 +75,16 @@ method f$test$TF$T$Int(p$n: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   l0$customList := con$c$CustomList$T$Int$T$Int(p$n, df$rt$intToRef(0))
-  anon$0 := f$c$CustomList$isEmpty$TF$T$c$CustomList(l0$customList)
+  anon$0 := f$c$CustomList$isEmpty$TF$T$CustomList(l0$customList)
   if (!df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     var anon$2: Ref
     var anon$3: Ref
     anon$2 := l0$customList.sp$size
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-    anon$1 := f$c$CustomList$get$TF$T$c$CustomList$T$Int(l0$customList, sp$minusInts(anon$2,
+    anon$1 := f$c$CustomList$get$TF$T$CustomList$T$Int(l0$customList, sp$minusInts(anon$2,
       df$rt$intToRef(1)))
-    anon$3 := f$c$CustomList$get$TF$T$c$CustomList$T$Int(l0$customList, df$rt$intToRef(0))
+    anon$3 := f$c$CustomList$get$TF$T$CustomList$T$Int(l0$customList, df$rt$intToRef(0))
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/custom_run_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/custom_run_functions.fir.diag.txt
@@ -516,7 +516,7 @@ method f$complexScenario$TF$T$Boolean(p$arg: Ref) returns (ret$0: Ref)
 field bf$member: Ref
 
 method con$c$CustomClass$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$CustomClass())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CustomClass())
   ensures acc(p$c$CustomClass$shared(ret), wildcard)
   ensures acc(p$c$CustomClass$unique(ret), write)
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/is_type_contract.fir.diag.txt
@@ -1,13 +1,13 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
 field bf$length: Ref
 
-method f$isString$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$isString$TF$NT$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$pkg$kotlin$String())
+    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$pkg$kotlin$String())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$pkg$kotlin$String()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$pkg$kotlin$String()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -21,10 +21,10 @@ field bf$length: Ref
 method f$isString$TF$T$Any(p$obj: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$T$c$pkg$kotlin$String())
+    df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$pkg$kotlin$String())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$anyType())
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$T$c$pkg$kotlin$String()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$pkg$kotlin$String()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -47,7 +47,7 @@ method f$subtypeTransitive$TF$T$Unit(p$x: Ref) returns (ret$0: Ref)
 field bf$bar: Ref
 
 method con$c$Foo$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)
 
@@ -58,7 +58,7 @@ method f$constructorReturnType$TF$() returns (ret$0: Ref)
 {
   var anon$0: Ref
   anon$0 := con$c$Foo$()
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$Foo()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Foo()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -66,11 +66,11 @@ method f$constructorReturnType$TF$() returns (ret$0: Ref)
 /is_type_contract.kt:(1016,1032): info: Generated Viper text for subtypeSuperType:
 field bf$bar: Ref
 
-method f$subtypeSuperType$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
+method f$subtypeSuperType$TF$T$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
-  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Foo())
+  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Foo())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -79,16 +79,16 @@ method f$subtypeSuperType$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
 /is_type_contract.kt:(1149,1160): info: Generated Viper text for typeOfField:
 field bf$bar: Ref
 
-method f$typeOfField$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$typeOfField$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   unfold acc(p$c$Foo$shared(p$foo), wildcard)
   anon$0 := p$foo.bf$bar
-  if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$Bar())) {
+  if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar())) {
     ret$0 := df$rt$boolToRef(true)
     goto lbl$ret$0
   } else {

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/list.fir.diag.txt
@@ -14,8 +14,7 @@ method f$declaration$TF$() returns (ret$0: Ref)
 /list.kt:(187,201): info: Generated Viper text for initialization:
 field sp$size: Ref
 
-method f$initialization$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
-  returns (ret$0: Ref)
+method f$initialization$TF$T$List(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   ensures acc(p$l.sp$size, write)
@@ -24,7 +23,7 @@ method f$initialization$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
 {
   var l0$myList: Ref
   var l0$myEmptyList: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   l0$myList := p$l
   l0$myEmptyList := f$pkg$kotlin_collections$emptyList$TF$()
@@ -33,7 +32,7 @@ method f$initialization$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
 }
 
 method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$pkg$kotlin_collections$List())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
   ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
@@ -43,8 +42,7 @@ method f$pkg$kotlin_collections$emptyList$TF$() returns (ret: Ref)
 /list.kt:(297,304): info: Generated Viper text for add_get:
 field sp$size: Ref
 
-method f$add_get$TF$T$c$pkg$kotlin_collections$MutableList(p$l: Ref)
-  returns (ret$0: Ref)
+method f$add_get$TF$T$MutableList(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   ensures acc(p$l.sp$size, write)
@@ -53,17 +51,17 @@ method f$add_get$TF$T$c$pkg$kotlin_collections$MutableList(p$l: Ref)
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$T$c$pkg$kotlin_collections$MutableList())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
   inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
-  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(p$l,
+  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int(p$l,
     df$rt$intToRef(1))
-  l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(p$l,
+  l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int(p$l,
     df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$MutableList$add$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int(this$dispatch: Ref,
   p$element: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -75,7 +73,7 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$c$pkg$kotlin_collections$
     old(df$rt$intFromRef(this$dispatch.sp$size)) + 1
 
 
-method f$pkg$kotlin_collections$c$MutableList$get$TF$T$c$pkg$kotlin_collections$MutableList$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -93,8 +91,7 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$c$pkg$kotlin_collections$
 /list.kt:(379,391): info: Generated Viper text for last_or_null:
 field sp$size: Ref
 
-method f$last_or_null$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
-  returns (ret$0: Ref)
+method f$last_or_null$TF$T$List(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   ensures acc(p$l.sp$size, write)
@@ -102,14 +99,14 @@ method f$last_or_null$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$size: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   l0$size := p$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   if (!(df$rt$intFromRef(l0$size) == 0)) {
     var anon$0: Ref
-    anon$0 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$l,
-      sp$minusInts(l0$size, df$rt$intToRef(1)))
+    anon$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$l, sp$minusInts(l0$size,
+      df$rt$intToRef(1)))
     ret$0 := anon$0
     goto lbl$ret$0
   } else {
@@ -119,7 +116,7 @@ method f$last_or_null$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -137,8 +134,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
 /list.kt:(545,553): info: Generated Viper text for is_empty:
 field sp$size: Ref
 
-method f$is_empty$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
-  returns (ret$0: Ref)
+method f$is_empty$TF$T$List(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   ensures acc(p$l.sp$size, write)
@@ -146,19 +142,18 @@ method f$is_empty$TF$T$c$pkg$kotlin_collections$List(p$l: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$T$c$pkg$kotlin_collections$List())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
-  anon$0 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(p$l)
+  anon$0 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$l)
   if (!df$rt$boolFromRef(anon$0)) {
-    ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$l,
-      df$rt$intToRef(0))
+    ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$l, df$rt$intToRef(0))
   } else {
     ret$0 := df$rt$intToRef(1)}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -173,7 +168,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -191,8 +186,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$Lis
 /list.kt:(670,683): info: Generated Viper text for nullable_list:
 field sp$size: Ref
 
-method f$nullable_list$TF$N$c$pkg$kotlin_collections$List(p$l: Ref)
-  returns (ret$0: Ref)
+method f$nullable_list$TF$NT$List(p$l: Ref) returns (ret$0: Ref)
   requires p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   requires p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
   ensures p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
@@ -200,12 +194,12 @@ method f$nullable_list$TF$N$c$pkg$kotlin_collections$List(p$l: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$nullable(df$rt$T$c$pkg$kotlin_collections$List()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$nullable(df$rt$c$pkg$kotlin_collections$List()))
   inhale p$l != df$rt$nullValue() ==>
     acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   if (!(p$l == df$rt$nullValue())) {
     var anon$1: Ref
-    anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(p$l)
+    anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$l)
     anon$0 := sp$notBool(anon$1)
   } else {
     anon$0 := df$rt$boolToRef(false)}
@@ -214,14 +208,14 @@ method f$nullable_list$TF$N$c$pkg$kotlin_collections$List(p$l: Ref)
     var anon$2: Ref
     anon$2 := p$l.sp$size
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-    l2$x := f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(p$l,
-      sp$minusInts(anon$2, df$rt$intToRef(1)))
+    l2$x := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$l, sp$minusInts(anon$2,
+      df$rt$intToRef(1)))
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$Int(this$dispatch: Ref,
+method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(this$dispatch: Ref,
   p$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
@@ -236,7 +230,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$c$pkg$kotlin_collections$List$T$
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$c$pkg$kotlin_collections$List(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_interfaces.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_interfaces.fir.diag.txt
@@ -1,11 +1,11 @@
 /multiple_interfaces.kt:(826,831): info: Generated Viper text for take1:
-method f$take1$TF$T$c$InterfaceWithImplementation1(p$obj: Ref)
+method f$take1$TF$T$InterfaceWithImplementation1(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$T$c$InterfaceWithImplementation1())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
   inhale acc(p$c$InterfaceWithImplementation1$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
@@ -18,13 +18,13 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(890,895): info: Generated Viper text for take2:
-method f$take2$TF$T$c$InterfaceWithoutImplementation2(p$obj: Ref)
+method f$take2$TF$T$InterfaceWithoutImplementation2(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$T$c$InterfaceWithoutImplementation2())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
   inhale acc(p$c$InterfaceWithoutImplementation2$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
@@ -39,24 +39,24 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 /multiple_interfaces.kt:(957,962): info: Generated Viper text for take3:
 field bf$field: Ref
 
-method f$take3$TF$T$c$AbstractWithFinalImplementation3(p$obj: Ref)
+method f$take3$TF$T$AbstractWithFinalImplementation3(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$T$c$AbstractWithFinalImplementation3())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
   inhale acc(p$c$AbstractWithFinalImplementation3$shared(p$obj), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /multiple_interfaces.kt:(1025,1030): info: Generated Viper text for take4:
-method f$take4$TF$T$c$AbstractWithOpenImplementation4(p$obj: Ref)
+method f$take4$TF$T$AbstractWithOpenImplementation4(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$T$c$AbstractWithOpenImplementation4())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
   inhale acc(p$c$AbstractWithOpenImplementation4$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
@@ -72,37 +72,37 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 field bf$field: Ref
 
 method con$c$Impl12$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl12())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl12())
   ensures acc(p$c$Impl12$shared(ret), wildcard)
   ensures acc(p$c$Impl12$unique(ret), write)
 
 
 method con$c$Impl14$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl14())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl14())
   ensures acc(p$c$Impl14$shared(ret), wildcard)
   ensures acc(p$c$Impl14$unique(ret), write)
 
 
 method con$c$Impl23$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl23())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl23())
   ensures acc(p$c$Impl23$shared(ret), wildcard)
   ensures acc(p$c$Impl23$unique(ret), write)
 
 
 method con$c$Impl24$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl24())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl24())
   ensures acc(p$c$Impl24$shared(ret), wildcard)
   ensures acc(p$c$Impl24$unique(ret), write)
 
 
 method con$c$Impl3$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl3())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl3())
   ensures acc(p$c$Impl3$shared(ret), wildcard)
   ensures acc(p$c$Impl3$unique(ret), write)
 
 
 method f$create6$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$InheritingInterfaceWithoutImplementation6())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$InheritingInterfaceWithoutImplementation6())
   ensures acc(p$c$InheritingInterfaceWithoutImplementation6$shared(ret), wildcard)
 
 
@@ -144,34 +144,34 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
   anon$0 := l0$impl12.bf$field
   l0$start12 := sp$minusInts(sp$plusInts(anon$0, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$1 := f$take1$TF$T$c$InterfaceWithImplementation1(l0$impl12)
-  anon$2 := f$take2$TF$T$c$InterfaceWithoutImplementation2(l0$impl12)
+  anon$1 := f$take1$TF$T$InterfaceWithImplementation1(l0$impl12)
+  anon$2 := f$take2$TF$T$InterfaceWithoutImplementation2(l0$impl12)
   l0$impl23 := con$c$Impl23$()
   unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
   anon$3 := l0$impl23.bf$field
   l0$start23 := sp$minusInts(sp$plusInts(anon$3, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$4 := f$take2$TF$T$c$InterfaceWithoutImplementation2(l0$impl23)
-  anon$5 := f$take3$TF$T$c$AbstractWithFinalImplementation3(l0$impl23)
+  anon$4 := f$take2$TF$T$InterfaceWithoutImplementation2(l0$impl23)
+  anon$5 := f$take3$TF$T$AbstractWithFinalImplementation3(l0$impl23)
   l0$impl3 := con$c$Impl3$()
   unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
   anon$6 := l0$impl3.bf$field
   l0$start3 := sp$minusInts(sp$plusInts(anon$6, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$7 := f$take3$TF$T$c$AbstractWithFinalImplementation3(l0$impl3)
+  anon$7 := f$take3$TF$T$AbstractWithFinalImplementation3(l0$impl3)
   l0$impl24 := con$c$Impl24$()
   anon$9 := pg$public$field(l0$impl24)
   anon$8 := anon$9
   inhale df$rt$isSubtype(df$rt$typeOf(anon$8), df$rt$intType())
   l0$start24 := sp$minusInts(sp$plusInts(anon$8, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$10 := f$take2$TF$T$c$InterfaceWithoutImplementation2(l0$impl24)
-  anon$11 := f$take4$TF$T$c$AbstractWithOpenImplementation4(l0$impl24)
+  anon$10 := f$take2$TF$T$InterfaceWithoutImplementation2(l0$impl24)
+  anon$11 := f$take4$TF$T$AbstractWithOpenImplementation4(l0$impl24)
   l0$impl14 := con$c$Impl14$()
   unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
   anon$12 := l0$impl14.bf$field
   l0$start14 := sp$minusInts(sp$plusInts(anon$12, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$13 := f$take1$TF$T$c$InterfaceWithImplementation1(l0$impl14)
-  anon$14 := f$take4$TF$T$c$AbstractWithOpenImplementation4(l0$impl14)
+  anon$13 := f$take1$TF$T$InterfaceWithImplementation1(l0$impl14)
+  anon$14 := f$take4$TF$T$AbstractWithOpenImplementation4(l0$impl14)
   l0$impl6 := f$create6$TF$()
   anon$16 := pg$public$field(l0$impl6)
   anon$15 := anon$16
@@ -193,22 +193,22 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$take1$TF$T$c$InterfaceWithImplementation1(p$obj: Ref)
+method f$take1$TF$T$InterfaceWithImplementation1(p$obj: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$take2$TF$T$c$InterfaceWithoutImplementation2(p$obj: Ref)
+method f$take2$TF$T$InterfaceWithoutImplementation2(p$obj: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$take3$TF$T$c$AbstractWithFinalImplementation3(p$obj: Ref)
+method f$take3$TF$T$AbstractWithFinalImplementation3(p$obj: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$take4$TF$T$c$AbstractWithOpenImplementation4(p$obj: Ref)
+method f$take4$TF$T$AbstractWithOpenImplementation4(p$obj: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/multiple_receivers.fir.diag.txt
@@ -1,7 +1,7 @@
 /multiple_receivers.kt:(315,325): info: Generated Viper text for applyDelta:
 field bf$delta: Ref
 
-method f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension$T$Int(this$dispatch: Ref,
+method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -10,7 +10,7 @@ method f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension$T$Int(this$di
   var anon$0: Ref
   var l0$withLabels: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$ClassWithExtension())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$intType())
   unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
@@ -28,11 +28,11 @@ method f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension$T$Int(this$di
 /multiple_receivers.kt:(610,621): info: Generated Viper text for returnDelta:
 field bf$delta: Ref
 
-method f$c$ClassWithExtension$returnDelta$TF$T$c$ClassWithExtension(this$dispatch: Ref)
+method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension(this$dispatch: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$ClassWithExtension())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$delta
@@ -43,11 +43,11 @@ method f$c$ClassWithExtension$returnDelta$TF$T$c$ClassWithExtension(this$dispatc
 /multiple_receivers.kt:(658,678): info: Generated Viper text for extensionReturnDelta:
 field bf$delta: Ref
 
-method f$extensionReturnDelta$TF$T$c$ClassWithExtension(this$extension: Ref)
+method f$extensionReturnDelta$TF$T$ClassWithExtension(this$extension: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$ClassWithExtension())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   ret$0 := this$extension.bf$delta
@@ -59,20 +59,20 @@ method f$extensionReturnDelta$TF$T$c$ClassWithExtension(this$extension: Ref)
 field bf$delta: Ref
 
 method con$c$ClassWithExtension$T$Int(p$delta: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$ClassWithExtension())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithExtension())
   ensures acc(p$c$ClassWithExtension$shared(ret), wildcard)
   ensures acc(p$c$ClassWithExtension$unique(ret), write)
   ensures (unfolding acc(p$c$ClassWithExtension$shared(ret), wildcard) in
       df$rt$intFromRef(ret.bf$delta) == df$rt$intFromRef(p$delta))
 
 
-method f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension$T$Int(this$dispatch: Ref,
+method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$c$ClassWithExtension$returnDelta$TF$T$c$ClassWithExtension(this$dispatch: Ref)
+method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension(this$dispatch: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
@@ -98,13 +98,13 @@ method f$checkClassWithExtension$TF$() returns (ret$0: Ref)
   anon$5 := con$c$ClassWithExtension$T$Int(df$rt$intToRef(42))
   anon$0 := anon$5
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$ClassWithExtension())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(anon$0), wildcard)
   anon$1 := anon$0
-  anon$7 := f$c$ClassWithExtension$applyDelta$TF$T$c$ClassWithExtension$T$Int(anon$1,
+  anon$7 := f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int(anon$1,
     df$rt$intToRef(42))
-  anon$8 := f$c$ClassWithExtension$returnDelta$TF$T$c$ClassWithExtension(anon$1)
-  anon$9 := f$extensionReturnDelta$TF$T$c$ClassWithExtension(anon$1)
+  anon$8 := f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension(anon$1)
+  anon$9 := f$extensionReturnDelta$TF$T$ClassWithExtension(anon$1)
   anon$2 := df$rt$intToRef(42)
   unfold acc(p$c$ClassWithExtension$shared(anon$1), wildcard)
   anon$11 := anon$1.bf$delta
@@ -127,6 +127,6 @@ method f$checkClassWithExtension$TF$() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$extensionReturnDelta$TF$T$c$ClassWithExtension(this$extension: Ref)
+method f$extensionReturnDelta$TF$T$ClassWithExtension(this$extension: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/override_properties_types.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/override_properties_types.fir.diag.txt
@@ -1,12 +1,12 @@
 /override_properties_types.kt:(520,530): info: Generated Viper text for extractInt:
 field bf$field: Ref
 
-method f$extractInt$TF$T$c$Base$T$Boolean(p$base: Ref, p$returnNull: Ref)
+method f$extractInt$TF$T$Base$T$Boolean(p$base: Ref, p$returnNull: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==> df$rt$boolFromRef(p$returnNull)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$Base())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$Base())
   inhale acc(p$c$Base$shared(p$base), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$returnNull), df$rt$boolType())
   if (df$rt$boolFromRef(p$returnNull)) {
@@ -15,23 +15,23 @@ method f$extractInt$TF$T$c$Base$T$Boolean(p$base: Ref, p$returnNull: Ref)
     ret$0 := anon$0
   } else {
     var anon$1: Ref
-    if (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$OpenClassOpenFieldVarDerived())) {
+    if (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$OpenClassOpenFieldVarDerived())) {
       var anon$2: Ref
       inhale acc(p$c$OpenClassOpenFieldVarDerived$shared(p$base), wildcard)
       anon$2 := pg$public$field(p$base)
       anon$1 := anon$2
       inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$FinalClassOpenFieldVarDerived())) {
+    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$FinalClassOpenFieldVarDerived())) {
       inhale acc(p$c$FinalClassOpenFieldVarDerived$shared(p$base), wildcard)
       inhale acc(p$base.bf$field, write)
       anon$1 := p$base.bf$field
       exhale acc(p$base.bf$field, write)
       inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$FinalClassFinalFieldValDerived())) {
+    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$FinalClassFinalFieldValDerived())) {
       inhale acc(p$c$FinalClassFinalFieldValDerived$shared(p$base), wildcard)
       unfold acc(p$c$FinalClassFinalFieldValDerived$shared(p$base), wildcard)
       anon$1 := p$base.bf$field
-    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$T$c$OpenClassFinalFieldVarDerived())) {
+    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$OpenClassFinalFieldVarDerived())) {
       inhale acc(p$c$OpenClassFinalFieldVarDerived$shared(p$base), wildcard)
       inhale acc(p$base.bf$field, write)
       anon$1 := p$base.bf$field

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/private_properties.fir.diag.txt
@@ -1,10 +1,10 @@
 /private_properties.kt:(195,210): info: Generated Viper text for getBooleanField:
-method f$c$A$getBooleanField$TF$T$c$A(this$dispatch: Ref)
+method f$c$A$getBooleanField$TF$T$A(this$dispatch: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$A())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$A())
   inhale acc(p$c$A$shared(this$dispatch), wildcard)
   anon$0 := pg$c$A$private$field(this$dispatch)
   ret$0 := anon$0
@@ -25,12 +25,11 @@ field bf$c$B$private$field: Ref
 
 field bf$length: Ref
 
-method f$c$B$getStringField$TF$T$c$B(this$dispatch: Ref)
-  returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$pkg$kotlin$String())
+method f$c$B$getStringField$TF$T$B(this$dispatch: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$pkg$kotlin$String())
   ensures acc(p$pkg$kotlin$c$String$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$B())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$B())
   inhale acc(p$c$B$shared(this$dispatch), wildcard)
   unfold acc(p$c$B$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$B$private$field
@@ -56,13 +55,13 @@ field bf$field: Ref
 field bf$length: Ref
 
 method con$c$C$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$C())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$C())
   ensures acc(p$c$C$shared(ret), wildcard)
   ensures acc(p$c$C$unique(ret), write)
 
 
 method con$c$D$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$D())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$D())
   ensures acc(p$c$D$shared(ret), wildcard)
   ensures acc(p$c$D$unique(ret), write)
 

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_booleans.fir.diag.txt
@@ -88,7 +88,7 @@ method f$call_fun_with_contracts$TF$T$Boolean(p$b: Ref)
 /returns_booleans.kt:(1467,1480): info: Generated Viper text for isNullOrEmpty:
 field sp$size: Ref
 
-method f$isNullOrEmpty$TF$N$c$pkg$kotlin_collections$Collection(p$collection: Ref)
+method f$isNullOrEmpty$TF$NT$Collection(p$collection: Ref)
   returns (ret$0: Ref)
   requires p$collection != df$rt$nullValue() ==>
     acc(p$collection.sp$size, write)
@@ -102,18 +102,18 @@ method f$isNullOrEmpty$TF$N$c$pkg$kotlin_collections$Collection(p$collection: Re
   ensures df$rt$boolFromRef(ret$0) == false ==>
     p$collection != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$collection), df$rt$nullable(df$rt$T$c$pkg$kotlin_collections$Collection()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$collection), df$rt$nullable(df$rt$c$pkg$kotlin_collections$Collection()))
   inhale p$collection != df$rt$nullValue() ==>
     acc(p$pkg$kotlin_collections$c$Collection$shared(p$collection), wildcard)
   if (p$collection == df$rt$nullValue()) {
     ret$0 := df$rt$boolToRef(true)
   } else {
-    ret$0 := f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$c$pkg$kotlin_collections$Collection(p$collection)}
+    ret$0 := f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection(p$collection)}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$c$pkg$kotlin_collections$Collection(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/returns_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_null.kt:(121,140): info: Generated Viper text for simple_returns_null:
-method f$simple_returns_null$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$simple_returns_null$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> false
@@ -11,7 +11,7 @@ method f$simple_returns_null$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /returns_null.kt:(300,320): info: Generated Viper text for returns_null_implies:
-method f$returns_null_implies$TF$N$Boolean(p$x: Ref) returns (ret$0: Ref)
+method f$returns_null_implies$TF$NT$Boolean(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$boolType()))
   ensures ret$0 == df$rt$nullValue() ==> p$x == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
@@ -23,7 +23,7 @@ method f$returns_null_implies$TF$N$Boolean(p$x: Ref) returns (ret$0: Ref)
 }
 
 /returns_null.kt:(511,531): info: Generated Viper text for returns_null_with_if:
-method f$returns_null_with_if$TF$N$Int$N$Int$N$Int(p$x: Ref, p$y: Ref, p$z: Ref)
+method f$returns_null_with_if$TF$NT$Int$NT$Int$NT$Int(p$x: Ref, p$y: Ref, p$z: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==>

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/unit_return_type.fir.diag.txt
@@ -1,5 +1,5 @@
 /unit_return_type.kt:(171,176): info: Generated Viper text for idFun:
-method f$idFun$TF$N$Any(p$t: Ref) returns (ret$0: Ref)
+method f$idFun$TF$NT$Any(p$t: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
@@ -19,7 +19,7 @@ method f$directReturns$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
   } else {
     var anon$0: Ref
     var anon$1: Ref
-    anon$1 := f$idFun$TF$N$Any(p$b)
+    anon$1 := f$idFun$TF$NT$Any(p$b)
     anon$0 := anon$1
     inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
     if (df$rt$boolFromRef(anon$0)) {
@@ -31,12 +31,12 @@ method f$directReturns$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$N$Any(p$t: Ref) returns (ret: Ref)
+method f$idFun$TF$NT$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /unit_return_type.kt:(374,387): info: Generated Viper text for useInlineUnit:
-method f$idFun$TF$N$Any(p$t: Ref) returns (ret: Ref)
+method f$idFun$TF$NT$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -58,7 +58,7 @@ method f$useInlineUnit$TF$T$Boolean(p$b: Ref) returns (ret$0: Ref)
     var anon$2: Ref
     var anon$3: Ref
     l4$tmp := df$rt$intToRef(42)
-    anon$3 := f$idFun$TF$N$Any(l4$tmp)
+    anon$3 := f$idFun$TF$NT$Any(l4$tmp)
     anon$2 := anon$3
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   }

--- a/plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/good_contracts/viper_casts_while_inlining.fir.diag.txt
@@ -1,5 +1,5 @@
 /viper_casts_while_inlining.kt:(250,255): info: Generated Viper text for idFun:
-method f$idFun$TF$N$Any(p$arg: Ref) returns (ret$0: Ref)
+method f$idFun$TF$NT$Any(p$arg: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
@@ -12,7 +12,7 @@ method f$idFun$TF$N$Any(p$arg: Ref) returns (ret$0: Ref)
 field bf$member: Ref
 
 method con$c$ClassWithMember$T$Int(p$member: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$ClassWithMember())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithMember())
   ensures acc(p$c$ClassWithMember$shared(ret), wildcard)
   ensures acc(p$c$ClassWithMember$unique(ret), write)
   ensures (unfolding acc(p$c$ClassWithMember$shared(ret), wildcard) in
@@ -43,9 +43,9 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   l0$obj := con$c$ClassWithMember$T$Int(df$rt$intToRef(42))
   inhale df$rt$isSubtype(df$rt$typeOf(l0$obj), df$rt$nullable(df$rt$anyType()))
   anon$0 := l0$obj
-  anon$7 := f$idFun$TF$N$Any(anon$0)
+  anon$7 := f$idFun$TF$NT$Any(anon$0)
   anon$1 := anon$7
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$ClassWithMember())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$ClassWithMember())
   inhale acc(p$c$ClassWithMember$shared(anon$1), wildcard)
   unfold acc(p$c$ClassWithMember$shared(anon$1), wildcard)
   ret$2 := anon$1.bf$member
@@ -61,7 +61,7 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$4), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(l0$obj), df$rt$nullable(df$rt$anyType()))
   anon$2 := l0$obj
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$T$c$ClassWithMember())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$c$ClassWithMember())
   inhale acc(p$c$ClassWithMember$shared(anon$2), wildcard)
   anon$3 := anon$2
   unfold acc(p$c$ClassWithMember$shared(l0$obj), wildcard)
@@ -80,23 +80,22 @@ method f$checkMemberAccess$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$N$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$NT$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /viper_casts_while_inlining.kt:(895,919): info: Generated Viper text for checkGenericMemberAccess:
 field bf$wrapped: Ref
 
-method con$c$Box$N$Any(p$wrapped: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
+method con$c$Box$NT$Any(p$wrapped: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
   ensures (unfolding acc(p$c$Box$shared(ret), wildcard) in
       ret.bf$wrapped == p$wrapped)
 
 
-method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
-  returns (ret$0: Ref)
+method f$checkGenericMemberAccess$TF$T$Box(p$box: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -116,13 +115,13 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   var anon$3: Ref
   var anon$10: Ref
   var anon$11: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$T$c$Box())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
   inhale acc(p$c$Box$shared(p$box), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$box
-  anon$4 := f$idFun$TF$N$Any(anon$0)
+  anon$4 := f$idFun$TF$NT$Any(anon$0)
   anon$1 := anon$4
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$Box())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$Box())
   inhale acc(p$c$Box$shared(anon$1), wildcard)
   unfold acc(p$c$Box$shared(anon$1), wildcard)
   ret$2 := anon$1.bf$wrapped
@@ -133,10 +132,10 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   label lbl$ret$1
   unfold acc(p$c$Box$shared(p$box), wildcard)
   anon$8 := p$box.bf$wrapped
-  anon$7 := con$c$Box$N$Any(anon$8)
+  anon$7 := con$c$Box$NT$Any(anon$8)
   anon$2 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$nullable(df$rt$anyType()))
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$T$c$Box())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$c$Box())
   inhale acc(p$c$Box$shared(anon$2), wildcard)
   anon$3 := anon$2
   unfold acc(p$c$Box$shared(anon$3), wildcard)
@@ -157,14 +156,14 @@ method f$checkGenericMemberAccess$TF$T$c$Box(p$box: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$N$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$NT$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /viper_casts_while_inlining.kt:(1161,1182): info: Generated Viper text for checkArgumentIsCopied:
 field bf$a: Ref
 
-method f$checkArgumentIsCopied$TF$T$c$ClassWithVar(p$x: Ref)
+method f$checkArgumentIsCopied$TF$T$ClassWithVar(p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -176,7 +175,7 @@ method f$checkArgumentIsCopied$TF$T$c$ClassWithVar(p$x: Ref)
   var anon$5: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$ClassWithVar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$ClassWithVar())
   inhale acc(p$c$ClassWithVar$shared(p$x), wildcard)
   inhale acc(p$x.bf$a, write)
   anon$4 := p$x.bf$a
@@ -213,8 +212,7 @@ field bf$c: Ref
 
 field bf$i: Ref
 
-method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
-  returns (ret$0: Ref)
+method f$accessManyMembers$TF$T$ManyMembers(p$m: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$4: Ref
@@ -244,23 +242,23 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   var anon$20: Ref
   var anon$21: Ref
   var anon$22: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$T$c$ManyMembers())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(p$m), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$m
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$ManyMembers())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(anon$0), wildcard)
   anon$1 := anon$0
   unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
   anon$9 := anon$1.bf$i
-  anon$8 := f$idFun$TF$N$Any(anon$9)
+  anon$8 := f$idFun$TF$NT$Any(anon$9)
   anon$7 := anon$8
   inhale df$rt$isSubtype(df$rt$typeOf(anon$7), df$rt$intType())
   inhale acc(anon$1.bf$b, write)
   anon$12 := anon$1.bf$b
   exhale acc(anon$1.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$12), df$rt$boolType())
-  anon$11 := f$idFun$TF$N$Any(anon$12)
+  anon$11 := f$idFun$TF$NT$Any(anon$12)
   anon$10 := anon$11
   inhale df$rt$isSubtype(df$rt$typeOf(anon$10), df$rt$boolType())
   unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
@@ -274,24 +272,24 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   label lbl$ret$1
   anon$5 := ret$1
   anon$4 := anon$5
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$4), df$rt$T$c$ClassWithVar())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$4), df$rt$c$ClassWithVar())
   inhale acc(p$c$ClassWithVar$shared(anon$4), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
   anon$2 := p$m
-  anon$16 := f$idFun$TF$N$Any(anon$2)
+  anon$16 := f$idFun$TF$NT$Any(anon$2)
   anon$3 := anon$16
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$T$c$ManyMembers())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(anon$3), wildcard)
   unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
   anon$19 := anon$3.bf$i
-  anon$18 := f$idFun$TF$N$Any(anon$19)
+  anon$18 := f$idFun$TF$NT$Any(anon$19)
   anon$17 := anon$18
   inhale df$rt$isSubtype(df$rt$typeOf(anon$17), df$rt$intType())
   inhale acc(anon$3.bf$b, write)
   anon$22 := anon$3.bf$b
   exhale acc(anon$3.bf$b, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$22), df$rt$boolType())
-  anon$21 := f$idFun$TF$N$Any(anon$22)
+  anon$21 := f$idFun$TF$NT$Any(anon$22)
   anon$20 := anon$21
   inhale df$rt$isSubtype(df$rt$typeOf(anon$20), df$rt$boolType())
   unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
@@ -305,13 +303,13 @@ method f$accessManyMembers$TF$T$c$ManyMembers(p$m: Ref)
   label lbl$ret$3
   anon$14 := ret$3
   anon$13 := anon$14
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$13), df$rt$T$c$ClassWithVar())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$13), df$rt$c$ClassWithVar())
   inhale acc(p$c$ClassWithVar$shared(anon$13), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$N$Any(p$arg: Ref) returns (ret: Ref)
+method f$idFun$TF$NT$Any(p$arg: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -324,7 +322,7 @@ field bf$c: Ref
 
 field bf$i: Ref
 
-method f$checkEvaluatedOnce$TF$T$Int$T$c$ManyMembers(p$i: Ref, p$mm: Ref)
+method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers(p$i: Ref, p$mm: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -338,7 +336,7 @@ method f$checkEvaluatedOnce$TF$T$Int$T$c$ManyMembers(p$i: Ref, p$mm: Ref)
   var ret$2: Ref
   var anon$1: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$mm), df$rt$T$c$ManyMembers())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$mm), df$rt$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(p$mm), wildcard)
   inhale acc(p$mm.bf$b, write)
   anon$5 := p$mm.bf$b

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/field_getters.fir.diag.txt
@@ -3,13 +3,13 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-method f$testPrimitiveFieldGetter$TF$T$c$PrimitiveFields(p$pf: Ref)
+method f$testPrimitiveFieldGetter$TF$T$PrimitiveFields(p$pf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$T$c$PrimitiveFields())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$a := p$pf.bf$a
@@ -30,7 +30,7 @@ field bf$f: Ref
 
 field bf$g: Ref
 
-method f$testReferenceFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
+method f$testReferenceFieldGetter$TF$T$ReferenceFields(p$rf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -40,14 +40,14 @@ method f$testReferenceFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   var l0$fb: Ref
   var l0$ga: Ref
   var l0$gb: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$T$c$ReferenceFields())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$f := p$rf.bf$f
   inhale acc(p$rf.bf$g, write)
   l0$g := p$rf.bf$g
   exhale acc(p$rf.bf$g, write)
-  inhale df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$T$c$PrimitiveFields())
+  inhale df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(l0$g), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(l0$f), wildcard)
   l0$fa := l0$f.bf$a
@@ -74,7 +74,7 @@ field bf$f: Ref
 
 field bf$g: Ref
 
-method f$testCascadingFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
+method f$testCascadingFieldGetter$TF$T$ReferenceFields(p$rf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -86,7 +86,7 @@ method f$testCascadingFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   var anon$2: Ref
   var l0$gb: Ref
   var anon$3: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$T$c$ReferenceFields())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := p$rf.bf$f
@@ -101,14 +101,14 @@ method f$testCascadingFieldGetter$TF$T$c$ReferenceFields(p$rf: Ref)
   inhale acc(p$rf.bf$g, write)
   anon$2 := p$rf.bf$g
   exhale acc(p$rf.bf$g, write)
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$T$c$PrimitiveFields())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(anon$2), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(anon$2), wildcard)
   l0$ga := anon$2.bf$a
   inhale acc(p$rf.bf$g, write)
   anon$3 := p$rf.bf$g
   exhale acc(p$rf.bf$g, write)
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$T$c$PrimitiveFields())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(anon$3), wildcard)
   inhale acc(anon$3.bf$b, write)
   l0$gb := anon$3.bf$b

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance.fir.diag.txt
@@ -5,10 +5,10 @@ field bf$x: Ref
 
 field bf$y: Ref
 
-method f$c$Foo$getY$TF$T$c$Foo(this$dispatch: Ref) returns (ret$0: Ref)
+method f$c$Foo$getY$TF$T$Foo(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$y
@@ -25,12 +25,12 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$c$Bar$sum$TF$T$c$Bar(this$dispatch: Ref) returns (ret$0: Ref)
+method f$c$Bar$sum$TF$T$Bar(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
   unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
@@ -51,16 +51,16 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$c$Foo$getY$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$getY$TF$T$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$callSuperMethod$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
+method f$callSuperMethod$TF$T$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := f$c$Foo$getY$TF$T$c$Foo(p$bar)
+  ret$0 := f$c$Foo$getY$TF$T$Foo(p$bar)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -74,10 +74,10 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$accessSuperField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
+method f$accessSuperField$TF$T$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   inhale acc(p$bar.bf$b, write)
   ret$0 := p$bar.bf$b
@@ -96,10 +96,10 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$accessNewField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
+method f$accessNewField$TF$T$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   unfold acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := p$bar.bf$z
@@ -116,16 +116,16 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$c$Bar$sum$TF$T$c$Bar(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Bar$sum$TF$T$Bar(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$callNewMethod$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
+method f$callNewMethod$TF$T$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := f$c$Bar$sum$TF$T$c$Bar(p$bar)
+  ret$0 := f$c$Bar$sum$TF$T$Bar(p$bar)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -139,10 +139,10 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$setSuperField$TF$T$c$Bar(p$bar: Ref) returns (ret$0: Ref)
+method f$setSuperField$TF$T$Bar(p$bar: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   inhale acc(p$bar.bf$b, write)
   p$bar.bf$b := df$rt$boolToRef(true)
@@ -160,10 +160,10 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$accessSuperSuperField$TF$T$c$Baz(p$baz: Ref) returns (ret$0: Ref)
+method f$accessSuperSuperField$TF$T$Baz(p$baz: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$baz), df$rt$T$c$Baz())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$baz), df$rt$c$Baz())
   inhale acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Bar$shared(p$baz), wildcard)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
@@ -1,14 +1,14 @@
 /inheritance_fields.kt:(227,234): info: Generated Viper text for createB:
 field bf$fieldNotOverride: Ref
 
-method con$c$B$T$c$FieldB(p$fieldOverride: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$B())
+method con$c$B$T$FieldB(p$fieldOverride: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$B())
   ensures acc(p$c$B$shared(ret), wildcard)
   ensures acc(p$c$B$unique(ret), write)
 
 
 method con$c$FieldB$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$FieldB())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FieldB())
   ensures acc(p$c$FieldB$shared(ret), wildcard)
   ensures acc(p$c$FieldB$unique(ret), write)
 
@@ -22,10 +22,10 @@ method f$createB$TF$() returns (ret$0: Ref)
   var anon$0: Ref
   var l0$fieldNotOverride: Ref
   l0$fieldB := con$c$FieldB$()
-  l0$b := con$c$B$T$c$FieldB(l0$fieldB)
+  l0$b := con$c$B$T$FieldB(l0$fieldB)
   anon$0 := pg$public$fieldOverride(l0$b)
   l0$fieldOverride := anon$0
-  inhale df$rt$isSubtype(df$rt$typeOf(l0$fieldOverride), df$rt$T$c$FieldB())
+  inhale df$rt$isSubtype(df$rt$typeOf(l0$fieldOverride), df$rt$c$FieldB())
   inhale acc(p$c$FieldB$shared(l0$fieldOverride), wildcard)
   unfold acc(p$c$B$shared(l0$b), wildcard)
   unfold acc(p$c$A$shared(l0$b), wildcard)
@@ -41,19 +41,19 @@ method pg$public$fieldOverride(this$dispatch: Ref) returns (ret: Ref)
 field bf$x: Ref
 
 method con$c$FirstBackingFieldClass$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$FirstBackingFieldClass())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FirstBackingFieldClass())
   ensures acc(p$c$FirstBackingFieldClass$shared(ret), wildcard)
   ensures acc(p$c$FirstBackingFieldClass$unique(ret), write)
 
 
 method con$c$NoBackingFieldClass$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$NoBackingFieldClass())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoBackingFieldClass())
   ensures acc(p$c$NoBackingFieldClass$shared(ret), wildcard)
   ensures acc(p$c$NoBackingFieldClass$unique(ret), write)
 
 
 method con$c$SecondBackingFieldClass$T$Int(p$x: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$SecondBackingFieldClass())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$SecondBackingFieldClass())
   ensures acc(p$c$SecondBackingFieldClass$shared(ret), wildcard)
   ensures acc(p$c$SecondBackingFieldClass$unique(ret), write)
   ensures (unfolding acc(p$c$SecondBackingFieldClass$shared(ret), wildcard) in
@@ -93,7 +93,7 @@ method pg$public$x(this$dispatch: Ref) returns (ret: Ref)
 field bf$a: Ref
 
 method con$c$Y$T$Int(p$a: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Y())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Y())
   ensures acc(p$c$Y$shared(ret), wildcard)
   ensures acc(p$c$Y$unique(ret), write)
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
@@ -1,5 +1,5 @@
 /interface.kt:(84,98): info: Generated Viper text for testProperties:
-method f$testProperties$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testProperties$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -8,7 +8,7 @@ method f$testProperties$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
   var anon$2: Ref
   var anon$3: Ref
   var anon$4: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   anon$0 := ps$public$varProp(p$foo, df$rt$intToRef(0))
   anon$2 := pg$public$varProp(p$foo)
@@ -36,7 +36,7 @@ method ps$public$varProp(this$dispatch: Ref, anon$0: Ref)
 field bf$number: Ref
 
 method con$c$Impl$T$Int(p$number: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Impl())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl())
   ensures acc(p$c$Impl$shared(ret), wildcard)
   ensures acc(p$c$Impl$unique(ret), write)
   ensures (unfolding acc(p$c$Impl$shared(ret), wildcard) in

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/member_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/member_functions.fir.diag.txt
@@ -1,11 +1,10 @@
 /member_functions.kt:(51,60): info: Generated Viper text for memberFun:
 field bf$x: Ref
 
-method f$c$Foo$memberFun$TF$T$c$Foo(this$dispatch: Ref)
-  returns (ret$0: Ref)
+method f$c$Foo$memberFun$TF$T$Foo(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$x
@@ -16,39 +15,39 @@ method f$c$Foo$memberFun$TF$T$c$Foo(this$dispatch: Ref)
 /member_functions.kt:(102,115): info: Generated Viper text for callMemberFun:
 field bf$x: Ref
 
-method f$c$Foo$callMemberFun$TF$T$c$Foo(this$dispatch: Ref)
+method f$c$Foo$callMemberFun$TF$T$Foo(this$dispatch: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  anon$0 := f$c$Foo$memberFun$TF$T$c$Foo(this$dispatch)
+  anon$0 := f$c$Foo$memberFun$TF$T$Foo(this$dispatch)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$c$Foo$memberFun$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$memberFun$TF$T$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 /member_functions.kt:(155,166): info: Generated Viper text for siblingCall:
 field bf$x: Ref
 
-method f$c$Foo$memberFun$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$memberFun$TF$T$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$c$Foo$siblingCall$TF$T$c$Foo$T$c$Foo(this$dispatch: Ref, p$other: Ref)
+method f$c$Foo$siblingCall$TF$T$Foo$T$Foo(this$dispatch: Ref, p$other: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$other), wildcard)
-  anon$0 := f$c$Foo$memberFun$TF$T$c$Foo(p$other)
+  anon$0 := f$c$Foo$memberFun$TF$T$Foo(p$other)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -56,17 +55,17 @@ method f$c$Foo$siblingCall$TF$T$c$Foo$T$c$Foo(this$dispatch: Ref, p$other: Ref)
 /member_functions.kt:(220,238): info: Generated Viper text for outerMemberFunCall:
 field bf$x: Ref
 
-method f$c$Foo$memberFun$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$memberFun$TF$T$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$outerMemberFunCall$TF$T$c$Foo(p$f: Ref) returns (ret$0: Ref)
+method f$outerMemberFunCall$TF$T$Foo(p$f: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$f), wildcard)
-  anon$0 := f$c$Foo$memberFun$TF$T$c$Foo(p$f)
+  anon$0 := f$c$Foo$memberFun$TF$T$Foo(p$f)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/multiple_interfaces.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/multiple_interfaces.fir.diag.txt
@@ -1,6 +1,6 @@
 /multiple_interfaces.kt:(162,173): info: Generated Viper text for testDiamond:
 method con$c$D$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$D())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$D())
   ensures acc(p$c$D$shared(ret), wildcard)
   ensures acc(p$c$D$unique(ret), write)
 
@@ -23,13 +23,13 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 /multiple_interfaces.kt:(405,415): info: Generated Viper text for testVarVal:
 method con$c$G$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$G())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$G())
   ensures acc(p$c$G$shared(ret), wildcard)
   ensures acc(p$c$G$unique(ret), write)
 
 
 method con$c$I$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$I())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$I())
   ensures acc(p$c$I$shared(ret), wildcard)
   ensures acc(p$c$I$unique(ret), write)
 
@@ -63,3 +63,4 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 method ps$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates.fir.diag.txt
@@ -31,37 +31,37 @@ predicate p$c$Recursive$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
   acc(p$c$Recursive$shared(this$dispatch.bf$next), wildcard)) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$T$c$Recursive()))
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Recursive()))
 }
 
 predicate p$c$Recursive$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
   acc(p$c$Recursive$shared(this$dispatch.bf$next), wildcard)) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$T$c$Recursive()))
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Recursive()))
 }
 
 predicate p$c$ReferenceField$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$pf, wildcard) &&
   acc(p$c$PrimitiveFields$shared(this$dispatch.bf$pf), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$pf), df$rt$T$c$PrimitiveFields()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$pf), df$rt$c$PrimitiveFields()) &&
   acc(p$c$Baz$shared(this$dispatch), wildcard)
 }
 
 predicate p$c$ReferenceField$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$pf, wildcard) &&
   acc(p$c$PrimitiveFields$shared(this$dispatch.bf$pf), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$pf), df$rt$T$c$PrimitiveFields()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$pf), df$rt$c$PrimitiveFields()) &&
   acc(p$c$Baz$unique(this$dispatch), write)
 }
 
-method f$useClasses$TF$T$c$ReferenceField$T$c$Recursive(p$rf: Ref, p$rec: Ref)
+method f$useClasses$TF$T$ReferenceField$T$Recursive(p$rf: Ref, p$rec: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$T$c$ReferenceField())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
   inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$T$c$Recursive())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$c$Recursive())
   inhale acc(p$c$Recursive$shared(p$rec), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -100,10 +100,10 @@ predicate p$c$C$unique(this$dispatch: Ref) {
   acc(p$c$B$unique(this$dispatch), write)
 }
 
-method f$threeLayersHierarchy$TF$T$c$C(p$c: Ref) returns (ret$0: Ref)
+method f$threeLayersHierarchy$TF$T$C(p$c: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$T$c$C())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   inhale acc(p$c$C$shared(p$c), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -164,15 +164,14 @@ predicate p$pkg$kotlin_collections$c$MutableList$unique(this$dispatch: Ref) {
   acc(p$pkg$kotlin_collections$c$MutableCollection$unique(this$dispatch), write)
 }
 
-method f$listHierarchy$TF$T$c$pkg$kotlin_collections$MutableList(p$xs: Ref)
-  returns (ret$0: Ref)
+method f$listHierarchy$TF$T$MutableList(p$xs: Ref) returns (ret$0: Ref)
   requires acc(p$xs.sp$size, write)
   requires df$rt$intFromRef(p$xs.sp$size) >= 0
   ensures acc(p$xs.sp$size, write)
   ensures df$rt$intFromRef(p$xs.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$xs), df$rt$T$c$pkg$kotlin_collections$MutableList())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$xs), df$rt$c$pkg$kotlin_collections$MutableList())
   inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$xs), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/predicates_access.fir.diag.txt
@@ -32,7 +32,7 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 predicate p$c$C$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$T$c$A()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
   acc(p$c$D$shared(this$dispatch), wildcard) &&
   acc(p$c$B$shared(this$dispatch), wildcard)
 }
@@ -40,10 +40,10 @@ predicate p$c$C$shared(this$dispatch: Ref) {
 predicate p$c$C$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$T$c$A()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
   acc(this$dispatch.bf$y, write) &&
   acc(p$c$A$shared(this$dispatch.bf$y), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$T$c$A()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$A()) &&
   acc(p$c$D$unique(this$dispatch), write) &&
   acc(p$c$B$unique(this$dispatch), write)
 }
@@ -56,11 +56,11 @@ predicate p$c$D$unique(this$dispatch: Ref) {
   true
 }
 
-method f$accessSuperTypeProperty$TF$T$c$C(p$c: Ref) returns (ret$0: Ref)
+method f$accessSuperTypeProperty$TF$T$C(p$c: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$T$c$C())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$B$shared(p$c), wildcard)
@@ -107,7 +107,7 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 predicate p$c$C$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$T$c$A()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
   acc(p$c$D$shared(this$dispatch), wildcard) &&
   acc(p$c$B$shared(this$dispatch), wildcard)
 }
@@ -115,10 +115,10 @@ predicate p$c$C$shared(this$dispatch: Ref) {
 predicate p$c$C$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$T$c$A()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
   acc(this$dispatch.bf$y, write) &&
   acc(p$c$A$shared(this$dispatch.bf$y), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$T$c$A()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$A()) &&
   acc(p$c$D$unique(this$dispatch), write) &&
   acc(p$c$B$unique(this$dispatch), write)
 }
@@ -131,12 +131,12 @@ predicate p$c$D$unique(this$dispatch: Ref) {
   true
 }
 
-method f$accessNested$TF$T$c$C(p$c: Ref) returns (ret$0: Ref)
+method f$accessNested$TF$T$C(p$c: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$T$c$C())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
   anon$0 := p$c.bf$x
@@ -162,11 +162,11 @@ predicate p$c$A$unique(this$dispatch: Ref) {
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-method f$accessNullable$TF$N$c$A(p$x: Ref) returns (ret$0: Ref)
+method f$accessNullable$TF$NT$A(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$T$c$A()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$A()))
   inhale p$x != df$rt$nullValue() ==> acc(p$c$A$shared(p$x), wildcard)
   if (!(p$x == df$rt$nullValue())) {
     unfold acc(p$c$A$shared(p$x), wildcard)
@@ -203,13 +203,13 @@ predicate p$c$B$unique(this$dispatch: Ref) {
   acc(p$c$A$unique(this$dispatch), write)
 }
 
-method f$accessCast$TF$T$c$A(p$x: Ref) returns (ret$0: Ref)
+method f$accessCast$TF$T$A(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$A())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   inhale acc(p$c$A$shared(p$x), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$B())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())
   inhale acc(p$c$B$shared(p$x), wildcard)
   unfold acc(p$c$B$shared(p$x), wildcard)
   l0$n := p$x.bf$b
@@ -244,19 +244,19 @@ predicate p$c$B$unique(this$dispatch: Ref) {
   acc(p$c$A$unique(this$dispatch), write)
 }
 
-method f$accessSafeCast$TF$T$c$A(p$x: Ref) returns (ret$0: Ref)
+method f$accessSafeCast$TF$T$A(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$A())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   inhale acc(p$c$A$shared(p$x), wildcard)
   l0$n := df$rt$intToRef(0)
-  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$B())) {
+  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
     l0$y := p$x
   } else {
     l0$y := df$rt$nullValue()}
-  inhale df$rt$isSubtype(df$rt$typeOf(l0$y), df$rt$nullable(df$rt$T$c$B()))
+  inhale df$rt$isSubtype(df$rt$typeOf(l0$y), df$rt$nullable(df$rt$c$B()))
   inhale l0$y != df$rt$nullValue() ==> acc(p$c$B$shared(l0$y), wildcard)
   if (!(l0$y == df$rt$nullValue())) {
     unfold acc(p$c$B$shared(l0$y), wildcard)
@@ -293,14 +293,14 @@ predicate p$c$B$unique(this$dispatch: Ref) {
   acc(p$c$A$unique(this$dispatch), write)
 }
 
-method f$accessSmartCast$TF$T$c$A(p$x: Ref) returns (ret$0: Ref)
+method f$accessSmartCast$TF$T$A(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$A())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   inhale acc(p$c$A$shared(p$x), wildcard)
   l0$n := df$rt$intToRef(0)
-  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$B())) {
+  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
     inhale acc(p$c$B$shared(p$x), wildcard)
     unfold acc(p$c$B$shared(p$x), wildcard)
     l0$n := p$x.bf$b

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
@@ -5,7 +5,7 @@ field bf$b: Ref
 
 method con$c$PrimitiveFields$T$Int$T$Int(p$a: Ref, p$b: Ref)
   returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$PrimitiveFields())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
   ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveFields$unique(ret), write)
   ensures (unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
@@ -14,7 +14,7 @@ method con$c$PrimitiveFields$T$Int$T$Int(p$a: Ref, p$b: Ref)
 
 
 method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$PrimitiveFields())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$PrimitiveFields())
   ensures acc(p$c$PrimitiveFields$shared(ret$0), wildcard)
 {
   ret$0 := con$c$PrimitiveFields$T$Int$T$Int(df$rt$intToRef(10), df$rt$intToRef(20))
@@ -25,8 +25,8 @@ method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
 /primary_constructors.kt:(178,193): info: Generated Viper text for createRecursive:
 field bf$a: Ref
 
-method con$c$Recursive$N$c$Recursive(p$a: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Recursive())
+method con$c$Recursive$NT$Recursive(p$a: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)
   ensures (unfolding acc(p$c$Recursive$shared(ret), wildcard) in
@@ -34,10 +34,10 @@ method con$c$Recursive$N$c$Recursive(p$a: Ref) returns (ret: Ref)
 
 
 method f$createRecursive$TF$() returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Recursive())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret$0), wildcard)
 {
-  ret$0 := con$c$Recursive$N$c$Recursive(df$rt$nullValue())
+  ret$0 := con$c$Recursive$NT$Recursive(df$rt$nullValue())
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -48,7 +48,7 @@ field bf$a: Ref
 field bf$c: Ref
 
 method con$c$FieldInBody$T$Int(p$c: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$FieldInBody())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FieldInBody())
   ensures acc(p$c$FieldInBody$shared(ret), wildcard)
   ensures acc(p$c$FieldInBody$unique(ret), write)
   ensures (unfolding acc(p$c$FieldInBody$shared(ret), wildcard) in
@@ -56,7 +56,7 @@ method con$c$FieldInBody$T$Int(p$c: Ref) returns (ret: Ref)
 
 
 method f$createFieldInBody$TF$() returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$FieldInBody())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$FieldInBody())
   ensures acc(p$c$FieldInBody$shared(ret$0), wildcard)
 {
   ret$0 := con$c$FieldInBody$T$Int(df$rt$intToRef(10))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/property_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/property_getters.fir.diag.txt
@@ -1,10 +1,10 @@
 /property_getters.kt:(102,129): info: Generated Viper text for testPrimitivePropertyGetter:
-method f$testPrimitivePropertyGetter$TF$T$c$PrimitiveProperty(p$pp: Ref)
+method f$testPrimitivePropertyGetter$TF$T$PrimitiveProperty(p$pp: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$T$c$PrimitiveProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
   inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   anon$0 := pg$public$nProp(p$pp)
   ret$0 := anon$0
@@ -17,7 +17,7 @@ method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 
 
 /property_getters.kt:(286,313): info: Generated Viper text for testReferencePropertyGetter:
-method f$testReferencePropertyGetter$TF$T$c$ReferenceProperty(p$rp: Ref)
+method f$testReferencePropertyGetter$TF$T$ReferenceProperty(p$rp: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -25,11 +25,11 @@ method f$testReferencePropertyGetter$TF$T$c$ReferenceProperty(p$rp: Ref)
   var anon$0: Ref
   var l0$ppn: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$T$c$ReferenceProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$0 := pg$public$rProp(p$rp)
   l0$pp := anon$0
-  inhale df$rt$isSubtype(df$rt$typeOf(l0$pp), df$rt$T$c$PrimitiveProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(l0$pp), df$rt$c$PrimitiveProperty())
   inhale acc(p$c$PrimitiveProperty$shared(l0$pp), wildcard)
   anon$1 := pg$public$nProp(l0$pp)
   l0$ppn := anon$1
@@ -45,7 +45,7 @@ method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
 
 
 /property_getters.kt:(391,418): info: Generated Viper text for testCascadingPropertyGetter:
-method f$testCascadingPropertyGetter$TF$T$c$ReferenceProperty(p$rp: Ref)
+method f$testCascadingPropertyGetter$TF$T$ReferenceProperty(p$rp: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -53,11 +53,11 @@ method f$testCascadingPropertyGetter$TF$T$c$ReferenceProperty(p$rp: Ref)
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$T$c$ReferenceProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$2 := pg$public$rProp(p$rp)
   anon$1 := anon$2
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$T$c$PrimitiveProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$PrimitiveProperty())
   inhale acc(p$c$PrimitiveProperty$shared(anon$1), wildcard)
   anon$0 := pg$public$nProp(anon$1)
   l0$ppn := anon$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
@@ -2,13 +2,13 @@
 field bf$a: Ref
 
 method con$c$NoPrimaryConstructor$T$Boolean(p$b: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$NoPrimaryConstructor())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoPrimaryConstructor())
   ensures acc(p$c$NoPrimaryConstructor$shared(ret), wildcard)
   ensures acc(p$c$NoPrimaryConstructor$unique(ret), write)
 
 
 method con$c$NoPrimaryConstructor$T$Int(p$n: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$NoPrimaryConstructor())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoPrimaryConstructor())
   ensures acc(p$c$NoPrimaryConstructor$shared(ret), wildcard)
   ensures acc(p$c$NoPrimaryConstructor$unique(ret), write)
 
@@ -28,13 +28,13 @@ method f$onlySecondConstructors$TF$() returns (ret$0: Ref)
 field bf$a: Ref
 
 method con$c$BothConstructors$T$Boolean(p$b: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$BothConstructors())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
   ensures acc(p$c$BothConstructors$shared(ret), wildcard)
   ensures acc(p$c$BothConstructors$unique(ret), write)
 
 
 method con$c$BothConstructors$T$Int(p$a: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$BothConstructors())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
   ensures acc(p$c$BothConstructors$shared(ret), wildcard)
   ensures acc(p$c$BothConstructors$unique(ret), write)
   ensures (unfolding acc(p$c$BothConstructors$shared(ret), wildcard) in

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/setters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/setters.fir.diag.txt
@@ -1,11 +1,11 @@
 /setters.kt:(103,127): info: Generated Viper text for testPrimitiveFieldSetter:
 field bf$a: Ref
 
-method f$testPrimitiveFieldSetter$TF$T$c$PrimitiveField(p$pf: Ref)
+method f$testPrimitiveFieldSetter$TF$T$PrimitiveField(p$pf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$T$c$PrimitiveField())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   inhale acc(p$pf.bf$a, write)
   p$pf.bf$a := df$rt$intToRef(0)
@@ -20,17 +20,17 @@ field bf$a: Ref
 field bf$pf: Ref
 
 method con$c$PrimitiveField$T$Int(p$a: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$PrimitiveField())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveField())
   ensures acc(p$c$PrimitiveField$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveField$unique(ret), write)
 
 
-method f$testReferenceFieldSetter$TF$T$c$ReferenceField(p$rf: Ref)
+method f$testReferenceFieldSetter$TF$T$ReferenceField(p$rf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$T$c$ReferenceField())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
   inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveField$T$Int(df$rt$intToRef(0))
   inhale acc(p$rf.bf$pf, write)
@@ -41,12 +41,12 @@ method f$testReferenceFieldSetter$TF$T$c$ReferenceField(p$rf: Ref)
 }
 
 /setters.kt:(427,454): info: Generated Viper text for testPrimitivePropertySetter:
-method f$testPrimitivePropertySetter$TF$T$c$PrimitiveProperty(p$pp: Ref)
+method f$testPrimitivePropertySetter$TF$T$PrimitiveProperty(p$pp: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$T$c$PrimitiveProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
   inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   anon$0 := ps$public$aProp(p$pp, df$rt$intToRef(0))
   label lbl$ret$0
@@ -61,18 +61,18 @@ method ps$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
 
 /setters.kt:(504,531): info: Generated Viper text for testReferencePropertySetter:
 method con$c$PrimitiveProperty$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$PrimitiveProperty())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveProperty())
   ensures acc(p$c$PrimitiveProperty$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveProperty$unique(ret), write)
 
 
-method f$testReferencePropertySetter$TF$T$c$ReferenceProperty(p$rp: Ref)
+method f$testReferencePropertySetter$TF$T$ReferenceProperty(p$rp: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$T$c$ReferenceProperty())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$1 := con$c$PrimitiveProperty$()
   anon$0 := ps$public$ppProp(p$rp, anon$1)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/subtyping.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/subtyping.fir.diag.txt
@@ -1,5 +1,5 @@
 /subtyping.kt:(80,89): info: Generated Viper text for smartCast:
-method f$smartCast$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$smartCast$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -38,10 +38,10 @@ method f$functionParameterSubtyping$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  anon$0 := f$nullableParameter$TF$N$Boolean(df$rt$boolToRef(false))
+  anon$0 := f$nullableParameter$TF$NT$Boolean(df$rt$boolToRef(false))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$nullableParameter$TF$N$Boolean(p$b: Ref) returns (ret: Ref)
+method f$nullableParameter$TF$NT$Boolean(p$b: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/unique_predicates.fir.diag.txt
@@ -12,7 +12,7 @@ predicate p$c$Foo$shared(this$dispatch: Ref) {
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$w), df$rt$intType()) &&
   acc(this$dispatch.bf$y, wildcard) &&
   acc(p$c$T$shared(this$dispatch.bf$y), wildcard) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$T$c$T()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$T()) &&
   acc(p$c$S$shared(this$dispatch), wildcard)
 }
 
@@ -24,11 +24,11 @@ predicate p$c$Foo$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$y, wildcard) &&
   acc(p$c$T$shared(this$dispatch.bf$y), wildcard) &&
   acc(p$c$T$unique(this$dispatch.bf$y), write) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$T$c$T()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$T()) &&
   acc(this$dispatch.bf$z, write) &&
   acc(p$c$T$shared(this$dispatch.bf$z), wildcard) &&
   acc(p$c$T$unique(this$dispatch.bf$z), write) &&
-  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$z), df$rt$T$c$T()) &&
+  df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$z), df$rt$c$T()) &&
   acc(p$c$S$unique(this$dispatch), write)
 }
 
@@ -48,11 +48,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$unique_foo_arg$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$unique_foo_arg$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
   requires acc(p$c$Foo$unique(p$foo), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -67,11 +67,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$nullable_unique_arg$TF$N$c$T(p$t: Ref) returns (ret$0: Ref)
+method f$nullable_unique_arg$TF$NT$T(p$t: Ref) returns (ret$0: Ref)
   requires p$t != df$rt$nullValue() ==> acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$T$c$T()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$c$T()))
   inhale p$t != df$rt$nullValue() ==> acc(p$c$T$shared(p$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -86,12 +86,12 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$borrowed_unique_arg$TF$T$c$T(p$t: Ref) returns (ret$0: Ref)
+method f$borrowed_unique_arg$TF$T$T(p$t: Ref) returns (ret$0: Ref)
   requires acc(p$c$T$unique(p$t), write)
   ensures acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$T$c$T())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$c$T())
   inhale acc(p$c$T$shared(p$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -106,11 +106,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$unique_receiver$TF$T$c$T(this$extension: Ref) returns (ret$0: Ref)
+method f$unique_receiver$TF$T$T(this$extension: Ref) returns (ret$0: Ref)
   requires acc(p$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$T())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
   inhale acc(p$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -125,13 +125,13 @@ predicate p$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$borrowed_unique_receiver$TF$T$c$T(this$extension: Ref)
+method f$borrowed_unique_receiver$TF$T$T(this$extension: Ref)
   returns (ret$0: Ref)
   requires acc(p$c$T$unique(this$extension), write)
   ensures acc(p$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$T$c$T())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
   inhale acc(p$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -147,13 +147,13 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 }
 
 method con$c$T$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$T())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$T())
   ensures acc(p$c$T$shared(ret), wildcard)
   ensures acc(p$c$T$unique(ret), write)
 
 
 method f$unique_result$TF$() returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$T())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$T())
   ensures acc(p$c$T$shared(ret$0), wildcard)
   ensures acc(p$c$T$unique(ret$0), write)
 {
@@ -172,7 +172,7 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 }
 
 method f$unique_nullable_result$TF$() returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$T()))
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$T()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$T$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$T$unique(ret$0), write)
 {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/exp_side_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/exp_side_effects.fir.diag.txt
@@ -2,7 +2,7 @@
 field bf$x: Ref
 
 method f$getFoo$TF$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
 
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/try_catch.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/try_catch.fir.diag.txt
@@ -213,7 +213,7 @@ method f$call$TF$T$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$ignore$TF$T$c$pkg$java_lang$Exception(p$e: Ref) returns (ret: Ref)
+method f$ignore$TF$T$Exception(p$e: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -234,7 +234,7 @@ method f$useException$TF$() returns (ret$0: Ref)
   }
   goto lbl$try_exit$0
   label lbl$catch$0
-  anon$3 := f$ignore$TF$T$c$pkg$java_lang$Exception(l2$e)
+  anon$3 := f$ignore$TF$T$Exception(l2$e)
   goto lbl$try_exit$0
   label lbl$try_exit$0
   label lbl$ret$0
@@ -245,3 +245,4 @@ method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
 method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/when.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/control_flow/when.fir.diag.txt
@@ -146,14 +146,14 @@ method f$unusedResult$TF$() returns (ret$0: Ref)
 }
 
 /when.kt:(1221,1227): info: Generated Viper text for whenIs:
-method f$whenIs$TF$T$c$Foo(p$x: Ref) returns (ret$0: Ref)
+method f$whenIs$TF$T$Foo(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$x), wildcard)
   anon$0 := p$x
-  if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$T$c$Bar())) {
+  if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar())) {
     ret$0 := df$rt$boolToRef(true)
   } else {
     ret$0 := df$rt$boolToRef(false)}

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/extension_properties.fir.diag.txt
@@ -44,19 +44,19 @@ method f$extensionSetterProperty$TF$() returns (ret$0: Ref)
 /extension_properties.kt:(414,453): info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
 field bf$x: Ref
 
-method eg$pfValProp$TF$T$c$PrimitiveField(this$dispatch: Ref)
+method eg$pfValProp$TF$T$PrimitiveField(this$dispatch: Ref)
   returns (ret: Ref)
 
 
-method f$extensionGetterPropertyUserDefinedClass$TF$T$c$PrimitiveField(p$pf: Ref)
+method f$extensionGetterPropertyUserDefinedClass$TF$T$PrimitiveField(p$pf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$T$c$PrimitiveField())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
-  anon$0 := eg$pfValProp$TF$T$c$PrimitiveField(p$pf)
+  anon$0 := eg$pfValProp$TF$T$PrimitiveField(p$pf)
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
   label lbl$ret$0
@@ -66,22 +66,22 @@ method f$extensionGetterPropertyUserDefinedClass$TF$T$c$PrimitiveField(p$pf: Ref
 /extension_properties.kt:(508,547): info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
 field bf$x: Ref
 
-method eg$pfVarProp$TF$T$c$PrimitiveField(this$dispatch: Ref)
+method eg$pfVarProp$TF$T$PrimitiveField(this$dispatch: Ref)
   returns (ret: Ref)
 
 
-method es$pfVarProp$TF$T$c$PrimitiveField$T$Int(this$dispatch: Ref, anon$0: Ref)
+method es$pfVarProp$TF$T$PrimitiveField$T$Int(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
 
 
-method f$extensionSetterPropertyUserDefinedClass$TF$T$c$PrimitiveField(p$pf: Ref)
+method f$extensionSetterPropertyUserDefinedClass$TF$T$PrimitiveField(p$pf: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$T$c$PrimitiveField())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
-  anon$0 := es$pfVarProp$TF$T$c$PrimitiveField$T$Int(p$pf, df$rt$intToRef(42))
+  anon$0 := es$pfVarProp$TF$T$PrimitiveField$T$Int(p$pf, df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -13,7 +13,7 @@ domain d$rt  {
 
   unique function df$rt$functionType(): d$rt
 
-  unique function df$rt$T$c$Foo(): d$rt
+  unique function df$rt$c$Foo(): d$rt
 
   function df$rt$nullValue(): Ref
 
@@ -100,7 +100,7 @@ domain d$rt  {
   }
 
   axiom {
-    df$rt$isSubtype(df$rt$T$c$Foo(), df$rt$anyType())
+    df$rt$isSubtype(df$rt$c$Foo(), df$rt$anyType())
   }
 
   axiom rt$supertype_of_nothing {
@@ -280,7 +280,7 @@ predicate p$c$Foo$unique(this$dispatch: Ref) {
 }
 
 method con$c$Foo$T$Int(p$x: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)
   ensures (unfolding acc(p$c$Foo$shared(ret), wildcard) in
@@ -299,6 +299,6 @@ method f$f$TF$() returns (ret$0: Ref)
 /full_viper_dump.kt:(172,173): info: Generated ExpEmbedding for f$f$TF$:
 Function(
     name = f$f$TF$,
-    { Declare(Var(l0$foo), T$c$Foo, MethodCall(callee = con$c$Foo$T$Int, Int(0))) },
+    { Declare(Var(l0$foo), T$Foo, MethodCall(callee = con$c$Foo$T$Int, Int(0))) },
     return = lbl$ret$0,
 )

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/function_overloading.fir.diag.txt
@@ -1,44 +1,44 @@
 /function_overloading.kt:(49,52): info: Generated Viper text for baz:
-method f$c$Bar$baz$TF$T$c$Bar$T$c$Foo(this$dispatch: Ref, p$f: Ref)
+method f$c$Bar$baz$TF$T$Bar$T$Foo(this$dispatch: Ref, p$f: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(74,77): info: Generated Viper text for baz:
-method f$c$Bar$baz$TF$T$c$Bar$T$c$Bar(this$dispatch: Ref, p$b: Ref)
+method f$c$Bar$baz$TF$T$Bar$T$Bar(this$dispatch: Ref, p$b: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(98,107): info: Generated Viper text for fakePrint:
-method f$fakePrint$TF$T$c$Bar(p$b: Ref) returns (ret$0: Ref)
+method f$fakePrint$TF$T$Bar(p$b: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(125,134): info: Generated Viper text for fakePrint:
-method f$fakePrint$TF$T$c$Foo(p$f: Ref) returns (ret$0: Ref)
+method f$fakePrint$TF$T$Foo(p$f: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -72,7 +72,7 @@ method f$differInNullability$TF$T$Int(p$i: Ref) returns (ret$0: Ref)
 }
 
 /function_overloading.kt:(256,275): info: Generated Viper text for differInNullability:
-method f$differInNullability$TF$N$Int(p$i: Ref) returns (ret$0: Ref)
+method f$differInNullability$TF$NT$Int(p$i: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$nullable(df$rt$intType()))
@@ -82,30 +82,30 @@ method f$differInNullability$TF$N$Int(p$i: Ref) returns (ret$0: Ref)
 
 /function_overloading.kt:(295,321): info: Generated Viper text for testGlobalScopeOverloading:
 method con$c$Bar$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Bar())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret), wildcard)
   ensures acc(p$c$Bar$unique(ret), write)
 
 
 method con$c$Foo$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)
+
+
+method f$fakePrint$TF$T$Bar(p$b: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$fakePrint$TF$T$Boolean(p$truth: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
+method f$fakePrint$TF$T$Foo(p$f: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
 method f$fakePrint$TF$T$Int(p$value: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-
-
-method f$fakePrint$TF$T$c$Bar(p$b: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-
-
-method f$fakePrint$TF$T$c$Foo(p$f: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -121,32 +121,32 @@ method f$testGlobalScopeOverloading$TF$() returns (ret$0: Ref)
   anon$0 := f$fakePrint$TF$T$Int(df$rt$intToRef(42))
   anon$1 := f$fakePrint$TF$T$Boolean(df$rt$boolToRef(true))
   anon$3 := con$c$Foo$()
-  anon$2 := f$fakePrint$TF$T$c$Foo(anon$3)
+  anon$2 := f$fakePrint$TF$T$Foo(anon$3)
   anon$5 := con$c$Bar$()
-  anon$4 := f$fakePrint$TF$T$c$Bar(anon$5)
+  anon$4 := f$fakePrint$TF$T$Bar(anon$5)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(413,441): info: Generated Viper text for testClassFunctionOverloading:
 method con$c$Bar$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Bar())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret), wildcard)
   ensures acc(p$c$Bar$unique(ret), write)
 
 
 method con$c$Foo$() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Foo())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)
 
 
-method f$c$Bar$baz$TF$T$c$Bar$T$c$Bar(this$dispatch: Ref, p$b: Ref)
+method f$c$Bar$baz$TF$T$Bar$T$Bar(this$dispatch: Ref, p$b: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$c$Bar$baz$TF$T$c$Bar$T$c$Foo(this$dispatch: Ref, p$f: Ref)
+method f$c$Bar$baz$TF$T$Bar$T$Foo(this$dispatch: Ref, p$f: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
@@ -161,9 +161,9 @@ method f$testClassFunctionOverloading$TF$() returns (ret$0: Ref)
   var anon$3: Ref
   l0$b := con$c$Bar$()
   anon$1 := con$c$Foo$()
-  anon$0 := f$c$Bar$baz$TF$T$c$Bar$T$c$Foo(l0$b, anon$1)
+  anon$0 := f$c$Bar$baz$TF$T$Bar$T$Foo(l0$b, anon$1)
   anon$3 := con$c$Bar$()
-  anon$2 := f$c$Bar$baz$TF$T$c$Bar$T$c$Bar(l0$b, anon$3)
+  anon$2 := f$c$Bar$baz$TF$T$Bar$T$Bar(l0$b, anon$3)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/as_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/as_operator.fir.diag.txt
@@ -1,11 +1,11 @@
 /as_operator.kt:(57,63): info: Generated Viper text for testAs:
-method f$testAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$T$c$Bar())
+method f$testAs$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Bar())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$foo), wildcard)
   ret$0 := p$foo
   goto lbl$ret$0
@@ -13,15 +13,15 @@ method f$testAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(97,111): info: Generated Viper text for testNullableAs:
-method f$testNullableAs$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
+method f$testNullableAs$TF$NT$Foo(p$foo: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Bar()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(p$foo), wildcard)
   ret$0 := p$foo
@@ -30,18 +30,18 @@ method f$testNullableAs$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(148,158): info: Generated Viper text for testSafeAs:
-method f$testSafeAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
+method f$testSafeAs$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Bar())) {
+  if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
     ret$0 := p$foo
   } else {
     ret$0 := df$rt$nullValue()}
-  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   inhale ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
   goto lbl$ret$0
@@ -49,19 +49,19 @@ method f$testSafeAs$TF$T$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 
 /as_operator.kt:(194,212): info: Generated Viper text for testNullableSafeAs:
-method f$testNullableSafeAs$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
+method f$testNullableSafeAs$TF$NT$Foo(p$foo: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
-  if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Bar())) {
+  if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
     ret$0 := p$foo
   } else {
     ret$0 := df$rt$nullValue()}
-  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$T$c$Bar()))
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   inhale ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
   goto lbl$ret$0

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/elvis.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/elvis.fir.diag.txt
@@ -1,5 +1,5 @@
 /elvis.kt:(121,134): info: Generated Viper text for elvisOperator:
-method f$elvisOperator$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperator$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -12,30 +12,30 @@ method f$elvisOperator$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /elvis.kt:(176,196): info: Generated Viper text for elvisOperatorComplex:
-method f$elvisOperator$TF$N$Int(p$x: Ref) returns (ret: Ref)
+method f$elvisOperator$TF$NT$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$elvisOperatorComplex$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperatorComplex$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  anon$0 := f$id$TF$N$Int(p$x)
+  anon$0 := f$id$TF$NT$Int(p$x)
   if (anon$0 != df$rt$nullValue()) {
     ret$0 := anon$0
   } else {
-    ret$0 := f$elvisOperator$TF$N$Int(df$rt$intToRef(2))}
+    ret$0 := f$elvisOperator$TF$NT$Int(df$rt$intToRef(2))}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$id$TF$N$Int(p$x: Ref) returns (ret: Ref)
+method f$id$TF$NT$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /elvis.kt:(257,276): info: Generated Viper text for elvisOperatorReturn:
-method f$elvisOperatorReturn$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$elvisOperatorReturn$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/is_operator.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/is_operator.fir.diag.txt
@@ -1,5 +1,5 @@
 /is_operator.kt:(23,36): info: Generated Viper text for isNonNullable:
-method f$isNonNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$isNonNullable$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -9,7 +9,7 @@ method f$isNonNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_operator.kt:(84,97): info: Generated Viper text for notIsNullable:
-method f$notIsNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$notIsNullable$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
@@ -19,7 +19,7 @@ method f$notIsNullable$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /is_operator.kt:(150,159): info: Generated Viper text for smartCast:
-method f$smartCast$TF$N$Any(p$x: Ref) returns (ret$0: Ref)
+method f$smartCast$TF$NT$Any(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/safe_call.fir.diag.txt
@@ -1,19 +1,19 @@
 /safe_call.kt:(142,154): info: Generated Viper text for testSafeCall:
 field bf$x: Ref
 
-method f$c$Foo$f$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$f$TF$T$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testSafeCall$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testSafeCall$TF$NT$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
-    anon$0 := f$c$Foo$f$TF$T$c$Foo(p$foo)
+    anon$0 := f$c$Foo$f$TF$T$Foo(p$foo)
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -24,19 +24,18 @@ method f$testSafeCall$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 /safe_call.kt:(217,240): info: Generated Viper text for testSafeCallNonNullable:
 field bf$x: Ref
 
-method f$c$Foo$f$TF$T$c$Foo(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$f$TF$T$Foo(this$dispatch: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testSafeCallNonNullable$TF$T$c$Foo(p$foo: Ref)
-  returns (ret$0: Ref)
+method f$testSafeCallNonNullable$TF$T$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
-    anon$0 := f$c$Foo$f$TF$T$c$Foo(p$foo)
+    anon$0 := f$c$Foo$f$TF$T$Foo(p$foo)
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -47,10 +46,10 @@ method f$testSafeCallNonNullable$TF$T$c$Foo(p$foo: Ref)
 /safe_call.kt:(267,287): info: Generated Viper text for testSafeCallProperty:
 field bf$x: Ref
 
-method f$testSafeCallProperty$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
+method f$testSafeCallProperty$TF$NT$Foo(p$foo: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$T$c$Foo()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
@@ -67,11 +66,11 @@ method f$testSafeCallProperty$TF$N$c$Foo(p$foo: Ref) returns (ret$0: Ref)
 /safe_call.kt:(354,385): info: Generated Viper text for testSafeCallPropertyNonNullable:
 field bf$x: Ref
 
-method f$testSafeCallPropertyNonNullable$TF$T$c$Foo(p$foo: Ref)
+method f$testSafeCallPropertyNonNullable$TF$T$Foo(p$foo: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$T$c$Foo())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
@@ -87,25 +86,25 @@ method f$testSafeCallPropertyNonNullable$TF$T$c$Foo(p$foo: Ref)
 /safe_call.kt:(493,506): info: Generated Viper text for safeCallChain:
 field bf$v: Ref
 
-method f$c$Rec$nullable$TF$T$c$Rec(this$dispatch: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$T$c$Rec()))
+method f$c$Rec$nullable$TF$T$Rec(this$dispatch: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$c$Rec()))
   ensures ret != df$rt$nullValue() ==> acc(p$c$Rec$shared(ret), wildcard)
 
 
-method f$safeCallChain$TF$N$c$Rec(p$rec: Ref) returns (ret$0: Ref)
+method f$safeCallChain$TF$NT$Rec(p$rec: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$nullable(df$rt$T$c$Rec()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$nullable(df$rt$c$Rec()))
   inhale p$rec != df$rt$nullValue() ==>
     acc(p$c$Rec$shared(p$rec), wildcard)
   if (p$rec != df$rt$nullValue()) {
-    anon$1 := f$c$Rec$nullable$TF$T$c$Rec(p$rec)
+    anon$1 := f$c$Rec$nullable$TF$T$Rec(p$rec)
   } else {
     anon$1 := df$rt$nullValue()}
   if (anon$1 != df$rt$nullValue()) {
-    anon$0 := f$c$Rec$nullable$TF$T$c$Rec(anon$1)
+    anon$0 := f$c$Rec$nullable$TF$T$Rec(anon$1)
   } else {
     anon$0 := df$rt$nullValue()}
   if (anon$0 != df$rt$nullValue()) {

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/generics.fir.diag.txt
@@ -1,11 +1,11 @@
 /generics.kt:(52,65): info: Generated Viper text for genericMethod:
 field bf$t: Ref
 
-method f$c$Box$genericMethod$TF$T$c$Box$N$Any(this$dispatch: Ref, p$x: Ref)
+method f$c$Box$genericMethod$TF$T$Box$NT$Any(this$dispatch: Ref, p$x: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$T$c$Box())
+  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Box())
   inhale acc(p$c$Box$shared(this$dispatch), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$x
@@ -16,8 +16,8 @@ method f$c$Box$genericMethod$TF$T$c$Box$N$Any(this$dispatch: Ref, p$x: Ref)
 /generics.kt:(107,116): info: Generated Viper text for createBox:
 field bf$t: Ref
 
-method con$c$Box$N$Any(p$t: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
+method con$c$Box$NT$Any(p$t: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
 
@@ -30,14 +30,14 @@ method f$createBox$TF$() returns (ret$0: Ref)
   var anon$0: Ref
   var l0$intBox: Ref
   var anon$1: Ref
-  l0$boolBox := con$c$Box$N$Any(df$rt$boolToRef(true))
+  l0$boolBox := con$c$Box$NT$Any(df$rt$boolToRef(true))
   inhale acc(l0$boolBox.bf$t, write)
   anon$0 := l0$boolBox.bf$t
   exhale acc(l0$boolBox.bf$t, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   l0$b := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
-  l0$intBox := con$c$Box$N$Any(df$rt$intToRef(2))
+  l0$intBox := con$c$Box$NT$Any(df$rt$intToRef(2))
   inhale acc(l0$intBox.bf$t, write)
   anon$1 := l0$intBox.bf$t
   exhale acc(l0$intBox.bf$t, write)
@@ -51,8 +51,8 @@ method f$createBox$TF$() returns (ret$0: Ref)
 /generics.kt:(227,242): info: Generated Viper text for setGenericField:
 field bf$t: Ref
 
-method con$c$Box$N$Any(p$t: Ref) returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$T$c$Box())
+method con$c$Box$NT$Any(p$t: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
 
@@ -61,7 +61,7 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$box: Ref
-  l0$box := con$c$Box$N$Any(df$rt$intToRef(3))
+  l0$box := con$c$Box$NT$Any(df$rt$intToRef(3))
   inhale acc(l0$box.bf$t, write)
   l0$box.bf$t := df$rt$intToRef(5)
   exhale acc(l0$box.bf$t, write)
@@ -70,7 +70,7 @@ method f$setGenericField$TF$() returns (ret$0: Ref)
 }
 
 /generics.kt:(293,303): info: Generated Viper text for genericFun:
-method f$genericFun$TF$N$Any(p$t: Ref) returns (ret$0: Ref)
+method f$genericFun$TF$NT$Any(p$t: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
@@ -85,26 +85,26 @@ method f$callGenericFunc$TF$() returns (ret$0: Ref)
 {
   var l0$x: Ref
   var anon$0: Ref
-  anon$0 := f$genericFun$TF$N$Any(df$rt$intToRef(3))
+  anon$0 := f$genericFun$TF$NT$Any(df$rt$intToRef(3))
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$genericFun$TF$N$Any(p$t: Ref) returns (ret: Ref)
+method f$genericFun$TF$NT$Any(p$t: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /generics.kt:(375,395): info: Generated Viper text for genericAsIfCondition:
 field bf$t: Ref
 
-method f$genericAsIfCondition$TF$T$c$Box(p$box: Ref) returns (ret$0: Ref)
+method f$genericAsIfCondition$TF$T$Box(p$box: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$T$c$Box())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
   inhale acc(p$c$Box$shared(p$box), wildcard)
   inhale acc(p$box.bf$t, write)
   anon$1 := p$box.bf$t

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/nullable.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/nullable.fir.diag.txt
@@ -1,5 +1,5 @@
 /nullable.kt:(80,96): info: Generated Viper text for useNullableTwice:
-method f$useNullableTwice$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$useNullableTwice$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$a: Ref
@@ -13,23 +13,23 @@ method f$useNullableTwice$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /nullable.kt:(162,183): info: Generated Viper text for passNullableParameter:
-method f$passNullableParameter$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$passNullableParameter$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  anon$0 := f$useNullableTwice$TF$N$Int(p$x)
+  anon$0 := f$useNullableTwice$TF$NT$Int(p$x)
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$useNullableTwice$TF$N$Int(p$x: Ref) returns (ret: Ref)
+method f$useNullableTwice$TF$NT$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /nullable.kt:(245,271): info: Generated Viper text for nullableNullableComparison:
-method f$nullableNullableComparison$TF$N$Int$N$Int(p$x: Ref, p$y: Ref)
+method f$nullableNullableComparison$TF$NT$Int$NT$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
@@ -41,7 +41,7 @@ method f$nullableNullableComparison$TF$N$Int$N$Int(p$x: Ref, p$y: Ref)
 }
 
 /nullable.kt:(326,355): info: Generated Viper text for nullableNonNullableComparison:
-method f$nullableNonNullableComparison$TF$N$Int$N$Int(p$x: Ref, p$y: Ref)
+method f$nullableNonNullableComparison$TF$NT$Int$NT$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
@@ -53,7 +53,7 @@ method f$nullableNonNullableComparison$TF$N$Int$N$Int(p$x: Ref, p$y: Ref)
 }
 
 /nullable.kt:(410,424): info: Generated Viper text for nullComparison:
-method f$nullComparison$TF$N$Int(p$x: Ref) returns (ret$0: Ref)
+method f$nullComparison$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/types/smartcast.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/types/smartcast.fir.diag.txt
@@ -1,5 +1,5 @@
 /smartcast.kt:(23,38): info: Generated Viper text for smartcastReturn:
-method f$smartcastReturn$TF$N$Int(p$n: Ref) returns (ret$0: Ref)
+method f$smartcastReturn$TF$NT$Int(p$n: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
@@ -12,11 +12,11 @@ method f$smartcastReturn$TF$N$Int(p$n: Ref) returns (ret$0: Ref)
 }
 
 /smartcast.kt:(88,106): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$N$c$pkg$kotlin$CharSequence(p$seq: Ref)
+method f$isNullOrEmptyWrong$TF$NT$CharSequence(p$seq: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$T$c$pkg$kotlin$CharSequence()))
+  inhale df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   inhale p$seq != df$rt$nullValue() ==>
     acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   if (p$seq == df$rt$nullValue()) {


### PR DESCRIPTION
This makes it easier to uniformly track flags for our embeddings; in Kotlin this is normally just nullability, but we also need to track uniqueness and borrowing.

This PR just restructures the code, it doesn't add any new support for unique/borrowing yet.

The PR does not attempt to fix the naming issues; it would be good to structure naming better, but I'll do that in a follow-up PR.