### PR TITLE
More examples (merge sort, sum from 1 to `n`) and necessary changes to verify them

### DIFF
--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -66,10 +66,7 @@ object SpecialKotlinFunctions {
                 MulIntInt(args[0], args[1])
             }
             addFunction(SpecialPackages.kotlin, className = "Int", name = "div") { args, _ ->
-                blockOf(
-                    InhaleDirect(NeCmp(args[1], IntLit(0))),
-                    DivIntInt(args[0], args[1]),
-                )
+                DivIntInt(args[0], args[1])
             }
         }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/PartiallySpecialKotlinFunction.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/callables/PartiallySpecialKotlinFunction.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.embeddings.callables
 
 import org.jetbrains.kotlin.formver.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.AddStringChar
 import org.jetbrains.kotlin.formver.embeddings.expression.OperatorExpEmbeddings.AddStringString
 import org.jetbrains.kotlin.formver.embeddings.types.buildFunctionPretype
 import org.jetbrains.kotlin.formver.embeddings.types.equalToType
@@ -34,8 +35,14 @@ abstract class AbstractPartiallySpecialKotlinFunction(
 }
 
 class StringPlusAnyFunction : AbstractPartiallySpecialKotlinFunction("kotlin", className = "String", name = "plus") {
-    override fun tryInsertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding? =
-        if (args[1].type.equalToType { string() }) AddStringString(args[0], args[1]) else null
+    override fun tryInsertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding? {
+        val argType = args[1].type
+        return when {
+            argType.equalToType { string() } -> AddStringString(args[0], args[1])
+            argType.equalToType { char() } -> AddStringChar(args[0], args[1])
+            else -> null
+        }
+    }
 
     override val callableType = buildFunctionPretype {
         withDispatchReceiver { string() }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/OperatorExpEmbeddings.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/OperatorExpEmbeddings.kt
@@ -220,6 +220,16 @@ object OperatorExpEmbeddings {
         viperImplementation { Exp.SeqAppend(args[0], args[1], pos, info, trafos) }
     }
 
+    val AddStringChar = buildBinaryOperator {
+        setName("addStringChar")
+        withSignature {
+            withParam { string() }
+            withParam { char() }
+            withReturnType { string() }
+        }
+        viperImplementation { Exp.SeqAppend(args[0], Exp.ExplicitSeq(listOf(args[1])), pos, info, trafos) }
+    }
+
     val allTemplates
         get() = listOf(
             AddIntInt, SubIntInt, MulIntInt, DivIntInt, RemIntInt,
@@ -227,6 +237,6 @@ object OperatorExpEmbeddings {
             Not, And, Or, Implies,
             AddCharInt, SubCharChar, SubCharInt,
             LeCharChar, GeCharChar, LtCharChar, GtCharChar,
-            StringLength, StringGet, AddStringString
+            StringLength, StringGet, AddStringString, AddStringChar,
         )
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassTypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/ClassTypeEmbedding.kt
@@ -58,16 +58,4 @@ private fun PretypeEmbedding.isCollectionTypeNamed(name: String): Boolean {
     }
 }
 
-val ClassTypeEmbedding.isString: Boolean
-    get() = NameMatcher.matchGlobalScope(name) {
-        ifPackageName(SpecialPackages.kotlin) {
-            ifClassName("String") {
-                return true
-            }
-        }
-        return false
-    }
-
-fun ClassTypeEmbedding.embedClassTypeFunc(): DomainFunc =
-    if (isString) RuntimeTypeDomain.stringType
-    else RuntimeTypeDomain.classTypeFunc(name)
+fun ClassTypeEmbedding.embedClassTypeFunc(): DomainFunc = RuntimeTypeDomain.classTypeFunc(name)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeBuilder.kt
@@ -44,6 +44,10 @@ object CharPretypeBuilder : PretypeBuilder {
     override fun complete() = CharTypeEmbedding
 }
 
+object StringPretypeBuilder : PretypeBuilder {
+    override fun complete() = StringTypeEmbedding
+}
+
 class FunctionPretypeBuilder : PretypeBuilder {
     private val paramTypes = mutableListOf<TypeEmbedding>()
     private var extensionReceiverType: TypeEmbedding? = null

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/PretypeEmbedding.kt
@@ -63,5 +63,10 @@ data object CharTypeEmbedding : PretypeEmbedding {
     override val name = PretypeName("Char")
 }
 
+data object StringTypeEmbedding : PretypeEmbedding {
+    override val runtimeType = RuntimeTypeDomain.stringType()
+    override val name = PretypeName("String")
+}
+
 fun PretypeEmbedding.asTypeEmbedding() = TypeEmbedding(this, TypeEmbeddingFlags(nullable = false))
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeBuilder.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeBuilder.kt
@@ -32,12 +32,7 @@ class TypeBuilder {
     fun int() = IntPretypeBuilder
     fun boolean() = BooleanPretypeBuilder
     fun char() = CharPretypeBuilder
-    fun string() = klass {
-        withName(buildName {
-            packageScope(listOf("kotlin"))
-            ClassKotlinName(listOf("String"))
-        })
-    }
+    fun string() = StringPretypeBuilder
 
     fun function(init: FunctionPretypeBuilder.() -> Unit) = FunctionPretypeBuilder().also { it.init() }
     fun klass(init: ClassPretypeBuilder.() -> Unit) = ClassPretypeBuilder().also { it.init() }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/types/TypeEmbedding.kt
@@ -80,8 +80,8 @@ data class TypeEmbeddingFlags(val nullable: Boolean) {
 
 inline fun TypeEmbedding.injectionOr(default: (TypeEmbedding) -> Injection): Injection {
     if (flags.nullable) return default(this)
-    if (equalToType { string() }) return RuntimeTypeDomain.stringInjection
     return when (this.pretype) {
+        StringTypeEmbedding -> RuntimeTypeDomain.stringInjection
         CharTypeEmbedding -> RuntimeTypeDomain.charInjection
         IntTypeEmbedding -> RuntimeTypeDomain.intInjection
         BooleanTypeEmbedding -> RuntimeTypeDomain.boolInjection

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/binary_search.fir.diag.txt
@@ -13,38 +13,35 @@ method f$mid_increased_by_one$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  var anon$2: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  inhale 2 != 0
-  anon$1 := p$arr.sp$size
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-  anon$0 := sp$divInts(anon$1, df$rt$intToRef(2))
-  l0$mid := sp$plusInts(anon$0, df$rt$intToRef(1))
-  anon$2 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
-  if (df$rt$boolFromRef(anon$2)) {
+  anon$0 := p$arr.sp$size
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  l0$mid := sp$plusInts(sp$divInts(anon$0, df$rt$intToRef(2)), df$rt$intToRef(1))
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
+  if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
-    var anon$3: Ref
-    anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-    if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(p$target)) {
+    var anon$2: Ref
+    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
-      var anon$4: Ref
-      anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-      if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(p$target)) {
+      var anon$3: Ref
+      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
+        var anon$4: Ref
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
+          sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
+        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int(anon$4, p$target)
+      } else {
         var anon$5: Ref
         anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
-          sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int(anon$5, p$target)
-      } else {
-        var anon$6: Ref
-        anon$6 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int(anon$6, p$target)
+        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int(anon$5, p$target)
       }
     }
   }
@@ -120,38 +117,35 @@ method f$mid_decreased_by_one$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  var anon$2: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  inhale 2 != 0
-  anon$1 := p$arr.sp$size
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-  anon$0 := sp$divInts(anon$1, df$rt$intToRef(2))
-  l0$mid := sp$minusInts(anon$0, df$rt$intToRef(1))
-  anon$2 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
-  if (df$rt$boolFromRef(anon$2)) {
+  anon$0 := p$arr.sp$size
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  l0$mid := sp$minusInts(sp$divInts(anon$0, df$rt$intToRef(2)), df$rt$intToRef(1))
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List(p$arr)
+  if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
-    var anon$3: Ref
-    anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-    if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(p$target)) {
+    var anon$2: Ref
+    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
-      var anon$4: Ref
-      anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-      if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(p$target)) {
+      var anon$3: Ref
+      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
+        var anon$4: Ref
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
+          sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
+        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int(anon$4, p$target)
+      } else {
         var anon$5: Ref
         anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
-          sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int(anon$5, p$target)
-      } else {
-        var anon$6: Ref
-        anon$6 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int(p$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int(anon$6, p$target)
+        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int(anon$5, p$target)
       }
     }
   }
@@ -232,7 +226,6 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int(p$arr: Ref, p$target: 
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  inhale 2 != 0
   anon$0 := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$divInts(anon$0, df$rt$intToRef(2))
@@ -348,7 +341,6 @@ method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int(p$arr: Ref, p$target: 
 {
   var l0$mid: Ref
   var anon$0: Ref
-  var anon$1: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
@@ -358,16 +350,14 @@ method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int(p$arr: Ref, p$target: 
     ret$0 := df$rt$boolToRef(false)
     goto lbl$ret$0
   }
-  inhale 2 != 0
-  anon$0 := sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2))
-  l0$mid := sp$plusInts(p$left, anon$0)
-  anon$1 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-  if (df$rt$intFromRef(anon$1) == df$rt$intFromRef(p$target)) {
+  l0$mid := sp$plusInts(p$left, sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2)))
+  anon$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+  if (df$rt$intFromRef(anon$0) == df$rt$intFromRef(p$target)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
-    var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-    if (df$rt$intFromRef(anon$2) < df$rt$intFromRef(p$target)) {
+    var anon$1: Ref
+    anon$1 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+    if (df$rt$intFromRef(anon$1) < df$rt$intFromRef(p$target)) {
       ret$0 := f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int(p$arr, p$target,
         sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
     } else {

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/cond_effects.fir.diag.txt
@@ -84,7 +84,4 @@ method f$recursiveContract$TF$T$Int$NT$Any(p$n: Ref, p$x: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
-
 /cond_effects.kt:(994,1029): warning: Cannot verify that if a true value is returned then x is String.

--- a/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/bad_contracts/is_type_contract.fir.diag.txt
@@ -9,9 +9,6 @@ method f$unverifiableTypeCheck$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
-
 /is_type_contract.kt:(216,245): warning: Cannot verify that if the function returns then x is Unit.
 
 /is_type_contract.kt:(319,341): info: Generated Viper text for nullableNotNonNullable:

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/full_viper_dump.fir.diag.txt
@@ -254,6 +254,12 @@ function sp$addCharInt(arg1: Ref, arg2: Ref): Ref
     df$rt$charFromRef(arg1) + df$rt$intFromRef(arg2)
 
 
+function sp$addStringChar(arg1: Ref, arg2: Ref): Ref
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
+  ensures df$rt$stringFromRef(result) ==
+    df$rt$stringFromRef(arg1) ++ Seq(df$rt$charFromRef(arg2))
+
+
 function sp$addStrings(arg1: Ref, arg2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/arithmetic.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/arithmetic.fir.diag.txt
@@ -37,7 +37,6 @@ method f$division$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
 {
   var l0$y: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$intFromRef(p$x) != 0
   l0$y := sp$divInts(p$x, p$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/arithmetic.kt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/arithmetic.kt
@@ -10,5 +10,6 @@ fun <!VIPER_TEXT!>multiplication<!>(x: Int) {
     val y = x * x
 }
 fun <!VIPER_TEXT!>division<!>(x: Int) {
+    // will not verify because `x` is not guaranteed to be non-zero
     val y = x / x
 }

--- a/plugins/formal-verification/testData/diagnostics/no_contracts/operators/increment.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/no_contracts/operators/increment.fir.diag.txt
@@ -9,7 +9,6 @@ method f$test_simple$TF$() returns (ret$0: Ref)
   l0$x := sp$minusInts(l0$x, df$rt$intToRef(3))
   l0$x := sp$plusInts(l0$x, df$rt$intToRef(1))
   l0$x := sp$timesInts(l0$x, df$rt$intToRef(2))
-  inhale 4 != 0
   l0$x := sp$divInts(l0$x, df$rt$intToRef(4))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/plugins/formal-verification/testData/diagnostics/verifies/contracts/is_type_contract.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/contracts/is_type_contract.fir.diag.txt
@@ -10,9 +10,6 @@ method f$isString$TF$NT$Any(p$x: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
-
 /is_type_contract.kt:(322,330): info: Generated Viper text for isString:
 method f$isString$TF$T$Any(this$extension: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -24,9 +21,6 @@ method f$isString$TF$T$Any(this$extension: Ref) returns (ret$0: Ref)
   goto lbl$ret$0
   label lbl$ret$0
 }
-
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
 
 /is_type_contract.kt:(491,508): info: Generated Viper text for subtypeTransitive:
 method f$subtypeTransitive$TF$T$Unit(p$x: Ref) returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/list/binary_search.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/list/binary_search.fir.diag.txt
@@ -69,7 +69,6 @@ method f$safe_binary_search$TF$T$List$T$Int(p$arr: Ref, p$target: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  inhale 2 != 0
   anon$0 := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$divInts(anon$0, df$rt$intToRef(2))
@@ -132,7 +131,6 @@ method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int(p$arr: Ref,
   var anon$1: Ref
   var l0$mid: Ref
   var anon$3: Ref
-  var anon$4: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
@@ -154,16 +152,14 @@ method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int(p$arr: Ref,
     ret$0 := df$rt$boolToRef(false)
     goto lbl$ret$0
   }
-  inhale 2 != 0
-  anon$3 := sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2))
-  l0$mid := sp$plusInts(p$left, anon$3)
-  anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-  if (df$rt$intFromRef(anon$4) == df$rt$intFromRef(p$target)) {
+  l0$mid := sp$plusInts(p$left, sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2)))
+  anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+  if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(p$target)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
-    var anon$5: Ref
-    anon$5 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
-    if (df$rt$intFromRef(anon$5) < df$rt$intFromRef(p$target)) {
+    var anon$4: Ref
+    anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int(p$arr, l0$mid)
+    if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(p$target)) {
       ret$0 := f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int(p$arr,
         p$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
     } else {

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/private_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/private_properties.fir.diag.txt
@@ -25,7 +25,6 @@ field bf$c$B$private$field: Ref
 
 method f$c$B$getStringField$TF$T$B(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
-  ensures acc(p$pkg$kotlin$c$String$shared(ret$0), wildcard)
 {
   inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$B())
   inhale acc(p$c$B$shared(this$dispatch), wildcard)
@@ -36,9 +35,6 @@ method f$c$B$getStringField$TF$T$B(this$dispatch: Ref) returns (ret$0: Ref)
 }
 
 method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
-
-
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 
 
 method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
@@ -86,9 +82,6 @@ method f$extractPublic$TF$() returns (ret$0: Ref)
 }
 
 method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
-
-
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 
 
 method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
@@ -284,6 +284,7 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var l0$str: Ref
   var l0$helloWorld: Ref
+  var l0$stringPlusInteger: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   inhale acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
   if (|df$rt$stringFromRef(p$s)| > 0) {
@@ -301,10 +302,15 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   assert df$rt$stringFromRef(l0$str)[1] == 98
   assert Seq(75, 111, 116, 108, 105, 110, 46, 83, 116, 114, 105, 110, 103) ==
     Seq(75, 111, 116, 108, 105, 110, 46, 83, 116, 114, 105, 110, 103)
-  l0$helloWorld := f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(df$rt$stringToRef(Seq(72,
-    101, 108, 108, 111, 32, 87, 111, 114, 108, 100)), df$rt$charToRef(33))
+  l0$helloWorld := sp$addStringChar(df$rt$stringToRef(Seq(72, 101, 108, 108,
+    111, 32, 87, 111, 114, 108, 100)), df$rt$charToRef(33))
+  assert df$rt$stringFromRef(l0$helloWorld) ==
+    Seq(72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33)
+  l0$stringPlusInteger := f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(df$rt$stringToRef(Seq(52,
+    50)), df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
@@ -5,13 +5,11 @@ field bf$str: Ref
 
 predicate p$c$StringBox$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
-  acc(p$pkg$kotlin$c$String$shared(this$dispatch.bf$str), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
 predicate p$c$StringBox$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
-  acc(p$pkg$kotlin$c$String$shared(this$dispatch.bf$str), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
@@ -37,40 +35,12 @@ predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$CharSequence$shared(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$CharSequence$unique(this$dispatch: Ref) {
-  true
-}
-
 predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
 predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
-}
-
-predicate p$pkg$kotlin$c$Comparable$shared(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$Comparable$unique(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$String$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin$c$Comparable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$kotlin$c$CharSequence$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
-}
-
-predicate p$pkg$kotlin$c$String$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin$c$Comparable$unique(this$dispatch), write) &&
-  acc(p$pkg$kotlin$c$CharSequence$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
 method con$c$StringBox$T$String(p$str: Ref) returns (ret: Ref)
@@ -90,7 +60,6 @@ method f$testType$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   var anon$2: Ref
   var anon$3: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  inhale acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
   anon$1 := con$c$StringBox$T$String(p$s)
   unfold acc(p$c$StringBox$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$str
@@ -103,9 +72,6 @@ method f$testType$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
-
 /strings.kt:(368,383): info: Generated Viper text for testLengthField:
 field bf$size: Ref
 
@@ -113,13 +79,11 @@ field bf$str: Ref
 
 predicate p$c$StringBox$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
-  acc(p$pkg$kotlin$c$String$shared(this$dispatch.bf$str), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
 predicate p$c$StringBox$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
-  acc(p$pkg$kotlin$c$String$shared(this$dispatch.bf$str), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
@@ -145,40 +109,12 @@ predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$CharSequence$shared(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$CharSequence$unique(this$dispatch: Ref) {
-  true
-}
-
 predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
 predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
-}
-
-predicate p$pkg$kotlin$c$Comparable$shared(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$Comparable$unique(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$String$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin$c$Comparable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$kotlin$c$CharSequence$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
-}
-
-predicate p$pkg$kotlin$c$String$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin$c$Comparable$unique(this$dispatch), write) &&
-  acc(p$pkg$kotlin$c$CharSequence$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
 method con$c$StringBox$T$String(p$str: Ref) returns (ret: Ref)
@@ -197,7 +133,6 @@ method f$testLengthField$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var anon$1: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  inhale acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
   l0$len := sp$stringLength(p$s)
   anon$1 := con$c$StringBox$T$String(df$rt$stringToRef(Seq(115, 116, 114)))
   unfold acc(p$c$StringBox$shared(anon$1), wildcard)
@@ -206,9 +141,6 @@ method f$testLengthField$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
-
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
 
 /strings.kt:(486,493): info: Generated Viper text for testOps:
 field bf$size: Ref
@@ -235,14 +167,6 @@ predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$CharSequence$shared(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$CharSequence$unique(this$dispatch: Ref) {
-  true
-}
-
 predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
@@ -251,30 +175,9 @@ predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$Comparable$shared(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$Comparable$unique(this$dispatch: Ref) {
-  true
-}
-
-predicate p$pkg$kotlin$c$String$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin$c$Comparable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$kotlin$c$CharSequence$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
-}
-
-predicate p$pkg$kotlin$c$String$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin$c$Comparable$unique(this$dispatch), write) &&
-  acc(p$pkg$kotlin$c$CharSequence$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
-}
-
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(this$dispatch: Ref, p$other: Ref)
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
-  ensures acc(p$pkg$kotlin$c$String$shared(ret), wildcard)
 
 
 method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
@@ -286,7 +189,6 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   var l0$helloWorld: Ref
   var l0$stringPlusInteger: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  inhale acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
   if (|df$rt$stringFromRef(p$s)| > 0) {
     l0$c := sp$stringGet(p$s, df$rt$intToRef(0))
   } else {
@@ -311,6 +213,3 @@ method f$testOps$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
-
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.kt
@@ -30,6 +30,8 @@ fun <!VIPER_TEXT!>testOps<!>(s: String) {
         str[1] != str[0],
         str[1] == 'b',
     )
-     verify("Kotlin" + "." + "String" == "Kotlin.String")
-     val helloWorld = "Hello World" + '!'
+    verify("Kotlin" + "." + "String" == "Kotlin.String")
+    val helloWorld = "Hello World" + '!'
+    verify(helloWorld == "Hello World!")
+    val stringPlusInteger = "42" + 42
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/merge_sort_of_string.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/merge_sort_of_string.fir.diag.txt
@@ -1,0 +1,271 @@
+/merge_sort_of_string.kt:(72,76): info: Generated Viper text for subs:
+method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(this$dispatch: Ref, p$other: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
+
+
+method f$subs$TF$T$String$T$Int$T$Int(this$extension: Ref, p$lo: Ref, p$hi: Ref)
+  returns (ret$0: Ref)
+  requires 0 <= df$rt$intFromRef(p$lo) &&
+    df$rt$intFromRef(p$lo) <= df$rt$intFromRef(p$hi) &&
+    df$rt$intFromRef(p$hi) <= |df$rt$stringFromRef(this$extension)|
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
+  ensures |df$rt$stringFromRef(ret$0)| ==
+    df$rt$intFromRef(p$hi) - df$rt$intFromRef(p$lo)
+  ensures (forall anon$5: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$5), df$rt$intType()) ==>
+      0 <= df$rt$intFromRef(anon$5) &&
+      df$rt$intFromRef(anon$5) < |df$rt$stringFromRef(ret$0)| ==>
+      df$rt$stringFromRef(ret$0)[df$rt$intFromRef(anon$5)] ==
+      df$rt$stringFromRef(this$extension)[df$rt$intFromRef(anon$5) +
+      df$rt$intFromRef(p$lo)])
+{
+  var l0$res: Ref
+  var l0$i: Ref
+  var anon$3: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
+  l0$res := df$rt$stringToRef(Seq[Int]())
+  l0$i := p$lo
+  label lbl$continue$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
+    invariant 0 <= df$rt$intFromRef(l0$i) &&
+      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$hi)
+    invariant |df$rt$stringFromRef(l0$res)| ==
+      df$rt$intFromRef(l0$i) - df$rt$intFromRef(p$lo)
+    invariant (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType()) ==>
+        0 <= df$rt$intFromRef(anon$1) &&
+        df$rt$intFromRef(anon$1) < |df$rt$stringFromRef(l0$res)| ==>
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$1)] ==
+        df$rt$stringFromRef(this$extension)[df$rt$intFromRef(anon$1) +
+        df$rt$intFromRef(p$lo)])
+  anon$3 := sp$ltInts(l0$i, p$hi)
+  if (df$rt$boolFromRef(anon$3)) {
+    var anon$4: Ref
+    var anon$2: Ref
+    anon$2 := l0$i
+    l0$i := sp$plusInts(anon$2, df$rt$intToRef(1))
+    anon$4 := anon$2
+    l0$res := sp$addStringChar(l0$res, sp$stringGet(this$extension, anon$4))
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
+    invariant 0 <= df$rt$intFromRef(l0$i) &&
+      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$hi)
+    invariant |df$rt$stringFromRef(l0$res)| ==
+      df$rt$intFromRef(l0$i) - df$rt$intFromRef(p$lo)
+    invariant (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType()) ==>
+        0 <= df$rt$intFromRef(anon$1) &&
+        df$rt$intFromRef(anon$1) < |df$rt$stringFromRef(l0$res)| ==>
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$1)] ==
+        df$rt$stringFromRef(this$extension)[df$rt$intFromRef(anon$1) +
+        df$rt$intFromRef(p$lo)])
+  ret$0 := l0$res
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/merge_sort_of_string.kt:(705,717): info: Generated Viper text for mergeStrings:
+method f$mergeStrings$TF$T$String$T$String(p$a: Ref, p$b: Ref)
+  returns (ret$0: Ref)
+  requires (forall anon$13: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$13), df$rt$intType()) ==>
+      (1 <= df$rt$intFromRef(anon$13) &&
+      df$rt$intFromRef(anon$13) < |df$rt$stringFromRef(p$a)| ==>
+      df$rt$stringFromRef(p$a)[df$rt$intFromRef(anon$13) - 1] <=
+      df$rt$stringFromRef(p$a)[df$rt$intFromRef(anon$13)]) &&
+      (1 <= df$rt$intFromRef(anon$13) &&
+      df$rt$intFromRef(anon$13) < |df$rt$stringFromRef(p$b)| ==>
+      df$rt$stringFromRef(p$b)[df$rt$intFromRef(anon$13) - 1] <=
+      df$rt$stringFromRef(p$b)[df$rt$intFromRef(anon$13)]))
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
+  ensures |df$rt$stringFromRef(ret$0)| ==
+    |df$rt$stringFromRef(p$a)| + |df$rt$stringFromRef(p$b)|
+  ensures (forall anon$14: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$14), df$rt$intType()) ==>
+      1 <= df$rt$intFromRef(anon$14) &&
+      df$rt$intFromRef(anon$14) < |df$rt$stringFromRef(ret$0)| ==>
+      df$rt$stringFromRef(ret$0)[df$rt$intFromRef(anon$14) - 1] <=
+      df$rt$stringFromRef(ret$0)[df$rt$intFromRef(anon$14)])
+{
+  var l0$pa: Ref
+  var l0$pb: Ref
+  var l0$res: Ref
+  var l0$n: Ref
+  var anon$7: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+  l0$pa := df$rt$intToRef(0)
+  l0$pb := df$rt$intToRef(0)
+  l0$res := df$rt$stringToRef(Seq[Int]())
+  l0$n := sp$plusInts(sp$stringLength(p$a), sp$stringLength(p$b))
+  label lbl$continue$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$pa), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$pb), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$n), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+    invariant 0 <= df$rt$intFromRef(l0$pa) &&
+      df$rt$intFromRef(l0$pa) <= |df$rt$stringFromRef(p$a)|
+    invariant 0 <= df$rt$intFromRef(l0$pb) &&
+      df$rt$intFromRef(l0$pb) <= |df$rt$stringFromRef(p$b)|
+    invariant |df$rt$stringFromRef(l0$res)| ==
+      df$rt$intFromRef(l0$pa) + df$rt$intFromRef(l0$pb)
+    invariant (forall anon$2: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType()) ==>
+        1 <= df$rt$intFromRef(anon$2) &&
+        df$rt$intFromRef(anon$2) < |df$rt$stringFromRef(l0$res)| ==>
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$2) - 1] <=
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$2)])
+    invariant |df$rt$stringFromRef(l0$res)| == 0 ||
+      df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(p$a)| ||
+      df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
+      df$rt$stringFromRef(p$a)[df$rt$intFromRef(l0$pa)]
+    invariant |df$rt$stringFromRef(l0$res)| == 0 ||
+      df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(p$b)| ||
+      df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
+      df$rt$stringFromRef(p$b)[df$rt$intFromRef(l0$pb)]
+  anon$7 := sp$ltInts(sp$plusInts(l0$pa, l0$pb), l0$n)
+  if (df$rt$boolFromRef(anon$7)) {
+    var anon$8: Ref
+    if (df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(p$a)|) {
+      var anon$9: Ref
+      var anon$3: Ref
+      anon$3 := l0$pb
+      l0$pb := sp$plusInts(anon$3, df$rt$intToRef(1))
+      anon$9 := anon$3
+      anon$8 := sp$stringGet(p$b, anon$9)
+    } elseif (df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(p$b)|) {
+      var anon$10: Ref
+      var anon$4: Ref
+      anon$4 := l0$pa
+      l0$pa := sp$plusInts(anon$4, df$rt$intToRef(1))
+      anon$10 := anon$4
+      anon$8 := sp$stringGet(p$a, anon$10)
+    } elseif (df$rt$stringFromRef(p$a)[df$rt$intFromRef(l0$pa)] <
+    df$rt$stringFromRef(p$b)[df$rt$intFromRef(l0$pb)]) {
+      var anon$11: Ref
+      var anon$5: Ref
+      anon$5 := l0$pa
+      l0$pa := sp$plusInts(anon$5, df$rt$intToRef(1))
+      anon$11 := anon$5
+      anon$8 := sp$stringGet(p$a, anon$11)
+    } else {
+      var anon$12: Ref
+      var anon$6: Ref
+      anon$6 := l0$pb
+      l0$pb := sp$plusInts(anon$6, df$rt$intToRef(1))
+      anon$12 := anon$6
+      anon$8 := sp$stringGet(p$b, anon$12)
+    }
+    l0$res := sp$addStringChar(l0$res, anon$8)
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$pa), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$pb), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$n), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+    invariant 0 <= df$rt$intFromRef(l0$pa) &&
+      df$rt$intFromRef(l0$pa) <= |df$rt$stringFromRef(p$a)|
+    invariant 0 <= df$rt$intFromRef(l0$pb) &&
+      df$rt$intFromRef(l0$pb) <= |df$rt$stringFromRef(p$b)|
+    invariant |df$rt$stringFromRef(l0$res)| ==
+      df$rt$intFromRef(l0$pa) + df$rt$intFromRef(l0$pb)
+    invariant (forall anon$2: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType()) ==>
+        1 <= df$rt$intFromRef(anon$2) &&
+        df$rt$intFromRef(anon$2) < |df$rt$stringFromRef(l0$res)| ==>
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$2) - 1] <=
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$2)])
+    invariant |df$rt$stringFromRef(l0$res)| == 0 ||
+      df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(p$a)| ||
+      df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
+      df$rt$stringFromRef(p$a)[df$rt$intFromRef(l0$pa)]
+    invariant |df$rt$stringFromRef(l0$res)| == 0 ||
+      df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(p$b)| ||
+      df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
+      df$rt$stringFromRef(p$b)[df$rt$intFromRef(l0$pb)]
+  ret$0 := l0$res
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(this$dispatch: Ref, p$other: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
+
+
+/merge_sort_of_string.kt:(1883,1894): info: Generated Viper text for mergeSorted:
+method f$mergeSorted$TF$T$String(this$extension: Ref) returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
+  ensures |df$rt$stringFromRef(ret$0)| ==
+    |df$rt$stringFromRef(this$extension)|
+  ensures (forall anon$8: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$8), df$rt$intType()) ==>
+      1 <= df$rt$intFromRef(anon$8) &&
+      df$rt$intFromRef(anon$8) < |df$rt$stringFromRef(ret$0)| ==>
+      df$rt$stringFromRef(ret$0)[df$rt$intFromRef(anon$8) - 1] <=
+      df$rt$stringFromRef(ret$0)[df$rt$intFromRef(anon$8)])
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  if (|df$rt$stringFromRef(this$extension)| <= 1) {
+    ret$0 := this$extension
+  } else {
+    var anon$4: Ref
+    var anon$5: Ref
+    var anon$6: Ref
+    var anon$7: Ref
+    anon$5 := f$subs$TF$T$String$T$Int$T$Int(this$extension, df$rt$intToRef(0),
+      sp$divInts(sp$stringLength(this$extension), df$rt$intToRef(2)))
+    anon$4 := f$mergeSorted$TF$T$String(anon$5)
+    anon$7 := f$subs$TF$T$String$T$Int$T$Int(this$extension, sp$divInts(sp$stringLength(this$extension),
+      df$rt$intToRef(2)), sp$stringLength(this$extension))
+    anon$6 := f$mergeSorted$TF$T$String(anon$7)
+    ret$0 := f$mergeStrings$TF$T$String$T$String(anon$4, anon$6)
+  }
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method f$mergeStrings$TF$T$String$T$String(p$a: Ref, p$b: Ref)
+  returns (ret: Ref)
+  requires (forall anon$9: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$9), df$rt$intType()) ==>
+      (1 <= df$rt$intFromRef(anon$9) &&
+      df$rt$intFromRef(anon$9) < |df$rt$stringFromRef(p$a)| ==>
+      df$rt$stringFromRef(p$a)[df$rt$intFromRef(anon$9) - 1] <=
+      df$rt$stringFromRef(p$a)[df$rt$intFromRef(anon$9)]) &&
+      (1 <= df$rt$intFromRef(anon$9) &&
+      df$rt$intFromRef(anon$9) < |df$rt$stringFromRef(p$b)| ==>
+      df$rt$stringFromRef(p$b)[df$rt$intFromRef(anon$9) - 1] <=
+      df$rt$stringFromRef(p$b)[df$rt$intFromRef(anon$9)]))
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
+  ensures |df$rt$stringFromRef(ret)| ==
+    |df$rt$stringFromRef(p$a)| + |df$rt$stringFromRef(p$b)|
+  ensures (forall anon$10: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$10), df$rt$intType()) ==>
+      1 <= df$rt$intFromRef(anon$10) &&
+      df$rt$intFromRef(anon$10) < |df$rt$stringFromRef(ret)| ==>
+      df$rt$stringFromRef(ret)[df$rt$intFromRef(anon$10) - 1] <=
+      df$rt$stringFromRef(ret)[df$rt$intFromRef(anon$10)])
+
+
+method f$subs$TF$T$String$T$Int$T$Int(this$extension: Ref, p$lo: Ref, p$hi: Ref)
+  returns (ret: Ref)
+  requires 0 <= df$rt$intFromRef(p$lo) &&
+    df$rt$intFromRef(p$lo) <= df$rt$intFromRef(p$hi) &&
+    df$rt$intFromRef(p$hi) <= |df$rt$stringFromRef(this$extension)|
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
+  ensures |df$rt$stringFromRef(ret)| ==
+    df$rt$intFromRef(p$hi) - df$rt$intFromRef(p$lo)
+  ensures (forall anon$11: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$11), df$rt$intType()) ==>
+      0 <= df$rt$intFromRef(anon$11) &&
+      df$rt$intFromRef(anon$11) < |df$rt$stringFromRef(ret)| ==>
+      df$rt$stringFromRef(ret)[df$rt$intFromRef(anon$11)] ==
+      df$rt$stringFromRef(this$extension)[df$rt$intFromRef(anon$11) +
+      df$rt$intFromRef(p$lo)])
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/merge_sort_of_string.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/merge_sort_of_string.kt
@@ -1,0 +1,83 @@
+import org.jetbrains.kotlin.formver.plugin.*
+
+
+@AlwaysVerify
+fun String.<!VIPER_TEXT!>subs<!>(lo: Int, hi: Int) : String {
+    preconditions {
+        0 <= lo && lo <= hi && hi <= length
+    }
+    postconditions<String> { res ->
+        res.length == hi - lo
+        forAll<Int> {
+            (0 <= it && it < res.length) implies (res[it] == this@subs[it + lo])
+        }
+    }
+
+    var res = ""
+    var i = lo
+    while (i < hi) {
+        loopInvariants {
+            0 <= i && i <= hi
+            res.length == i - lo
+            forAll<Int> {
+                (0 <= it && it < res.length) implies (res[it] == this@subs[it + lo])
+            }
+        }
+        res += this[i++]
+    }
+    return res
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>mergeStrings<!>(a: String, b: String): String {
+    preconditions {
+        forAll<Int> {
+            (1 <= it && it < a.length) implies (a[it - 1] <= a[it])
+            (1 <= it && it < b.length) implies (b[it - 1] <= b[it])
+        }
+    }
+    postconditions<String> { res ->
+        res.length == a.length + b.length
+        forAll<Int> {
+            (1 <= it && it < res.length) implies (res[it - 1] <= res[it])
+        }
+    }
+
+    var pa = 0
+    var pb = 0
+    var res = ""
+
+    val n = a.length + b.length
+
+    while (pa + pb < n) {
+        loopInvariants {
+            0 <= pa && pa <= a.length
+            0 <= pb && pb <= b.length
+            res.length == pa + pb
+            forAll<Int> {
+                (1 <= it && it < res.length) implies (res[it - 1] <= res[it])
+            }
+            res.length == 0 || pa == a.length || res[res.length - 1] <= a[pa]
+            res.length == 0 || pb == b.length || res[res.length - 1] <= b[pb]
+        }
+        res += when {
+            pa == a.length -> b[pb++]
+            pb == b.length -> a[pa++]
+            a[pa] < b[pb] -> a[pa++]
+            else -> b[pb++]
+        }
+    }
+    return res
+}
+
+@AlwaysVerify
+fun String.<!VIPER_TEXT!>mergeSorted<!>(): String {
+    postconditions<String> { res ->
+        res.length == length
+        forAll<Int> {
+            (1 <= it && it < res.length) implies (res[it - 1] <= res[it])
+        }
+    }
+    return if (length <= 1) this
+        else mergeStrings(subs(0, length / 2).mergeSorted(), subs(length / 2, length).mergeSorted())
+}

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.fir.diag.txt
@@ -33,13 +33,11 @@ method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String(p$str: Ref)
   var l0$i: Ref
   var anon$2: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
-  inhale acc(p$pkg$kotlin$c$String$shared(p$str), wildcard)
   l0$res := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(10)
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant acc(p$pkg$kotlin$c$String$shared(p$str), wildcard)
     invariant df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
     invariant (forall anon$0: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType()) ==>
         0 <= df$rt$intFromRef(anon$0) &&
@@ -57,7 +55,6 @@ method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String(p$str: Ref)
   label lbl$break$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant acc(p$pkg$kotlin$c$String$shared(p$str), wildcard)
     invariant df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
     invariant (forall anon$0: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType()) ==>
         0 <= df$rt$intFromRef(anon$0) &&
@@ -69,5 +66,3 @@ method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String(p$str: Ref)
   goto lbl$ret$0
   label lbl$ret$0
 }
-
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_postcondition.fir.diag.txt
@@ -19,9 +19,6 @@ method f$testString$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
-
 /simple_postcondition.kt:(323,343): info: Generated Viper text for testWithPrecondition:
 method f$testWithPrecondition$TF$T$Int(p$int: Ref) returns (ret$0: Ref)
   requires df$rt$intFromRef(p$int) > 10

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_precondition.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_precondition.fir.diag.txt
@@ -15,9 +15,6 @@ method f$test$TF$T$Int(p$idx: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-
-
 /simple_precondition.kt:(446,469): info: Generated Viper text for inlineWithSpecification:
 method f$inlineWithSpecification$TF$T$Boolean(p$bool: Ref)
   returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/strings_in_conditions.fir.diag.txt
@@ -10,7 +10,6 @@ method f$firstNotSortedIndex$TF$T$String(p$s: Ref) returns (ret$0: Ref)
       df$rt$stringFromRef(p$s)[df$rt$intFromRef(anon$3) + 1])
 {
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  inhale acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
   if (|df$rt$stringFromRef(p$s)| == 0) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
@@ -20,7 +19,6 @@ method f$firstNotSortedIndex$TF$T$String(p$s: Ref) returns (ret$0: Ref)
     l4$i := df$rt$intToRef(1)
     label lbl$continue$0
       invariant df$rt$isSubtype(df$rt$typeOf(l4$i), df$rt$intType())
-      invariant acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
       invariant df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
       invariant (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1),
           df$rt$intType()) ==>
@@ -39,7 +37,6 @@ method f$firstNotSortedIndex$TF$T$String(p$s: Ref) returns (ret$0: Ref)
     }
     label lbl$break$0
       invariant df$rt$isSubtype(df$rt$typeOf(l4$i), df$rt$intType())
-      invariant acc(p$pkg$kotlin$c$String$shared(p$s), wildcard)
       invariant df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
       invariant (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1),
           df$rt$intType()) ==>
@@ -53,5 +50,76 @@ method f$firstNotSortedIndex$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+/strings_in_conditions.kt:(621,636): info: Generated Viper text for returnNewString:
+method f$returnNewString$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
+{
+  ret$0 := df$rt$stringToRef(Seq(52, 50))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
 
+/strings_in_conditions.kt:(672,689): info: Generated Viper text for addCharacterTimes:
+method f$addCharacterTimes$TF$T$String$T$Char$T$Int(p$s: Ref, p$c: Ref, p$n: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$intFromRef(p$n) >= 0
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
+  ensures |df$rt$stringFromRef(ret$0)| ==
+    |df$rt$stringFromRef(p$s)| + df$rt$intFromRef(p$n)
+  ensures (forall anon$3: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$intType()) ==>
+      |df$rt$stringFromRef(p$s)| <= df$rt$intFromRef(anon$3) &&
+      df$rt$intFromRef(anon$3) < |df$rt$stringFromRef(ret$0)| ==>
+      df$rt$stringFromRef(ret$0)[df$rt$intFromRef(anon$3)] ==
+      df$rt$charFromRef(p$c))
+{
+  var l0$i: Ref
+  var l0$res: Ref
+  var anon$2: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  l0$i := df$rt$intToRef(0)
+  l0$res := p$s
+  label lbl$continue$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+    invariant 0 <= df$rt$intFromRef(l0$i) &&
+      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+    invariant |df$rt$stringFromRef(l0$res)| ==
+      |df$rt$stringFromRef(p$s)| + df$rt$intFromRef(l0$i)
+    invariant (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType()) ==>
+        |df$rt$stringFromRef(p$s)| <= df$rt$intFromRef(anon$1) &&
+        df$rt$intFromRef(anon$1) < |df$rt$stringFromRef(l0$res)| ==>
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$1)] ==
+        df$rt$charFromRef(p$c))
+  anon$2 := sp$ltInts(l0$i, p$n)
+  if (df$rt$boolFromRef(anon$2)) {
+    l0$res := sp$addStringChar(l0$res, p$c)
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+    invariant 0 <= df$rt$intFromRef(l0$i) &&
+      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+    invariant |df$rt$stringFromRef(l0$res)| ==
+      |df$rt$stringFromRef(p$s)| + df$rt$intFromRef(l0$i)
+    invariant (forall anon$1: Ref ::df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType()) ==>
+        |df$rt$stringFromRef(p$s)| <= df$rt$intFromRef(anon$1) &&
+        df$rt$intFromRef(anon$1) < |df$rt$stringFromRef(l0$res)| ==>
+        df$rt$stringFromRef(l0$res)[df$rt$intFromRef(anon$1)] ==
+        df$rt$charFromRef(p$c))
+  ret$0 := l0$res
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any(this$dispatch: Ref, p$other: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/strings_in_conditions.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/strings_in_conditions.kt
@@ -23,3 +23,35 @@ fun <!VIPER_TEXT!>firstNotSortedIndex<!>(s: String): Int {
         return i
     }
 }
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>returnNewString<!>(): String {
+    return "42"
+}
+
+fun <!VIPER_TEXT!>addCharacterTimes<!>(s: String, c: Char, n: Int): String {
+    preconditions {
+        n >= 0
+    }
+    postconditions<String> { res ->
+        res.length == s.length + n
+        forAll<Int> {
+            (s.length <= it && it < res.length) implies (res[it] == c)
+        }
+    }
+
+    var i = 0
+    var res = s
+    while (i < n) {
+        loopInvariants {
+            0 <= i && i <= n
+            res.length == s.length + i
+            forAll<Int> {
+                (s.length <= it && it < res.length) implies (res[it] == c)
+            }
+        }
+        res += c
+    }
+
+    return res
+}

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/sum_of_1_to_n.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/sum_of_1_to_n.fir.diag.txt
@@ -1,0 +1,58 @@
+/sum_of_1_to_n.kt:(64,91): info: Generated Viper text for recursiveSumOfIntegersUpToN:
+method f$recursiveSumOfIntegersUpToN$TF$T$Int(p$n: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$intFromRef(p$n) >= 0
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures df$rt$intFromRef(ret$0) ==
+    df$rt$intFromRef(p$n) * (df$rt$intFromRef(p$n) + 1) / 2
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  if (df$rt$intFromRef(p$n) == 0) {
+    ret$0 := df$rt$intToRef(0)
+    goto lbl$ret$0
+  } else {
+    var anon$0: Ref
+    anon$0 := f$recursiveSumOfIntegersUpToN$TF$T$Int(sp$minusInts(p$n, df$rt$intToRef(1)))
+    ret$0 := sp$plusInts(p$n, anon$0)
+    goto lbl$ret$0
+  }
+  label lbl$ret$0
+}
+
+/sum_of_1_to_n.kt:(296,314): info: Generated Viper text for sumOfIntegersUpToN:
+method f$sumOfIntegersUpToN$TF$T$Int(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$intFromRef(p$n) >= 0
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+  ensures df$rt$intFromRef(ret$0) ==
+    df$rt$intFromRef(p$n) * (df$rt$intFromRef(p$n) + 1) / 2
+{
+  var l0$sum: Ref
+  var l0$i: Ref
+  var anon$0: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  l0$sum := df$rt$intToRef(0)
+  l0$i := df$rt$intToRef(0)
+  label lbl$continue$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$sum), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+    invariant df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+    invariant df$rt$intFromRef(l0$sum) ==
+      df$rt$intFromRef(l0$i) * (df$rt$intFromRef(l0$i) + 1) / 2
+  anon$0 := sp$ltInts(l0$i, p$n)
+  if (df$rt$boolFromRef(anon$0)) {
+    l0$sum := sp$plusInts(l0$sum, sp$plusInts(l0$i, df$rt$intToRef(1)))
+    l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$sum), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+    invariant df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+    invariant df$rt$intFromRef(l0$sum) ==
+      df$rt$intFromRef(l0$i) * (df$rt$intFromRef(l0$i) + 1) / 2
+  ret$0 := l0$sum
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/sum_of_1_to_n.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/user_invariants/sum_of_1_to_n.kt
@@ -1,0 +1,28 @@
+import org.jetbrains.kotlin.formver.plugin.*
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>recursiveSumOfIntegersUpToN<!>(n: Int): Int {
+    preconditions { n >= 0 }
+    postconditions<Int> { res -> res == n * (n + 1) / 2 }
+
+    if (n == 0) return 0
+    else return n + recursiveSumOfIntegersUpToN(n - 1)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>sumOfIntegersUpToN<!>(n: Int): Int {
+    preconditions { n >= 0 }
+    postconditions<Int> { res -> res == n * (n + 1) / 2 }
+
+    var sum = 0
+    var i = 0
+    while (i < n) {
+        loopInvariants {
+            i <= n
+            sum == i * (i + 1) / 2
+        }
+        sum += i + 1
+        ++i
+    }
+    return sum
+}

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -691,6 +691,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
       }
 
       @Test
+      @TestMetadata("merge_sort_of_string.kt")
+      public void testMerge_sort_of_string() {
+        runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/merge_sort_of_string.kt");
+      }
+
+      @Test
       @TestMetadata("simple_forall.kt")
       public void testSimple_forall() {
         runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/simple_forall.kt");

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -719,6 +719,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
       public void testStrings_in_conditions() {
         runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/strings_in_conditions.kt");
       }
+
+      @Test
+      @TestMetadata("sum_of_1_to_n.kt")
+      public void testSum_of_1_to_n() {
+        runTest("plugins/formal-verification/testData/diagnostics/verifies/user_invariants/sum_of_1_to_n.kt");
+      }
     }
   }
 }


### PR DESCRIPTION
In this PR, two big tests are added (merge sort, sum of integers from one to `n`).
The following changes are made for them to pass:

- When dividing, we do not inhale that the divisor is zero anymore.
- `String` is fully primitive type; it does not feature any predicates and behaves the same way `Int` or `Boolean` behave.
- For function `String.plus(other: Any?)`, `String.plus(other: Char)` is supported separately.