### PR TITLE
Support nested `unfolding in` instead of `unfold` in `Pure Linearizer`

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -299,12 +299,12 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                     require(param is FirVariableEmbedding) { "Constructor parameters must be represented by FirVariableEmbeddings" }
                     constructorParamSymbolsToFields[param.symbol]?.let { field ->
                         (field.accessPolicy == AccessPolicy.ALWAYS_READABLE).ifTrue {
-                            EqCmp(PrimitiveFieldAccess(returnVariable, field), param)
+                            EqCmp(FieldAccess(returnVariable, field), param)
                         }
                     }
                 }
                 return if (invariants.isEmpty()) null
-                else UnfoldingSharedClassPredicateEmbedding(returnVariable, invariants.toConjunction())
+                else invariants.toConjunction()
             }
 
             override val declarationSource: KtSourceElement? = symbol.source

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ControlFlow.kt
@@ -162,35 +162,6 @@ data class NonDeterministically(val exp: ExpEmbedding) : UnitResultExpEmbedding,
         get() = listOf(exp)
 }
 
-data class UnfoldingSharedClassPredicateEmbedding(val predicated: VariableEmbedding, override val inner: ExpEmbedding) :
-    UnaryDirectResultExpEmbedding {
-    override val type: TypeEmbedding = inner.type
-    private fun toViperImpl(ctx: LinearizationContext, action: ExpEmbedding.() -> Exp): Exp {
-        val predicatedType = predicated.type.pretype
-        check(predicatedType is ClassTypeEmbedding) {
-            "Built-in types do not have predicates."
-        }
-        return Exp.Unfolding(
-            Exp.PredicateAccess(
-                predicatedType.details.sharedPredicate.name,
-                listOf(predicated.pureToViper(false)),
-                PermExp.WildcardPerm(),
-                pos = ctx.source.asPosition,
-                info = sourceRole.asInfo
-            ),
-            inner.action()
-        )
-    }
-
-    override fun toViper(ctx: LinearizationContext): Exp = toViperImpl(ctx) {
-        toViper(ctx)
-    }
-
-    override fun toViperBuiltinType(ctx: LinearizationContext): Exp = toViperImpl(ctx) {
-        toViperBuiltinType(ctx)
-    }
-}
-
 // Note: this is always a *real* Viper method call.
 data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbedding>) : StoredResultExpEmbedding {
     override val type: TypeEmbedding = method.callableType.returnType

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/LinearizationContext.kt
@@ -15,6 +15,10 @@ import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Label
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
+enum class UnfoldPolicy {
+    UNFOLD, UNFOLDING_IN;
+}
+
 /**
  * Context in which an `ExpEmbedding` can be flattened to an `Exp` and a sequence of `Stmt`s.
  *
@@ -24,6 +28,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
  */
 interface LinearizationContext {
     val source: KtSourceElement?
+    val unfoldPolicy: UnfoldPolicy
 
     fun freshAnonVar(type: TypeEmbedding): AnonymousVariableEmbedding
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/Linearizer.kt
@@ -22,6 +22,9 @@ data class Linearizer(
     override val source: KtSourceElement?,
     val stmtModifierTracker: StmtModifierTracker? = null
 ) : LinearizationContext {
+    override val unfoldPolicy: UnfoldPolicy
+        get() = UnfoldPolicy.UNFOLD
+
     override fun freshAnonVar(type: TypeEmbedding): AnonymousVariableEmbedding {
         val variable = state.freshAnonVar(type)
         addDeclaration(variable.toLocalVarDecl())

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/linearization/PureLinearizer.kt
@@ -24,6 +24,9 @@ class PureLinearizerMisuseException(val offendingFunction: String) : IllegalStat
  * would be an error.
  */
 class PureLinearizer(override val source: KtSourceElement?) : LinearizationContext {
+    override val unfoldPolicy: UnfoldPolicy
+        get() = UnfoldPolicy.UNFOLDING_IN
+
     override fun <R> withPosition(newSource: KtSourceElement, action: LinearizationContext.() -> R): R =
         PureLinearizer(newSource).action()
 

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/inheritance_fields.fir.diag.txt
@@ -56,8 +56,9 @@ method con$c$SecondBackingFieldClass$T$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$SecondBackingFieldClass())
   ensures acc(p$c$SecondBackingFieldClass$shared(ret), wildcard)
   ensures acc(p$c$SecondBackingFieldClass$unique(ret), write)
-  ensures (unfolding acc(p$c$SecondBackingFieldClass$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$x) == df$rt$intFromRef(p$x))
+  ensures df$rt$intFromRef((unfolding acc(p$c$SecondBackingFieldClass$shared(ret), wildcard) in
+      ret.bf$x)) ==
+    df$rt$intFromRef(p$x)
 
 
 method f$createBFsAndNoBF$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/interface.fir.diag.txt
@@ -39,8 +39,9 @@ method con$c$Impl$T$Int(p$number: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl())
   ensures acc(p$c$Impl$shared(ret), wildcard)
   ensures acc(p$c$Impl$unique(ret), write)
-  ensures (unfolding acc(p$c$Impl$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$number) == df$rt$intFromRef(p$number))
+  ensures df$rt$intFromRef((unfolding acc(p$c$Impl$shared(ret), wildcard) in
+      ret.bf$number)) ==
+    df$rt$intFromRef(p$number)
 
 
 method f$createImpl$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/primary_constructors.fir.diag.txt
@@ -8,9 +8,12 @@ method con$c$PrimitiveFields$T$Int$T$Int(p$a: Ref, p$b: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
   ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveFields$unique(ret), write)
-  ensures (unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$a) == df$rt$intFromRef(p$a) &&
-      df$rt$intFromRef(ret.bf$b) == df$rt$intFromRef(p$b))
+  ensures df$rt$intFromRef((unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
+      ret.bf$a)) ==
+    df$rt$intFromRef(p$a) &&
+    df$rt$intFromRef((unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
+      ret.bf$b)) ==
+    df$rt$intFromRef(p$b)
 
 
 method f$createPrimitiveFields$TF$() returns (ret$0: Ref)
@@ -29,8 +32,8 @@ method con$c$Recursive$NT$Recursive(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)
-  ensures (unfolding acc(p$c$Recursive$shared(ret), wildcard) in
-      ret.bf$a == p$a)
+  ensures (unfolding acc(p$c$Recursive$shared(ret), wildcard) in ret.bf$a) ==
+    p$a
 
 
 method f$createRecursive$TF$() returns (ret$0: Ref)
@@ -51,8 +54,9 @@ method con$c$FieldInBody$T$Int(p$c: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FieldInBody())
   ensures acc(p$c$FieldInBody$shared(ret), wildcard)
   ensures acc(p$c$FieldInBody$unique(ret), write)
-  ensures (unfolding acc(p$c$FieldInBody$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$c) == df$rt$intFromRef(p$c))
+  ensures df$rt$intFromRef((unfolding acc(p$c$FieldInBody$shared(ret), wildcard) in
+      ret.bf$c)) ==
+    df$rt$intFromRef(p$c)
 
 
 method f$createFieldInBody$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/classes/secondary_constructors.fir.diag.txt
@@ -37,8 +37,9 @@ method con$c$BothConstructors$T$Int(p$a: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
   ensures acc(p$c$BothConstructors$shared(ret), wildcard)
   ensures acc(p$c$BothConstructors$unique(ret), write)
-  ensures (unfolding acc(p$c$BothConstructors$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$a) == df$rt$intFromRef(p$a))
+  ensures df$rt$intFromRef((unfolding acc(p$c$BothConstructors$shared(ret), wildcard) in
+      ret.bf$a)) ==
+    df$rt$intFromRef(p$a)
 
 
 method f$primaryAndSecondConstructor$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -402,8 +402,9 @@ method con$c$Foo$T$Int(p$x: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)
-  ensures (unfolding acc(p$c$Foo$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$x) == df$rt$intFromRef(p$x))
+  ensures df$rt$intFromRef((unfolding acc(p$c$Foo$shared(ret), wildcard) in
+      ret.bf$x)) ==
+    df$rt$intFromRef(p$x)
 
 
 method f$f$TF$() returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -15,8 +15,9 @@ method con$c$ClassWithMember$T$Int(p$member: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithMember())
   ensures acc(p$c$ClassWithMember$shared(ret), wildcard)
   ensures acc(p$c$ClassWithMember$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassWithMember$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$member) == df$rt$intFromRef(p$member))
+  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithMember$shared(ret), wildcard) in
+      ret.bf$member)) ==
+    df$rt$intFromRef(p$member)
 
 
 method f$checkMemberAccess$TF$() returns (ret$0: Ref)
@@ -91,8 +92,8 @@ method con$c$Box$NT$Any(p$wrapped: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
-  ensures (unfolding acc(p$c$Box$shared(ret), wildcard) in
-      ret.bf$wrapped == p$wrapped)
+  ensures (unfolding acc(p$c$Box$shared(ret), wildcard) in ret.bf$wrapped) ==
+    p$wrapped
 
 
 method f$checkGenericMemberAccess$TF$T$Box(p$box: Ref) returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/multiple_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/multiple_receivers.fir.diag.txt
@@ -66,8 +66,9 @@ method con$c$ClassWithExtension$T$Int(p$delta: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithExtension())
   ensures acc(p$c$ClassWithExtension$shared(ret), wildcard)
   ensures acc(p$c$ClassWithExtension$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassWithExtension$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$delta) == df$rt$intFromRef(p$delta))
+  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithExtension$shared(ret), wildcard) in
+      ret.bf$delta)) ==
+    df$rt$intFromRef(p$delta)
 
 
 method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref,

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/backing_field_getters.fir.diag.txt
@@ -204,17 +204,20 @@ method con$c$ClassI$T$Int$T$Int(p$x: Ref, p$y: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassI())
   ensures acc(p$c$ClassI$shared(ret), wildcard)
   ensures acc(p$c$ClassI$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassI$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$x) == df$rt$intFromRef(p$x) &&
-      df$rt$intFromRef(ret.bf$y) == df$rt$intFromRef(p$y))
+  ensures df$rt$intFromRef((unfolding acc(p$c$ClassI$shared(ret), wildcard) in
+      ret.bf$x)) ==
+    df$rt$intFromRef(p$x) &&
+    df$rt$intFromRef((unfolding acc(p$c$ClassI$shared(ret), wildcard) in
+      ret.bf$y)) ==
+    df$rt$intFromRef(p$y)
 
 
 method con$c$ClassII$T$Z(p$z: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassII())
   ensures acc(p$c$ClassII$shared(ret), wildcard)
   ensures acc(p$c$ClassII$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassII$shared(ret), wildcard) in
-      ret.bf$z == p$z)
+  ensures (unfolding acc(p$c$ClassII$shared(ret), wildcard) in ret.bf$z) ==
+    p$z
 
 
 method con$c$Z$() returns (ret: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/chars.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/chars.fir.diag.txt
@@ -7,8 +7,9 @@ method con$c$CharBox$T$Char(p$char: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CharBox())
   ensures acc(p$c$CharBox$shared(ret), wildcard)
   ensures acc(p$c$CharBox$unique(ret), write)
-  ensures (unfolding acc(p$c$CharBox$shared(ret), wildcard) in
-      df$rt$charFromRef(ret.bf$char) == df$rt$charFromRef(p$char))
+  ensures df$rt$charFromRef((unfolding acc(p$c$CharBox$shared(ret), wildcard) in
+      ret.bf$char)) ==
+    df$rt$charFromRef(p$char)
 
 
 method f$testChars$TF$T$Char(p$c: Ref) returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
@@ -85,8 +85,9 @@ method con$c$StringBox$T$String(p$str: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$StringBox())
   ensures acc(p$c$StringBox$shared(ret), wildcard)
   ensures acc(p$c$StringBox$unique(ret), write)
-  ensures (unfolding acc(p$c$StringBox$shared(ret), wildcard) in
-      df$rt$stringFromRef(ret.bf$str) == df$rt$stringFromRef(p$str))
+  ensures df$rt$stringFromRef((unfolding acc(p$c$StringBox$shared(ret), wildcard) in
+      ret.bf$str)) ==
+    df$rt$stringFromRef(p$str)
 
 
 method f$testType$TF$T$String(p$s: Ref) returns (ret$0: Ref)
@@ -200,8 +201,9 @@ method con$c$StringBox$T$String(p$str: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$StringBox())
   ensures acc(p$c$StringBox$shared(ret), wildcard)
   ensures acc(p$c$StringBox$unique(ret), write)
-  ensures (unfolding acc(p$c$StringBox$shared(ret), wildcard) in
-      df$rt$stringFromRef(ret.bf$str) == df$rt$stringFromRef(p$str))
+  ensures df$rt$stringFromRef((unfolding acc(p$c$StringBox$shared(ret), wildcard) in
+      ret.bf$str)) ==
+    df$rt$stringFromRef(p$str)
 
 
 method f$testLengthField$TF$T$String(p$s: Ref) returns (ret$0: Ref)
@@ -342,4 +344,3 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
 }
 
 method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-

--- a/plugins/formal-verification/testData/diagnostics/verifies/while.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/while.fir.diag.txt
@@ -7,8 +7,9 @@ method con$c$ClassWithField$T$Int(p$field: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithField())
   ensures acc(p$c$ClassWithField$shared(ret), wildcard)
   ensures acc(p$c$ClassWithField$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassWithField$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$field) == df$rt$intFromRef(p$field))
+  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithField$shared(ret), wildcard) in
+      ret.bf$field)) ==
+    df$rt$intFromRef(p$field)
 
 
 method f$pkg$kotlin$c$Int$unaryMinus$TF$T$Int(this$dispatch: Ref)
@@ -78,8 +79,9 @@ method con$c$ClassWithField$T$Int(p$field: Ref) returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithField())
   ensures acc(p$c$ClassWithField$shared(ret), wildcard)
   ensures acc(p$c$ClassWithField$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassWithField$shared(ret), wildcard) in
-      df$rt$intFromRef(ret.bf$field) == df$rt$intFromRef(p$field))
+  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithField$shared(ret), wildcard) in
+      ret.bf$field)) ==
+    df$rt$intFromRef(p$field)
 
 
 method f$test_while_with_inlining$TF$T$ClassWithField(p$param: Ref)


### PR DESCRIPTION
Now we're allowed to access read-only fields in pure contexts.
This is needed i.e. to write such invariants as `it <= s.length`.