### PR TITLE
Kotlin postconditions

### DIFF
--- a/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -16,6 +16,8 @@ fun loopInvariants(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.() -> Un
 
 fun preconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.() -> Unit) = Unit
 
+fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) -> Unit) = Unit
+
 /**
  * This class is designed as a receiver for lambda blocks of `loopInvariants`, `preconditions` and `postconditions`.
  * Later, it will have member methods, e.g. `forall`.

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FormverFirBlock.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FormverFirBlock.kt
@@ -5,37 +5,49 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
+import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.isFormverFunctionNamed
 
-private fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirBlock? {
+private fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirAnonymousFunction? {
     if (this !is FirFunctionCall) return null
     val firFunction = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return null
     if (!predicate(firFunction)) return null
     val formverInvariantsArgument = argument
     if (formverInvariantsArgument !is FirAnonymousFunctionExpression)
         error("Only lambdas are allowed as arguments of ${firFunction.name}.")
-    return formverInvariantsArgument.anonymousFunction.body
+    return formverInvariantsArgument.anonymousFunction
 }
 
 fun extractLoopInvariants(parentBlock: FirBlock): FirBlock? {
     val firstStmt = parentBlock.statements.firstOrNull() ?: return null
-    return firstStmt.extractFormverFirBlock { isFormverFunctionNamed("loopInvariants") }
+    return firstStmt.extractFormverFirBlock { isFormverFunctionNamed("loopInvariants") }?.body
 }
 
-data class FirSpecification(val precond: FirBlock?, val postcond: FirBlock?)
+data class FirSpecification(val precond: FirBlock?, val postcond: FirBlock?, val returnVar: FirValueParameterSymbol?) {
+    constructor() : this(null, null, null)
+}
 
-fun extractFirSpecification(parentBlock: FirBlock): FirSpecification {
-    val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification(null, null)
+private fun FirAnonymousFunction.extractFormverReturnVar(returnType: ConeKotlinType): FirValueParameterSymbol {
+    val param = valueParameters.first()
+    if (param.symbol.resolvedReturnType != returnType)
+        error("Expected type ${returnType} based on signature, got ${param.symbol.resolvedReturnType}")
+    return param.symbol
+}
 
-    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let {
-        return FirSpecification(null, it)
+fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType): FirSpecification {
+    val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification()
+
+    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let { lambda ->
+        return FirSpecification(null, lambda.body, lambda.extractFormverReturnVar(returnType))
     }
 
     val precond = firstStmt.extractFormverFirBlock { isFormverFunctionNamed("preconditions") }
-        ?: return FirSpecification(null, null)
+        ?: return FirSpecification()
     val postcond = parentBlock.statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
-    return FirSpecification(precond, postcond)
+    return FirSpecification(precond.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ParameterResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ParameterResolver.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.config.AnalysisFlag.Delegates.Boolean.Companion.defaultValue
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
@@ -32,7 +31,7 @@ interface ParameterResolver {
 fun ParameterResolver.resolveNamedReturnTarget(returnPointName: String): ReturnTarget? =
     (returnPointName == labelName).ifTrue { defaultResolvedReturnTarget }
 
-open class RootParameterResolver(
+class RootParameterResolver(
     val ctx: ProgramConversionContext,
     private val signature: FunctionSignature,
     firArgs: List<FirValueParameterSymbol>,
@@ -51,17 +50,13 @@ open class RootParameterResolver(
     }
 }
 
-class SpecificationParameterResolver(
-    ctx: ProgramConversionContext,
-    signature: FunctionSignature,
-    firArgs: List<FirValueParameterSymbol>,
-    labelName: String?,
-    defaultResolvedReturnTarget: ReturnTarget,
-    private val substitutedReturnParameter: FirValueParameterSymbol?,
-) : RootParameterResolver(ctx, signature, firArgs, labelName, defaultResolvedReturnTarget) {
+class SubstitutedReturnParameterResolver(
+    private val rootResolver: RootParameterResolver,
+    private val substitutedReturnParameter: FirValueParameterSymbol,
+) : ParameterResolver by rootResolver {
     override fun tryResolveParameter(symbol: FirValueParameterSymbol): ExpEmbedding? {
         if (substitutedReturnParameter == symbol) return defaultResolvedReturnTarget.variable
-        return super.tryResolveParameter(symbol)
+        return rootResolver.tryResolveParameter(symbol)
     }
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -294,7 +294,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
 
         return object : FullNamedFunctionSignature, NamedFunctionSignature by subSignature {
             // TODO (inhale vs require) Decide if `predicateAccessInvariant` should be required rather than inhaled in the beginning of the body.
-            override fun getPreconditions(returnVariable: VariableEmbedding) = buildList {
+            override fun getPreconditions() = buildList {
                 subSignature.formalArgs.forEach {
                     addAll(it.pureInvariants())
                     addAll(it.accessInvariants())

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
-import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullNamedFunctionSignature.kt
@@ -26,7 +26,7 @@ interface FullNamedFunctionSignature : NamedFunctionSignature {
     /**
      * Preconditions of function in form of `ExpEmbedding`s with type `boolType()`.
      */
-    fun getPreconditions(returnVariable: VariableEmbedding): List<ExpEmbedding>
+    fun getPreconditions(): List<ExpEmbedding>
 
     /**
      * Postconditions of function in form of `ExpEmbedding`s with type `boolType()`.
@@ -47,7 +47,7 @@ abstract class PropertyAccessorFunctionSignature(
     override val name: MangledName,
     propertySymbol: FirPropertySymbol,
 ) : FullNamedFunctionSignature, GenericFunctionSignatureMixin() {
-    override fun getPreconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
+    override fun getPreconditions() = emptyList<ExpEmbedding>()
     override fun getPostconditions(returnVariable: VariableEmbedding) = emptyList<ExpEmbedding>()
     override val dispatchReceiver: VariableEmbedding
         get() = PlaceholderVariableEmbedding(DispatchReceiverName, buildType { nullableAny() })
@@ -87,7 +87,7 @@ fun FullNamedFunctionSignature.toViperMethod(
     name,
     formalArgs.map { it.toLocalVarDecl() },
     returnVariable.toLocalVarDecl(),
-    getPreconditions(returnVariable).pureToViper(toBuiltin = true),
+    getPreconditions().pureToViper(toBuiltin = true),
     getPostconditions(returnVariable).pureToViper(toBuiltin = true),
     body,
     declarationSource.asPosition

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.SubCharInt
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.SubIntInt
 import org.jetbrains.kotlin.formver.embeddings.types.buildFunctionPretype
+import org.jetbrains.kotlin.formver.embeddings.types.nullableAny
 import org.jetbrains.kotlin.formver.names.*
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.name.CallableId
@@ -122,6 +123,25 @@ object SpecialKotlinFunctions {
         withCallableType(invariantsBuilderCallableType) {
             addNoOpFunction(SpecialPackages.formver, name = "loopInvariants")
             addNoOpFunction(SpecialPackages.formver, name = "preconditions")
+        }
+
+        val postconditionsBuilderCallableType = buildFunctionPretype {
+            withParam {
+                function {
+                    withDispatchReceiver {
+                        klass {
+                            withName(invariantBuilderTypeName)
+                        }
+                    }
+                    withParam { nullableAny() }
+                    withReturnType { unit() }
+                }
+            }
+            withReturnType { unit() }
+        }
+
+        withCallableType(postconditionsBuilderCallableType) {
+            addNoOpFunction(SpecialPackages.formver, name = "postconditions")
         }
 
         val contractCallableType = buildFunctionPretype {

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.fir.diag.txt
@@ -1,6 +1,7 @@
-/simple_postcondition.kt:(239,250): info: Generated Viper text for testGreater:
+/simple_postcondition.kt:(64,75): info: Generated Viper text for testGreater:
 method f$testGreater$TF$T$Int(p$init: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures df$rt$intFromRef(ret$0) > df$rt$intFromRef(p$init)
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$init), df$rt$intType())
   ret$0 := sp$plusInts(p$init, df$rt$intToRef(5))
@@ -8,11 +9,12 @@ method f$testGreater$TF$T$Int(p$init: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/simple_postcondition.kt:(376,386): info: Generated Viper text for testString:
+/simple_postcondition.kt:(201,211): info: Generated Viper text for testString:
 field bf$length: Ref
 
 method f$testString$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$charType())
+  ensures df$rt$charFromRef(ret$0) == 97
 {
   ret$0 := sp$stringGet(df$rt$stringToRef(Seq(98, 97, 98)), df$rt$intToRef(1))
   goto lbl$ret$0
@@ -20,4 +22,48 @@ method f$testString$TF$() returns (ret$0: Ref)
 }
 
 method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+
+
+/simple_postcondition.kt:(323,343): info: Generated Viper text for testWithPrecondition:
+method f$testWithPrecondition$TF$T$Int(p$int: Ref) returns (ret$0: Ref)
+  requires df$rt$intFromRef(p$int) > 10
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures df$rt$intFromRef(ret$0) > 0
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$int), df$rt$intType())
+  ret$0 := sp$minusInts(p$int, df$rt$intToRef(10))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/simple_postcondition.kt:(492,507): info: Generated Viper text for returnGreater13:
+method f$returnGreater13$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures df$rt$intFromRef(ret$0) > 13
+{
+  ret$0 := df$rt$intToRef(16)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/simple_postcondition.kt:(600,608): info: Generated Viper text for scenario:
+method f$returnGreater13$TF$() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+  ensures df$rt$intFromRef(ret) > 13
+
+
+method f$scenario$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var anon$0: Ref
+  anon$0 := f$returnGreater13$TF$()
+  ret$0 := f$testWithPrecondition$TF$T$Int(anon$0)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method f$testWithPrecondition$TF$T$Int(p$int: Ref) returns (ret: Ref)
+  requires df$rt$intFromRef(p$int) > 10
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+  ensures df$rt$intFromRef(ret) > 0
 

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.fir.diag.txt
@@ -1,0 +1,23 @@
+/simple_postcondition.kt:(239,250): info: Generated Viper text for testGreater:
+method f$testGreater$TF$T$Int(p$init: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$init), df$rt$intType())
+  ret$0 := sp$plusInts(p$init, df$rt$intToRef(5))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/simple_postcondition.kt:(376,386): info: Generated Viper text for testString:
+field bf$length: Ref
+
+method f$testString$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$charType())
+{
+  ret$0 := sp$stringGet(df$rt$stringToRef(Seq(98, 97, 98)), df$rt$intToRef(1))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.kt
@@ -1,7 +1,4 @@
-import org.jetbrains.kotlin.formver.plugin.NeverConvert
-import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
-import org.jetbrains.kotlin.formver.plugin.verify
-import org.jetbrains.kotlin.formver.plugin.postconditions
+import org.jetbrains.kotlin.formver.plugin.*
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>testGreater<!>(init: Int) : Int {
@@ -19,3 +16,25 @@ fun <!VIPER_TEXT!>testString<!>() : Char {
     }
     return "bab"[1]
 }
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>testWithPrecondition<!>(int: Int): Int {
+    preconditions {
+        int > 10
+    }
+    postconditions<Int> {
+        it > 0
+    }
+    return int - 10
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>returnGreater13<!>(): Int {
+    postconditions<Int> {
+        it > 13
+    }
+    return 16
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>scenario<!>() = testWithPrecondition(returnGreater13())

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.kt
@@ -1,0 +1,21 @@
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.verify
+import org.jetbrains.kotlin.formver.plugin.postconditions
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>testGreater<!>(init: Int) : Int {
+    postconditions<Int> { result ->
+        result > init
+    }
+
+    return init + 5
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>testString<!>() : Char {
+    postconditions<Char> { res ->
+        res == 'a'
+    }
+    return "bab"[1]
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -691,6 +691,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
       }
 
       @Test
+      @TestMetadata("simple_postcondition.kt")
+      public void testSimple_postcondition() {
+        runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.kt");
+      }
+
+      @Test
       @TestMetadata("simple_precondition.kt")
       public void testSimple_precondition() {
         runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_precondition.kt");


### PR DESCRIPTION
This pull request introduces user-specified postconditions.

A single `postconditions` scope is allowed, either in the very beginning of the function or right after `preconditions` scope.
Note that `postconditions` consumes generic function, but the type in the lambda must always coincide with the return type of the function. 

Example:
```kotlin
fun decreaseByTen(int: Int) {
    preconditions {
        int >= 10
    }
    postconditions<Int> { res ->
        res >= 0
    }
    return int - 10
}
```