### PR TITLE
Forall scope

### DIFF
--- a/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -5,8 +5,8 @@
 
 package org.jetbrains.kotlin.formver.plugin
 
-private class FormverFunctionCalledInRuntimeError(offendingFunction: String) :
-    RuntimeException("Function `$offendingFunction` should never be called in runtime")
+private class FormverFunctionCalledInRuntimeException(offendingFunction: String) :
+    RuntimeException("Function `$offendingFunction` should never be called in runtime.")
 
 /**
  * Built-in function used to mark a boolean predicate to be verified in Viper.
@@ -27,5 +27,5 @@ fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) 
  * This class is designed as a receiver for lambda blocks of `loopInvariants`, `preconditions` and `postconditions`.
  */
 class InvariantBuilder {
-    fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit): Boolean = throw FormverFunctionCalledInRuntimeError("forAll")
+    fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit): Boolean = throw FormverFunctionCalledInRuntimeException("forAll")
 }

--- a/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/plugins/formal-verification/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -5,6 +5,9 @@
 
 package org.jetbrains.kotlin.formver.plugin
 
+private class FormverFunctionCalledInRuntimeError(offendingFunction: String) :
+    RuntimeException("Function `$offendingFunction` should never be called in runtime")
+
 /**
  * Built-in function used to mark a boolean predicate to be verified in Viper.
  * This function hooks-in in the `formver` plugin, its invocation in a Kotlin
@@ -22,6 +25,7 @@ fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) 
 
 /**
  * This class is designed as a receiver for lambda blocks of `loopInvariants`, `preconditions` and `postconditions`.
- * Later, it will have member methods, e.g. `forall`.
  */
-class InvariantBuilder
+class InvariantBuilder {
+    fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit): Boolean = throw FormverFunctionCalledInRuntimeError("forAll")
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -57,7 +57,7 @@ val FirBasedSymbol<*>.asSourceRole: SourceRole
 fun annotationId(name: String): ClassId =
     ClassId(FqName.fromSegments(SpecialPackages.formver), Name.identifier(name))
 
-fun formverCallableId(className: String? = null, name: String): CallableId =
+fun formverCallableId(className: String?, name: String): CallableId =
     if (className == null)
         CallableId(FqName.fromSegments(SpecialPackages.formver), Name.identifier(name))
     else
@@ -73,7 +73,7 @@ fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotat
 fun FirAnnotationContainer.isBorrowed(session: FirSession) = hasAnnotation(annotationId("Borrowed"), session)
 
 fun FirFunctionSymbol<*>.isFormverFunctionNamed(name: String) =
-    this is FirNamedFunctionSymbol && callableId == formverCallableId(null, name)
+    this is FirNamedFunctionSymbol && callableId == formverCallableId(className = null, name)
 
 fun FirFunctionSymbol<*>.isInvariantBuilderFunctionNamed(name: String) =
     this is FirNamedFunctionSymbol && callableId == formverCallableId("InvariantBuilder", name)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/FirUtils.kt
@@ -9,8 +9,6 @@ import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.FirAnnotationContainer
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.contracts.FirEffectDeclaration
-import org.jetbrains.kotlin.fir.declarations.FirFunction
-import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyGetter
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertySetter
@@ -59,8 +57,12 @@ val FirBasedSymbol<*>.asSourceRole: SourceRole
 fun annotationId(name: String): ClassId =
     ClassId(FqName.fromSegments(SpecialPackages.formver), Name.identifier(name))
 
-fun formverCallableId(name: String): CallableId =
-    CallableId(FqName.fromSegments(SpecialPackages.formver), Name.identifier(name))
+fun formverCallableId(className: String? = null, name: String): CallableId =
+    if (className == null)
+        CallableId(FqName.fromSegments(SpecialPackages.formver), Name.identifier(name))
+    else
+        CallableId(FqName.fromSegments(SpecialPackages.formver), FqName.fromSegments(listOf(className)), Name.identifier(name))
+
 
 fun FirBasedSymbol<*>.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
 
@@ -71,7 +73,10 @@ fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotat
 fun FirAnnotationContainer.isBorrowed(session: FirSession) = hasAnnotation(annotationId("Borrowed"), session)
 
 fun FirFunctionSymbol<*>.isFormverFunctionNamed(name: String) =
-    this is FirNamedFunctionSymbol && callableId == formverCallableId(name)
+    this is FirNamedFunctionSymbol && callableId == formverCallableId(null, name)
+
+fun FirFunctionSymbol<*>.isInvariantBuilderFunctionNamed(name: String) =
+    this is FirNamedFunctionSymbol && callableId == formverCallableId("InvariantBuilder", name)
 
 @OptIn(SymbolInternals::class)
 val FirFunctionSymbol<*>.shouldBeInlined

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FormverFirBlock.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FormverFirBlock.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.isFormverFunctionNamed
 
-private fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirAnonymousFunction? {
+fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirAnonymousFunction? {
     if (this !is FirFunctionCall) return null
     val firFunction = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return null
     if (!predicate(firFunction)) return null

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshEntityProducer.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/FreshEntityProducer.kt
@@ -15,4 +15,5 @@ typealias SimpleFreshEntityProducer<R> = FreshEntityProducer<R, Unit>
 fun <R> simpleFreshEntityProducer(build: (Int) -> R): SimpleFreshEntityProducer<R> = FreshEntityProducer { n, _ -> build(n) }
 fun <R> SimpleFreshEntityProducer<R>.getFresh() = getFresh(Unit)
 
-fun indexProducer(): SimpleFreshEntityProducer<Int> = simpleFreshEntityProducer { it }
+fun scopeIndexProducer(): SimpleFreshEntityProducer<ScopeIndex.Indexed> = simpleFreshEntityProducer(ScopeIndex::Indexed)
+fun indexProducer() = simpleFreshEntityProducer { it }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodContextFactory.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodContextFactory.kt
@@ -14,6 +14,6 @@ class MethodContextFactory(
 ) {
     fun create(
         programCtx: ProgramConversionContext,
-        scopeDepth: Int,
+        scopeDepth: ScopeIndex,
     ): MethodConversionContext = MethodConverter(programCtx, signature, paramResolver, scopeDepth, parent)
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -42,7 +42,7 @@ interface MethodConversionContext : ProgramConversionContext {
     fun resolveDispatchReceiver(): ExpEmbedding?
     fun resolveExtensionReceiver(labelName: String): ExpEmbedding?
 
-    fun <R> withScopeImpl(scopeDepth: Int, action: () -> R): R
+    fun <R> withScopeImpl(scopeDepth: ScopeIndex, action: () -> R): R
     fun addLoopIdentifier(labelName: String, index: Int)
     fun resolveLoopIndex(name: String): Int
     fun resolveNamedReturnTarget(labelName: String): ReturnTarget?

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConversionContext.kt
@@ -34,6 +34,7 @@ class ReturnTarget(depth: Int, type: TypeEmbedding) {
 interface MethodConversionContext : ProgramConversionContext {
     val signature: FunctionSignature
     val defaultResolvedReturnTarget: ReturnTarget
+    val isValidForForAllBlock: Boolean
 
     fun resolveParameter(symbol: FirValueParameterSymbol): ExpEmbedding
     fun resolveLocal(symbol: FirVariableSymbol<*>): VariableEmbedding

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.formver.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.embeddings.expression.VariableEmbedding
-import org.jetbrains.kotlin.name.Name
 
 /**
  * The symbol resolution data for a single method.
@@ -28,12 +27,12 @@ class MethodConverter(
     private val programCtx: ProgramConversionContext,
     override val signature: FunctionSignature,
     private val paramResolver: ParameterResolver,
-    scopeDepth: Int,
+    scopeDepth: ScopeIndex,
     private val parent: MethodConversionContext? = null,
 ) : MethodConversionContext, ProgramConversionContext by programCtx {
     private var propertyResolver = PropertyResolver(scopeDepth)
 
-    override fun <R> withScopeImpl(scopeDepth: Int, action: () -> R): R {
+    override fun <R> withScopeImpl(scopeDepth: ScopeIndex, action: () -> R): R {
         propertyResolver = propertyResolver.innerScope(scopeDepth)
         val result = action()
         propertyResolver = propertyResolver.parent!!

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/MethodConverter.kt
@@ -32,6 +32,9 @@ class MethodConverter(
 ) : MethodConversionContext, ProgramConversionContext by programCtx {
     private var propertyResolver = PropertyResolver(scopeDepth)
 
+    override val isValidForForAllBlock: Boolean
+        get() = !propertyResolver.canCreateLocals
+
     override fun <R> withScopeImpl(scopeDepth: ScopeIndex, action: () -> R): R {
         propertyResolver = propertyResolver.innerScope(scopeDepth)
         val result = action()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConversionContext.kt
@@ -29,7 +29,7 @@ interface ProgramConversionContext {
     val whileIndexProducer: SimpleFreshEntityProducer<Int>
     val catchLabelNameProducer: SimpleFreshEntityProducer<CatchLabelName>
     val tryExitLabelNameProducer: SimpleFreshEntityProducer<TryExitLabelName>
-    val scopeIndexProducer: SimpleFreshEntityProducer<Int>
+    val scopeIndexProducer: SimpleFreshEntityProducer<ScopeIndex.Indexed>
 
     val anonVarProducer: FreshEntityProducer<AnonymousVariableEmbedding, TypeEmbedding>
     val returnTargetProducer: FreshEntityProducer<ReturnTarget, TypeEmbedding>

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ProgramConverter.kt
@@ -58,7 +58,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
     override val whileIndexProducer = indexProducer()
     override val catchLabelNameProducer = simpleFreshEntityProducer(::CatchLabelName)
     override val tryExitLabelNameProducer = simpleFreshEntityProducer(::TryExitLabelName)
-    override val scopeIndexProducer = indexProducer()
+    override val scopeIndexProducer = scopeIndexProducer()
 
     // The type annotation is necessary for the code to compile.
     override val anonVarProducer = FreshEntityProducer(::AnonymousVariableEmbedding)
@@ -321,7 +321,7 @@ class ProgramConverter(val session: FirSession, override val config: PluginConfi
                 this@ProgramConverter,
                 subSignature,
                 paramResolver,
-                scopeDepth = 0,
+                scopeDepth = ScopeIndex.NoScope,
             ).statementCtxt()
         }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
@@ -28,6 +28,9 @@ class PropertyResolver(
 ) {
     private val variables: MutableMap<FirVariableSymbol<*>, VariableEmbedding> = mutableMapOf()
 
+    val canCreateLocals: Boolean
+        get() = scopeIndex is ScopeIndex.Indexed
+
     fun tryResolveLocalProperty(symbol: FirVariableSymbol<*>): VariableEmbedding? =
         variables[symbol] ?: parent?.tryResolveLocalProperty(symbol)
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/PropertyResolver.kt
@@ -22,7 +22,7 @@ data class LoopIdentifier(val targetName: String, val index: Int)
  * to the resolver for the outer scopes, and automatically searches them.
  */
 class PropertyResolver(
-    private val scopeIndex: Int,
+    private val scopeIndex: ScopeIndex,
     val parent: PropertyResolver? = null,
     private val loopName: LoopIdentifier? = null,
 ) {
@@ -48,7 +48,7 @@ class PropertyResolver(
         variables[symbol] = FirVariableEmbedding(name.embedScopedLocalName(scopeIndex), type, symbol)
     }
 
-    fun innerScope(innerScopeIndex: Int) = PropertyResolver(innerScopeIndex, this)
+    fun innerScope(innerScopeIndex: ScopeIndex) = PropertyResolver(innerScopeIndex, this)
 
     fun addLoopIdentifier(labelName: String, index: Int) = PropertyResolver(scopeIndex, parent, LoopIdentifier(labelName, index))
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ScopeIndex.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ScopeIndex.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.conversion
+
+sealed class ScopeIndex {
+    data class Indexed(val index: Int) : ScopeIndex()
+    data object NoScope : ScopeIndex()
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ScopeIndex.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/ScopeIndex.kt
@@ -5,6 +5,11 @@
 
 package org.jetbrains.kotlin.formver.conversion
 
+/**
+ * When converting Kotlin methods, we explicitly track what local variables are declared in each scope
+ * to resolve shadowing. In scopes where local variables are not permitted, we use a special `NoScope`
+ * placeholder that is treated as an error downstream.
+ */
 sealed class ScopeIndex {
     data class Indexed(val index: Int) : ScopeIndex()
     data object NoScope : ScopeIndex()

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -198,11 +198,13 @@ fun StmtConversionContext.insertInlineFunctionCall(
     }
 }
 
-fun StmtConversionContext.insertForAllScope(
+/**
+ * Insert `ForAllEmbedding` where `forAll` function call was encountered.
+ */
+fun StmtConversionContext.insertForAllFunctionCall(
     symbol: FirValueParameterSymbol,
-    block: FirBlock?,
+    block: FirBlock,
 ): ExpEmbedding {
-    if (block  == null) return BooleanLit(true)
     val anonVar = freshAnonVar(embedType(symbol.resolvedReturnType))
     val methodCtxFactory = MethodContextFactory(
         signature,

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.formver.conversion
 import org.jetbrains.kotlin.fir.FirLabel
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
-import org.jetbrains.kotlin.fir.declarations.utils.isInline
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.references.symbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirIntersectionOverridePropertySymbol
@@ -26,10 +25,7 @@ import org.jetbrains.kotlin.formver.isCustom
 import org.jetbrains.kotlin.formver.linearization.Linearizer
 import org.jetbrains.kotlin.formver.linearization.SeqnBuilder
 import org.jetbrains.kotlin.formver.linearization.SharedLinearizationState
-import org.jetbrains.kotlin.formver.shouldBeInlined
 import org.jetbrains.kotlin.formver.viper.MangledName
-import org.jetbrains.kotlin.formver.viper.ast.delegateToCallable
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 import org.jetbrains.kotlin.utils.filterIsInstanceAnd
@@ -199,6 +195,27 @@ fun StmtConversionContext.insertInlineFunctionCall(
             // if unit is what we return we might not guarantee it yet
             add(returnTarget.variable.withIsUnitInvariantIfUnit())
         }
+    }
+}
+
+fun StmtConversionContext.insertForAllScope(
+    symbol: FirValueParameterSymbol,
+    block: FirBlock?,
+): ExpEmbedding {
+    if (block  == null) return BooleanLit(true)
+    val anonVar = freshAnonVar(embedType(symbol.resolvedReturnType))
+    val methodCtxFactory = MethodContextFactory(
+        signature,
+        InlineParameterResolver(
+            substitutions = mapOf(SubstitutedArgument.ValueParameter(symbol) to anonVar),
+            labelName = null,
+            // TODO: ideally, there shouldn't be a return target since return is prohibited
+            defaultResolvedReturnTarget = defaultResolvedReturnTarget,
+        ),
+        parent = this,
+    )
+    return withMethodCtx(methodCtxFactory) {
+        ForAllEmbedding(anonVar, collectInvariants(block))
     }
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -37,9 +37,9 @@ import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.LtIntInt
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.Not
 import org.jetbrains.kotlin.formver.embeddings.toLink
-import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.embeddings.types.equalToType
 import org.jetbrains.kotlin.formver.functionCallArguments
+import org.jetbrains.kotlin.formver.isInvariantBuilderFunctionNamed
 import org.jetbrains.kotlin.text
 import org.jetbrains.kotlin.types.ConstantValueKind
 import org.jetbrains.kotlin.utils.addIfNotNull
@@ -263,13 +263,23 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         }
 
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: StmtConversionContext): ExpEmbedding {
-        val symbol = functionCall.toResolvedCallableSymbol()
-        val callee = data.embedFunction(symbol as FirFunctionSymbol<*>)
-        return callee.insertCall(
-            functionCall.functionCallArguments.withVarargsHandled(data, callee),
-            data,
-            data.embedType(functionCall.resolvedType),
-        )
+        val symbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
+            ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
+
+        when (val forAllLambda = functionCall.extractFormverFirBlock { isInvariantBuilderFunctionNamed("forAll") }) {
+            null -> {
+                val callee = data.embedFunction(symbol)
+                return callee.insertCall(
+                    functionCall.functionCallArguments.withVarargsHandled(data, callee),
+                    data,
+                    data.embedType(functionCall.resolvedType),
+                )
+            }
+            else -> {
+                val forAllArg = forAllLambda.valueParameters.first()
+                return data.insertForAllScope(forAllArg.symbol, forAllLambda.body)
+            }
+        }
     }
 
     override fun visitImplicitInvokeCall(
@@ -310,7 +320,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 addAll(it.provenInvariants())
             }
             extractLoopInvariants(whileLoop.block)?.let {
-                addAll(data.collectInvariants(it))
+                addAll(data.withScopeImpl(ScopeIndex.NoScope) { data.collectInvariants(it) })
             }
         }
         return data.withFreshWhile(whileLoop.label) {

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionVisitor.kt
@@ -276,8 +276,12 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 )
             }
             else -> {
+                if (!data.isValidForForAllBlock)
+                    error("`forAll` scope is only allowed inside one of the `loopInvariants`, `preconditions` or `postconditions`.")
                 val forAllArg = forAllLambda.valueParameters.first()
-                return data.insertForAllScope(forAllArg.symbol, forAllLambda.body)
+                val forAllBody = forAllLambda.body
+                    ?: error("Lambda body should be accessible in `forAll` function call.")
+                return data.insertForAllFunctionCall(forAllArg.symbol, forAllBody)
             }
         }
     }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ForAllEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ForAllEmbedding.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.embeddings.expression
+
+import org.jetbrains.kotlin.formver.asPosition
+import org.jetbrains.kotlin.formver.domains.RuntimeTypeDomain.Companion.isOf
+import org.jetbrains.kotlin.formver.embeddings.asInfo
+import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.embeddings.types.buildType
+import org.jetbrains.kotlin.formver.linearization.LinearizationContext
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toConjunction
+
+class ForAllEmbedding(
+    // TODO: support multiple variables
+    val variable: VariableEmbedding,
+    conditions: List<ExpEmbedding>,
+) : OnlyToBuiltinTypeExpEmbedding {
+
+    override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
+        Exp.Forall(
+            variables = listOf(variable.toLocalVarDecl()),
+            // TODO: right now we hope that Viper will infer triggers successfully, later we might enable user triggers here
+            triggers = emptyList(),
+            exp = Exp.Implies(
+                variable.toViper(ctx).isOf(variable.type.runtimeType),
+                subexpressions.map { it.toViperBuiltinType(ctx) }.toConjunction(),
+            ),
+            pos = ctx.source.asPosition,
+            info = sourceRole.asInfo,
+        )
+
+    override val subexpressions: List<ExpEmbedding> = conditions
+
+    override val type: TypeEmbedding
+        get() = buildType { boolean() }
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
@@ -78,11 +78,15 @@ fun CallableId.embedFunctionName(type: FunctionTypeEmbedding): ScopedKotlinName 
 }
 
 fun Name.embedScopedLocalName(scope: ScopeIndex) = buildName {
-    // TODO : otherwise, an error should be reported at some point
-    if (scope is ScopeIndex.Indexed)
-        localScope(scope.index)
-    else
-        badScope()
+    when (scope) {
+        is ScopeIndex.Indexed -> localScope(scope.index)
+        // If we're in the context where creating locals is not permitted
+        // an error would be reported down the stream (most likely, when we convert
+        // ExpEmbedding to Viper)
+        // For extra safety, we produce a name for such a variable that does not compile
+        // TODO: make reporting more transparent here
+        ScopeIndex.NoScope -> badScope()
+    }
     SimpleKotlinName(this@embedScopedLocalName)
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameEmbeddings.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.formver.conversion.ProgramConversionContext
+import org.jetbrains.kotlin.formver.conversion.ScopeIndex
 import org.jetbrains.kotlin.formver.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -76,8 +77,12 @@ fun CallableId.embedFunctionName(type: FunctionTypeEmbedding): ScopedKotlinName 
     FunctionKotlinName(callableName, type)
 }
 
-fun Name.embedScopedLocalName(scope: Int) = buildName {
-    localScope(scope)
+fun Name.embedScopedLocalName(scope: ScopeIndex) = buildName {
+    // TODO : otherwise, an error should be reported at some point
+    if (scope is ScopeIndex.Indexed)
+        localScope(scope.index)
+    else
+        badScope()
     SimpleKotlinName(this@embedScopedLocalName)
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/NameScope.kt
@@ -80,6 +80,12 @@ data object ParameterScope : NameScope {
         get() = "p"
 }
 
+data object BadScope : NameScope {
+    override val parent: NameScope? = null
+    override val mangledScopeName: String
+        get() = "<BAD>"
+}
+
 data class LocalScope(val level: Int) : NameScope {
     override val parent: NameScope? = null
     override val mangledScopeName = "l$level"

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/names/ScopedKotlinNameBuilder.kt
@@ -50,6 +50,11 @@ class ScopedKotlinNameBuilder {
         scope = LocalScope(level)
     }
 
+    fun badScope() {
+        require(scope == null)
+        scope = BadScope
+    }
+
     fun fakeScope() {
         require(scope == null) { "Fake scope cannot be nested." }
         scope = FakeScope

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.fir.diag.txt
@@ -1,0 +1,80 @@
+/simple_forall.kt:(64,92): info: Generated Viper text for anyIntegerSquaredAtLeastZero:
+method f$anyIntegerSquaredAtLeastZero$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType()) ==>
+      df$rt$intFromRef(anon$1) * df$rt$intFromRef(anon$1) >= 0 &&
+      df$rt$intFromRef(anon$1) * df$rt$intFromRef(anon$1) >=
+      df$rt$intFromRef(ret$0))
+{
+  ret$0 := df$rt$intToRef(0)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/simple_forall.kt:(259,298): info: Generated Viper text for anyIntegerSquaredIsAtLeastOneExceptZero:
+method f$anyIntegerSquaredIsAtLeastOneExceptZero$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType()) ==>
+      !(df$rt$intFromRef(anon$1) == 0) ==>
+      df$rt$intFromRef(anon$1) * df$rt$intFromRef(anon$1) >=
+      df$rt$intFromRef(ret$0))
+{
+  ret$0 := df$rt$intToRef(1)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/simple_forall.kt:(460,503): info: Generated Viper text for anyIntegerSquaredIsAtLeastZeroStringVersion:
+field bf$length: Ref
+
+method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String(p$str: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var l0$res: Ref
+  var l0$i: Ref
+  var anon$2: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+  inhale acc(p$pkg$kotlin$c$String$shared(p$str), wildcard)
+  l0$res := df$rt$intToRef(0)
+  l0$i := df$rt$intToRef(10)
+  label lbl$continue$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant acc(p$pkg$kotlin$c$String$shared(p$str), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+    invariant (forall anon$0: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType()) ==>
+        0 <= df$rt$intFromRef(anon$0) &&
+        df$rt$intFromRef(anon$0) <
+        df$rt$intFromRef((unfolding acc(p$pkg$kotlin$c$String$shared(p$str), wildcard) in
+          p$str.bf$length)) ==>
+        (df$rt$stringFromRef(p$str)[df$rt$intFromRef(anon$0)] - 97) *
+        (df$rt$stringFromRef(p$str)[df$rt$intFromRef(anon$0)] - 97) >=
+        df$rt$intFromRef(l0$res))
+  anon$2 := sp$gtInts(l0$i, df$rt$intToRef(0))
+  if (df$rt$boolFromRef(anon$2)) {
+    var anon$1: Ref
+    anon$1 := l0$i
+    l0$i := sp$minusInts(anon$1, df$rt$intToRef(1))
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant acc(p$pkg$kotlin$c$String$shared(p$str), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+    invariant (forall anon$0: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType()) ==>
+        0 <= df$rt$intFromRef(anon$0) &&
+        df$rt$intFromRef(anon$0) <
+        df$rt$intFromRef((unfolding acc(p$pkg$kotlin$c$String$shared(p$str), wildcard) in
+          p$str.bf$length)) ==>
+        (df$rt$stringFromRef(p$str)[df$rt$intFromRef(anon$0)] - 97) *
+        (df$rt$stringFromRef(p$str)[df$rt$intFromRef(anon$0)] - 97) >=
+        df$rt$intFromRef(l0$res))
+  ret$0 := l0$res
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.kt
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.formver.plugin.*
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>anyIntegerSquaredAtLeastZero<!>(): Int {
+    postconditions<Int> { res ->
+        forAll<Int> {
+            it * it >= 0
+            it * it >= res
+        }
+    }
+    return 0
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>anyIntegerSquaredIsAtLeastOneExceptZero<!>(): Int {
+    postconditions<Int> { res ->
+        forAll<Int> {
+            (it != 0) implies (it * it >= res)
+        }
+    }
+    return 1
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>anyIntegerSquaredIsAtLeastZeroStringVersion<!>(str: String): Int {
+    var res = 0
+    var i = 10
+    while (i > 0) {
+        loopInvariants {
+            forAll<Int> {
+                (0 <= it && it < str.length) implies ((str[it] - 'a') * (str[it] - 'a') >= res)
+            }
+        }
+        i--
+    }
+    return res
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -691,6 +691,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
       }
 
       @Test
+      @TestMetadata("simple_forall.kt")
+      public void testSimple_forall() {
+        runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.kt");
+      }
+
+      @Test
       @TestMetadata("simple_loop.kt")
       public void testSimple_loop() {
         runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_loop.kt");


### PR DESCRIPTION
This pull request introduces `forAll` scope. It can be used with trivial types (like `Int`) in the following manner:

```kotlin
fun foo(): Int {
    postconditions<Int> { res ->
        forAll<Int> { it * it >= res }
    }
    return 0
}
```

Currently, only a single argument lambda is supported.