### PR TITLE
Restore string tests after rebase

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -103,6 +103,22 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             else -> handleUnimplementedElement("Constant Expression of type ${literalExpression.kind} is not yet implemented.", data)
         }
 
+    private val FirLiteralExpression.stringValue: String
+        get() = value.toString()
+
+    override fun visitStringConcatenationCall(
+        stringConcatenationCall: FirStringConcatenationCall,
+        data: StmtConversionContext
+    ): ExpEmbedding {
+        val combinedLiteral = stringConcatenationCall.arguments.joinToString("") { arg ->
+            check(arg is FirLiteralExpression) {
+                "${arg::class.simpleName} is not supported as an element of string concatenation."
+            }
+            arg.stringValue
+        }
+        return StringLit(combinedLiteral)
+    }
+
     override fun visitIntegerLiteralOperatorCall(
         integerLiteralOperatorCall: FirIntegerLiteralOperatorCall,
         data: StmtConversionContext,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 import org.jetbrains.kotlin.formver.embeddings.expression.*
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.AddCharInt
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.AddIntInt
-import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.AddStringString
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.DivIntInt
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.MulIntInt
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.Not
@@ -176,16 +175,6 @@ object SpecialKotlinFunctions {
 
         addFunction(stringIntToCharType, SpecialPackages.kotlin, className = "String", name = "get") { args, _ ->
             StringGet(args[0], args[1])
-        }
-
-        val stringStringToStringType = buildFunctionPretype {
-            withDispatchReceiver { string() }
-            withParam { string() }
-            withReturnType { string() }
-        }
-
-        addFunction(stringStringToStringType, SpecialPackages.kotlin, className = "String", name = "plus") { args, _ ->
-            AddStringString(args[0], args[1])
         }
     }
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
@@ -299,6 +299,12 @@ predicate p$pkg$kotlin$c$String$unique(this$dispatch: Ref) {
   acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
+method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(this$dispatch: Ref, p$other: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
+  ensures acc(p$pkg$kotlin$c$String$shared(ret), wildcard)
+
+
 method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -306,6 +312,7 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var anon$1: Ref
   var l0$str: Ref
+  var l0$helloWorld: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   inhale acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
   unfold acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
@@ -327,6 +334,10 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   assert df$rt$stringFromRef(l0$str)[0] == df$rt$stringFromRef(l0$str)[2]
   assert !(df$rt$stringFromRef(l0$str)[1] == df$rt$stringFromRef(l0$str)[0])
   assert df$rt$stringFromRef(l0$str)[1] == 98
+  assert Seq(75, 111, 116, 108, 105, 110, 46, 83, 116, 114, 105, 110, 103) ==
+    Seq(75, 111, 116, 108, 105, 110, 46, 83, 116, 114, 105, 110, 103)
+  l0$helloWorld := f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(df$rt$stringToRef(Seq(72,
+    101, 108, 108, 111, 32, 87, 111, 114, 108, 100)), df$rt$charToRef(33))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.kt
@@ -30,6 +30,6 @@ fun <!VIPER_TEXT!>testOps<!>(s: String) {
         str[1] != str[0],
         str[1] == 'b',
     )
-    // verify("Kotlin" + "." + "String" == "Kotlin.String")
-    // val helloWorld = "Hello World" + '!'
+     verify("Kotlin" + "." + "String" == "Kotlin.String")
+     val helloWorld = "Hello World" + '!'
 }


### PR DESCRIPTION
String concatenation tests were failing because new `firElement` (`firStringConcatenationCall`) was not added to the visitor before.
Now it is supported.