### PR TITLE
Validity error reporting

### DIFF
--- a/plugins/formal-verification/formver.common/build.gradle.kts
+++ b/plugins/formal-verification/formver.common/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     compileOnly(kotlinStdlib())
+    compileOnly(project(":compiler:fir:plugin-utils"))
 }
 
 sourceSets {

--- a/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/ErrorCollector.kt
+++ b/plugins/formal-verification/formver.common/src/org/jetbrains/kotlin/formver/ErrorCollector.kt
@@ -5,6 +5,8 @@
 
 package org.jetbrains.kotlin.formver
 
+import org.jetbrains.kotlin.KtSourceElement
+
 /** Collector for *internal* plugin errors.
  *
  * TODO: Replace this with some kind of more systematic approach to generating diagnostics.
@@ -12,6 +14,7 @@ package org.jetbrains.kotlin.formver
 class ErrorCollector {
     private val internalErrorInfos = mutableListOf<String>()
     private val minorErrors = mutableListOf<String>()
+    private val purityErrors = mutableListOf<Pair<KtSourceElement, String>>()
 
     fun addMinorError(error: String) {
         minorErrors.add(error)
@@ -26,5 +29,15 @@ class ErrorCollector {
 
     fun addErrorInfo(msg: String) {
         internalErrorInfos.add(msg)
+    }
+
+    fun addPurityError(position: KtSourceElement, msg: String) {
+        purityErrors.add(Pair(position, msg))
+    }
+
+    fun forEachPurityError(action: (KtSourceElement, String) -> Unit) {
+        purityErrors.forEach { (key, value) ->
+            action(key, value)
+        }
     }
 }

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/Utils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/Utils.kt
@@ -8,3 +8,13 @@ package org.jetbrains.kotlin.formver
 fun <T> List<T>.forEachWithIsLast(f: (T, Boolean) -> Unit) = indices.forEach { f(this[it], it == lastIndex) }
 fun <T, R> List<T>.mapWithIsLast(f: (T, Boolean) -> R): List<R> = indices.map { f(this[it], it == lastIndex) }
 
+/**
+ * Similar to `all`, but does not short-circuit.
+ */
+fun <T> Sequence<T>.exhaustiveAll(predicate: (T) -> Boolean): Boolean {
+    var result = true
+    for (item in this) {
+        if (!predicate(item)) result = false
+    }
+    return result
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/conversion/StmtConversionContext.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.formver.isCustom
 import org.jetbrains.kotlin.formver.linearization.Linearizer
 import org.jetbrains.kotlin.formver.linearization.SeqnBuilder
 import org.jetbrains.kotlin.formver.linearization.SharedLinearizationState
+import org.jetbrains.kotlin.formver.purity.checkValidity
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
@@ -238,6 +239,9 @@ fun StmtConversionContext.convertMethodWithBody(
     // note: we must guarantee somewhere that returned value is Unit
     // as we may not encounter any `return` statement in the body
     returnTarget.variable.withIsUnitInvariantIfUnit().toViperUnusedResult(linearizer)
+
+    // TODO: Terminate conversion if purity check fails
+    body.checkValidity(declaration.source, errorCollector)
     return FunctionBodyEmbedding(seqnBuilder.block, returnTarget, bodyExp)
 }
 

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/ExpEmbedding.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.formver.linearization.InhaleExhaleStmtModifier
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.linearization.UnfoldPolicy
 import org.jetbrains.kotlin.formver.linearization.pureToViper
+import org.jetbrains.kotlin.formver.purity.PurityContext
 import org.jetbrains.kotlin.formver.viper.MangledName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -84,7 +85,7 @@ sealed interface ExpEmbedding : DebugPrintable {
 
     fun children(): Sequence<ExpEmbedding> = emptySequence()
     fun <R> accept(v: ExpVisitor<R>): R
-    fun isValid(): Boolean = true
+    fun isValid(ctx: PurityContext): Boolean = true
 }
 
 sealed class ToViperBuiltinMisuseError(msg: String) : RuntimeException(msg)

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/embeddings/expression/Special.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.formver.asPosition
 import org.jetbrains.kotlin.formver.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.linearization.LinearizationContext
+import org.jetbrains.kotlin.formver.purity.PurityContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
@@ -47,8 +48,9 @@ data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugT
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitAssert(this)
 
-    override fun isValid(): Boolean = exp.accept(ExprPurityVisitor)
-
+    override fun isValid(ctx: PurityContext): Boolean = exp.accept(ExprPurityVisitor).also {
+        if (!it) ctx.addPurityError(exp, "Assert condition is impure")
+    }
 }
 
 /**

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/purity/DefaultPurityContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/purity/DefaultPurityContext.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.purity
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.ErrorCollector
+import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+
+class DefaultPurityContext(
+    private val source: KtSourceElement,
+    private val errorCollector: ErrorCollector,
+) : PurityContext {
+    override fun addPurityError(embedding: ExpEmbedding, msg: String) =
+        errorCollector.addPurityError(embedding.expressionSource(source), msg)
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/purity/ExprUtils.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/purity/ExprUtils.kt
@@ -5,13 +5,50 @@
 
 package org.jetbrains.kotlin.formver.purity
 
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.ErrorCollector
 import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.embeddings.expression.SharingContext
+import org.jetbrains.kotlin.formver.embeddings.expression.WithPosition
+import org.jetbrains.kotlin.formver.exhaustiveAll
 
-fun ExpEmbedding.preorder(): Sequence<ExpEmbedding> = sequence {
-    yield(this@preorder)
-    yieldAll(this@preorder.children().flatMap { it.preorder() })
+/**
+ * Positioning information for a node is stored in the closest parent `WithPosition` node.
+ *
+ * @return a preordered sequence of pairs, each containing the `ExpEmbedding` and its FIR source as a `KtSourceElement`
+ */
+fun ExpEmbedding.preorder(currentSource: KtSourceElement? = null): Sequence<Pair<ExpEmbedding, KtSourceElement?>> = sequence {
+    val nextSource = (this@preorder as? WithPosition)?.source ?: currentSource
+
+    if (this@preorder !is WithPosition) yield(Pair(this@preorder, nextSource))
+
+    yieldAll(this@preorder.children().flatMap { it.preorder(currentSource = nextSource) })
 }
 
-fun ExpEmbedding.checkValidity(): Boolean =
-    preorder()
-        .all { it.isValid() }
+/**
+ * Validates all nodes using the isValid function.
+ * Avoids `all` to prevent short-circuiting, ensuring all errors are reported.
+ */
+fun ExpEmbedding.checkValidity(source: KtSourceElement?, errorCollector: ErrorCollector): Boolean =
+    preorder(source)
+        .exhaustiveAll {
+            val embedding = it.first
+            val source = checkNotNull(it.second) {
+                "Purity-check expected a KtSourceElement, but none was present"
+            }
+            embedding.isValid(DefaultPurityContext(source, errorCollector))
+        }
+
+/**
+ * Returns the `KtSourceElement` of the outermost `WithPosition`
+ * inside this expression; returns [fallback] if none is found.
+ */
+internal fun ExpEmbedding.expressionSource(fallback: KtSourceElement): KtSourceElement {
+    var curr: ExpEmbedding = this@expressionSource
+    while (true) {
+        if (curr is WithPosition) return curr.source
+        else if (curr is SharingContext) curr = curr.inner
+        else break
+    }
+    return fallback
+}

--- a/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/purity/PurityContext.kt
+++ b/plugins/formal-verification/formver.core/src/org/jetbrains/kotlin/formver/purity/PurityContext.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.purity
+
+import org.jetbrains.kotlin.formver.embeddings.expression.ExpEmbedding
+
+interface PurityContext {
+    fun addPurityError(embedding: ExpEmbedding, msg: String)
+}

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/FormalVerificationPluginErrorMessages.kt
@@ -61,5 +61,10 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
             CommonRenderers.STRING
         )
+        map.put(
+            PluginErrors.PURITY_VIOLATION,
+            "{0}",
+            CommonRenderers.STRING
+        )
     }
 }

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/PluginErrors.kt
@@ -19,6 +19,7 @@ object PluginErrors {
     val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
     val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
     val INVALID_SUBLIST_RANGE by warning2<PsiElement, String, String>()
+    val PURITY_VIOLATION by error1<PsiElement, String>()
 
     val UNIQUENESS_VIOLATION by error1<PsiElement, String>()
 

--- a/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/plugins/formal-verification/formver.plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -65,6 +65,10 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
                 }
             }
 
+            errorCollector.forEachPurityError { source, errorMessage ->
+                reporter.reportOn(source, PluginErrors.PURITY_VIOLATION, errorMessage)
+            }
+
             val verifier = Verifier()
             val onFailure = { err: VerifierError ->
                 val source = err.position.unwrapOr { declaration.source }

--- a/plugins/formal-verification/testData/diagnostics/purity/assert_statements.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/purity/assert_statements.fir.diag.txt
@@ -1,0 +1,46 @@
+/assert_statements.kt:(63,67): info: Generated Viper text for test:
+field bf$size: Ref
+
+method f$test$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$1: Ref
+  var anon$0: Ref
+  var anon$2: Ref
+  l0$x := df$rt$intToRef(42)
+  assert true
+  assert false
+  assert 2 <= df$rt$intFromRef(l0$x)
+  anon$0 := l0$x
+  l0$x := sp$plusInts(anon$0, df$rt$intToRef(1))
+  anon$1 := anon$0
+  assert df$rt$intFromRef(anon$1) < 43
+  l0$x := sp$plusInts(l0$x, df$rt$intToRef(1))
+  anon$2 := l0$x
+  assert df$rt$intFromRef(anon$2) < 43
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/assert_statements.kt:(160,166): error: Assert condition is impure
+
+/assert_statements.kt:(168,174): error: Assert condition is impure
+
+/assert_statements.kt:(196,206): info: Generated Viper text for testImpure:
+field bf$size: Ref
+
+method f$testImpure$TF$() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  l0$x := df$rt$intToRef(42)
+  l0$x := sp$plusInts(l0$x, df$rt$intToRef(1))
+  anon$0 := l0$x
+  assert df$rt$intFromRef(anon$0) < 43
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/assert_statements.kt:(237,243): error: Assert condition is impure

--- a/plugins/formal-verification/testData/diagnostics/purity/assert_statements.kt
+++ b/plugins/formal-verification/testData/diagnostics/purity/assert_statements.kt
@@ -1,0 +1,16 @@
+import org.jetbrains.kotlin.formver.plugin.*
+
+@NeverVerify
+fun <!VIPER_TEXT!>test<!>() {
+    var x = 42
+    // Pure
+    verify(true,false, 2 <= x)
+    // Both impure
+    verify(<!PURITY_VIOLATION!>x++<43<!>, <!PURITY_VIOLATION!>++x<43<!>)
+}
+
+@NeverVerify
+fun <!VIPER_TEXT!>testImpure<!>() {
+    var x = 42
+    verify(<!PURITY_VIOLATION!>++x<43<!>)
+}

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/custom_run_functions.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/custom_run_functions.fir.diag.txt
@@ -77,35 +77,37 @@ method f$useRun$TF$() returns (ret$0: Ref)
   var anon$43: Ref
   var ret$29: Ref
   var anon$3: Ref
-  var anon$44: Ref
+  var l0$cond1: Ref
   var ret$30: Ref
   var l30$result: Ref
   var ret$31: Ref
-  var anon$45: Ref
+  var l0$cond2: Ref
+  var anon$44: Ref
   var ret$32: Ref
   var l32$result: Ref
   var ret$33: Ref
-  var anon$46: Ref
+  var l0$cond3: Ref
   var ret$34: Ref
   var l34$result: Ref
   var ret$35: Ref
   var anon$4: Ref
-  var anon$47: Ref
+  var l0$cond4: Ref
+  var anon$45: Ref
   var ret$36: Ref
   var l36$result: Ref
   var ret$37: Ref
   var anon$5: Ref
-  var anon$48: Ref
+  var l0$cond5: Ref
   var ret$38: Ref
   var l38$result: Ref
   var ret$39: Ref
   var anon$6: Ref
-  var anon$49: Ref
+  var l0$cond6: Ref
   var ret$40: Ref
   var l40$result: Ref
   var ret$41: Ref
   var anon$7: Ref
-  var anon$50: Ref
+  var l0$cond7: Ref
   var ret$42: Ref
   var l42$result: Ref
   var ret$44: Ref
@@ -274,10 +276,6 @@ method f$useRun$TF$() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$41), df$rt$intType())
   l0$genericReceiverResult := df$rt$boolToRef(df$rt$intFromRef(anon$41) ==
     3)
-  assert df$rt$boolFromRef(l0$intResult)
-  assert df$rt$boolFromRef(l0$genericResult)
-  assert df$rt$boolFromRef(l0$stdlibResult)
-  assert df$rt$boolFromRef(l0$capturedResult)
   ret$31 := sp$plusInts(df$rt$intToRef(1), df$rt$intToRef(2))
   goto lbl$ret$31
   label lbl$ret$31
@@ -285,8 +283,7 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$30 := df$rt$boolToRef(df$rt$intFromRef(l30$result) == 3)
   goto lbl$ret$30
   label lbl$ret$30
-  anon$44 := ret$30
-  assert df$rt$boolFromRef(anon$44)
+  l0$cond1 := ret$30
   ret$33 := df$rt$intToRef(4)
   goto lbl$ret$33
   label lbl$ret$33
@@ -294,8 +291,8 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$32 := df$rt$boolToRef(df$rt$intFromRef(l32$result) == 3)
   goto lbl$ret$32
   label lbl$ret$32
-  anon$45 := ret$32
-  assert !df$rt$boolFromRef(anon$45)
+  anon$44 := ret$32
+  l0$cond2 := sp$notBool(anon$44)
   anon$4 := df$rt$intToRef(1)
   ret$35 := sp$plusInts(anon$4, df$rt$intToRef(2))
   goto lbl$ret$35
@@ -304,8 +301,7 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$34 := df$rt$boolToRef(df$rt$intFromRef(l34$result) == 3)
   goto lbl$ret$34
   label lbl$ret$34
-  anon$46 := ret$34
-  assert df$rt$boolFromRef(anon$46)
+  l0$cond3 := ret$34
   anon$5 := df$rt$intToRef(1)
   ret$37 := anon$5
   goto lbl$ret$37
@@ -314,8 +310,8 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$36 := df$rt$boolToRef(df$rt$intFromRef(l36$result) == 3)
   goto lbl$ret$36
   label lbl$ret$36
-  anon$47 := ret$36
-  assert !df$rt$boolFromRef(anon$47)
+  anon$45 := ret$36
+  l0$cond4 := sp$notBool(anon$45)
   anon$6 := df$rt$intToRef(1)
   ret$39 := sp$plusInts(anon$6, df$rt$intToRef(2))
   goto lbl$ret$39
@@ -324,8 +320,7 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$38 := df$rt$boolToRef(df$rt$intFromRef(l38$result) == 3)
   goto lbl$ret$38
   label lbl$ret$38
-  anon$48 := ret$38
-  assert df$rt$boolFromRef(anon$48)
+  l0$cond5 := ret$38
   anon$7 := df$rt$intToRef(1)
   ret$41 := sp$plusInts(anon$7, df$rt$intToRef(2))
   goto lbl$ret$41
@@ -334,8 +329,7 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$40 := df$rt$boolToRef(df$rt$intFromRef(l40$result) == 3)
   goto lbl$ret$40
   label lbl$ret$40
-  anon$49 := ret$40
-  assert df$rt$boolFromRef(anon$49)
+  l0$cond6 := ret$40
   anon$8 := df$rt$intToRef(1)
   ret$43 := sp$plusInts(anon$8, df$rt$intToRef(1))
   goto lbl$ret$43
@@ -348,15 +342,25 @@ method f$useRun$TF$() returns (ret$0: Ref)
   ret$42 := df$rt$boolToRef(df$rt$intFromRef(l42$result) == 3)
   goto lbl$ret$42
   label lbl$ret$42
-  anon$50 := ret$42
-  assert df$rt$boolFromRef(anon$50)
+  l0$cond7 := ret$42
+  assert df$rt$boolFromRef(l0$intResult)
+  assert df$rt$boolFromRef(l0$genericResult)
+  assert df$rt$boolFromRef(l0$stdlibResult)
+  assert df$rt$boolFromRef(l0$capturedResult)
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
+  assert df$rt$boolFromRef(l0$cond3)
+  assert df$rt$boolFromRef(l0$cond4)
+  assert df$rt$boolFromRef(l0$cond5)
+  assert df$rt$boolFromRef(l0$cond6)
+  assert df$rt$boolFromRef(l0$cond7)
   assert df$rt$boolFromRef(l0$doubleIntRunResult)
   assert df$rt$boolFromRef(l0$genericReceiverResult)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/custom_run_functions.kt:(2199,2214): info: Generated Viper text for complexScenario:
+/custom_run_functions.kt:(2354,2369): info: Generated Viper text for complexScenario:
 method f$complexScenario$TF$T$Boolean(p$arg: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> df$rt$boolFromRef(p$arg)
@@ -528,7 +532,7 @@ method f$complexScenario$TF$T$Boolean(p$arg: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/custom_run_functions.kt:(3255,3270): info: Generated Viper text for testCustomClass:
+/custom_run_functions.kt:(3410,3425): info: Generated Viper text for testCustomClass:
 field bf$member: Ref
 
 field bf$size: Ref
@@ -543,6 +547,7 @@ method f$testCustomClass$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$custom: Ref
+  var l0$cond1: Ref
   var anon$0: Ref
   var anon$1: Ref
   var ret$1: Ref
@@ -578,7 +583,9 @@ method f$testCustomClass$TF$() returns (ret$0: Ref)
   anon$4 := ret$3
   anon$3 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$intType())
-  assert df$rt$intFromRef(anon$0) == df$rt$intFromRef(anon$3)
+  l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$0) ==
+    df$rt$intFromRef(anon$3))
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/custom_run_functions.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/custom_run_functions.kt
@@ -51,18 +51,26 @@ public fun <!VIPER_TEXT!>useRun<!>() {
     val doubleIntRunResult = 1.doubleIntRun { plus(1) } == 3
     val genericReceiverResult = 1.copiedRun { plus(2) } == 3
 
+    val cond1 = equalsThree { 1 + 2 }
+    val cond2 = !equalsThree { 4 }
+    val cond3 = equalsThreeParametrized { it + 2 }
+    val cond4 = !equalsThreeParametrized { arg -> arg }
+    val cond5 = equalsThreeExtension { this + 2 }
+    val cond6 = equalsThreeExtension { plus(2) }
+    val cond7 = doubleEqualsThree { plus(1) }
+
     verify(
         intResult,
         genericResult,
         stdlibResult,
         capturedResult,
-        equalsThree { 1 + 2 },
-        !equalsThree { 4 },
-        equalsThreeParametrized { it + 2 },
-        !equalsThreeParametrized { arg -> arg },
-        equalsThreeExtension { this + 2 },
-        equalsThreeExtension { plus(2) },
-        doubleEqualsThree { plus(1) },
+        cond1,
+        cond2,
+        cond3,
+        cond4,
+        cond5,
+        cond6,
+        cond7,
         doubleIntRunResult,
         genericReceiverResult
     )
@@ -115,5 +123,6 @@ inline fun <T> CustomClass.extensionRun(block: CustomClass.() -> T): T = block()
 @AlwaysVerify
 fun <!VIPER_TEXT!>testCustomClass<!>() {
     val custom = CustomClass()
-    verify(custom.memberRun { member } == custom.extensionRun { member })
+    val cond1 = custom.memberRun { member } == custom.extensionRun { member }
+    verify(cond1)
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/inline_returns.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/inline_returns.fir.diag.txt
@@ -4,24 +4,24 @@ field bf$size: Ref
 method f$simple_return$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  var anon$0: Ref
+  var l0$cond1: Ref
   var ret$1: Ref
-  var anon$1: Ref
+  var anon$0: Ref
   var ret$2: Ref
   ret$2 := df$rt$boolToRef(false)
   goto lbl$ret$2
   label lbl$ret$2
-  anon$1 := ret$2
-  ret$1 := sp$notBool(anon$1)
+  anon$0 := ret$2
+  ret$1 := sp$notBool(anon$0)
   goto lbl$ret$1
   label lbl$ret$1
-  anon$0 := ret$1
-  assert df$rt$boolFromRef(anon$0)
+  l0$cond1 := ret$1
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/inline_returns.kt:(412,426): info: Generated Viper text for unnamed_return:
+/inline_returns.kt:(434,448): info: Generated Viper text for unnamed_return:
 method f$unnamed_return$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
@@ -43,7 +43,7 @@ method f$unnamed_return$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/inline_returns.kt:(583,601): info: Generated Viper text for named_local_return:
+/inline_returns.kt:(605,623): info: Generated Viper text for named_local_return:
 method f$named_local_return$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
@@ -65,7 +65,7 @@ method f$named_local_return$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/inline_returns.kt:(763,784): info: Generated Viper text for named_nonlocal_return:
+/inline_returns.kt:(785,806): info: Generated Viper text for named_nonlocal_return:
 method f$named_nonlocal_return$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
@@ -87,7 +87,7 @@ method f$named_nonlocal_return$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/inline_returns.kt:(963,985): info: Generated Viper text for double_nonlocal_return:
+/inline_returns.kt:(985,1007): info: Generated Viper text for double_nonlocal_return:
 method f$double_nonlocal_return$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
@@ -123,7 +123,7 @@ method f$double_nonlocal_return$TF$() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/inline_returns.kt:(1336,1364): info: Generated Viper text for named_double_nonlocal_return:
+/inline_returns.kt:(1358,1386): info: Generated Viper text for named_double_nonlocal_return:
 method f$named_double_nonlocal_return$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/inline_returns.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/inline_returns.kt
@@ -9,7 +9,8 @@ inline fun not(f: () -> Boolean): Boolean = !f()
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>simple_return<!>() {
-    verify(not { false })
+    val cond1 = not { false }
+    verify(cond1)
 }
 
 @OptIn(ExperimentalContracts::class)

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/scoped_receivers.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/scoped_receivers.fir.diag.txt
@@ -5,71 +5,71 @@ method f$with_run_extension_labeled$TF$NT$Int(this$extension: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
+  var l0$cond1: Ref
   var anon$13: Ref
-  var anon$14: Ref
   var ret$1: Ref
+  var anon$14: Ref
   var anon$15: Ref
-  var anon$16: Ref
   var ret$3: Ref
   var anon$0: Ref
-  var anon$17: Ref
+  var anon$16: Ref
   var ret$4: Ref
   var anon$1: Ref
+  var anon$17: Ref
   var anon$18: Ref
-  var anon$19: Ref
   var ret$5: Ref
   var anon$2: Ref
-  var anon$20: Ref
+  var anon$19: Ref
   var ret$6: Ref
   var anon$3: Ref
-  var anon$21: Ref
+  var anon$20: Ref
   var ret$7: Ref
   var anon$4: Ref
-  var anon$22: Ref
+  var anon$21: Ref
   var ret$8: Ref
   var anon$5: Ref
-  var anon$23: Ref
+  var anon$22: Ref
   var ret$9: Ref
   var anon$6: Ref
+  var anon$23: Ref
   var anon$24: Ref
-  var anon$25: Ref
   var ret$10: Ref
   var anon$7: Ref
-  var anon$26: Ref
+  var anon$25: Ref
   var ret$11: Ref
   var anon$8: Ref
+  var anon$26: Ref
   var anon$27: Ref
-  var anon$28: Ref
   var ret$12: Ref
+  var anon$28: Ref
   var anon$29: Ref
-  var anon$30: Ref
   var ret$14: Ref
   var anon$9: Ref
-  var anon$31: Ref
+  var anon$30: Ref
   var ret$15: Ref
   var anon$10: Ref
+  var anon$31: Ref
   var anon$32: Ref
-  var anon$33: Ref
   var ret$16: Ref
   var anon$11: Ref
-  var anon$34: Ref
+  var anon$33: Ref
   var ret$17: Ref
   var anon$12: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$intType()))
   ret$1 := df$rt$boolToRef(this$extension == df$rt$nullValue())
   goto lbl$ret$1
   label lbl$ret$1
-  anon$14 := ret$1
-  if (df$rt$boolFromRef(anon$14)) {
-    anon$13 := df$rt$boolToRef(true)
+  anon$13 := ret$1
+  if (df$rt$boolFromRef(anon$13)) {
+    l0$cond1 := df$rt$boolToRef(true)
   } else {
     var ret$2: Ref
     ret$2 := sp$notBool(df$rt$boolToRef(this$extension == df$rt$nullValue()))
     goto lbl$ret$2
     label lbl$ret$2
-    anon$13 := ret$2
+    l0$cond1 := ret$2
   }
-  assert df$rt$boolFromRef(anon$13)
+  assert df$rt$boolFromRef(l0$cond1)
   anon$0 := df$rt$boolToRef(true)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
@@ -83,32 +83,32 @@ method f$with_run_extension_labeled$TF$NT$Int(this$extension: Ref)
   ret$7 := df$rt$boolToRef(anon$4 == df$rt$nullValue())
   goto lbl$ret$7
   label lbl$ret$7
-  anon$21 := ret$7
-  assert df$rt$boolFromRef(anon$21)
+  anon$20 := ret$7
+  assert df$rt$boolFromRef(anon$20)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$nullable(df$rt$intType()))
   anon$5 := anon$3
   ret$8 := df$rt$boolToRef(anon$5 == df$rt$nullValue())
   goto lbl$ret$8
   label lbl$ret$8
-  anon$22 := ret$8
-  assert df$rt$boolFromRef(anon$22)
+  anon$21 := ret$8
+  assert df$rt$boolFromRef(anon$21)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$nullable(df$rt$intType()))
   anon$6 := anon$3
   ret$9 := df$rt$boolToRef(anon$6 == df$rt$nullValue())
   goto lbl$ret$9
   label lbl$ret$9
-  anon$23 := ret$9
-  assert df$rt$boolFromRef(anon$23)
+  anon$22 := ret$9
+  assert df$rt$boolFromRef(anon$22)
   label lbl$ret$6
   inhale df$rt$isSubtype(df$rt$typeOf(ret$6), df$rt$unitType())
-  anon$20 := ret$6
-  ret$5 := anon$20
+  anon$19 := ret$6
+  ret$5 := anon$19
   inhale df$rt$isSubtype(df$rt$typeOf(ret$5), df$rt$nullable(df$rt$anyType()))
   goto lbl$ret$5
   label lbl$ret$5
-  anon$19 := ret$5
-  anon$18 := anon$19
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$18), df$rt$unitType())
+  anon$18 := ret$5
+  anon$17 := anon$18
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$17), df$rt$unitType())
   assert df$rt$boolFromRef(anon$1)
   assert df$rt$boolFromRef(anon$1)
   anon$7 := df$rt$boolToRef(false)
@@ -121,18 +121,18 @@ method f$with_run_extension_labeled$TF$NT$Int(this$extension: Ref)
   ret$12 := df$rt$boolToRef(this$extension == df$rt$nullValue())
   goto lbl$ret$12
   label lbl$ret$12
-  anon$28 := ret$12
-  if (df$rt$boolFromRef(anon$28)) {
-    anon$27 := df$rt$boolToRef(true)
+  anon$27 := ret$12
+  if (df$rt$boolFromRef(anon$27)) {
+    anon$26 := df$rt$boolToRef(true)
   } else {
     var ret$13: Ref
     ret$13 := sp$notBool(df$rt$boolToRef(this$extension ==
       df$rt$nullValue()))
     goto lbl$ret$13
     label lbl$ret$13
-    anon$27 := ret$13
+    anon$26 := ret$13
   }
-  assert df$rt$boolFromRef(anon$27)
+  assert df$rt$boolFromRef(anon$26)
   anon$9 := df$rt$boolToRef(false)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$9), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$9), df$rt$boolType())
@@ -149,44 +149,44 @@ method f$with_run_extension_labeled$TF$NT$Int(this$extension: Ref)
   assert df$rt$boolFromRef(anon$12)
   label lbl$ret$17
   inhale df$rt$isSubtype(df$rt$typeOf(ret$17), df$rt$unitType())
-  anon$34 := ret$17
-  ret$16 := anon$34
+  anon$33 := ret$17
+  ret$16 := anon$33
   inhale df$rt$isSubtype(df$rt$typeOf(ret$16), df$rt$nullable(df$rt$anyType()))
   goto lbl$ret$16
   label lbl$ret$16
-  anon$33 := ret$16
-  anon$32 := anon$33
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$32), df$rt$unitType())
+  anon$32 := ret$16
+  anon$31 := anon$32
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$31), df$rt$unitType())
   label lbl$ret$15
   inhale df$rt$isSubtype(df$rt$typeOf(ret$15), df$rt$unitType())
-  anon$31 := ret$15
-  ret$14 := anon$31
+  anon$30 := ret$15
+  ret$14 := anon$30
   inhale df$rt$isSubtype(df$rt$typeOf(ret$14), df$rt$nullable(df$rt$anyType()))
   goto lbl$ret$14
   label lbl$ret$14
-  anon$30 := ret$14
-  anon$29 := anon$30
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$29), df$rt$unitType())
+  anon$29 := ret$14
+  anon$28 := anon$29
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$28), df$rt$unitType())
   label lbl$ret$11
   inhale df$rt$isSubtype(df$rt$typeOf(ret$11), df$rt$unitType())
-  anon$26 := ret$11
-  ret$10 := anon$26
+  anon$25 := ret$11
+  ret$10 := anon$25
   inhale df$rt$isSubtype(df$rt$typeOf(ret$10), df$rt$nullable(df$rt$anyType()))
   goto lbl$ret$10
   label lbl$ret$10
-  anon$25 := ret$10
-  anon$24 := anon$25
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$24), df$rt$unitType())
+  anon$24 := ret$10
+  anon$23 := anon$24
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$23), df$rt$unitType())
   label lbl$ret$4
   inhale df$rt$isSubtype(df$rt$typeOf(ret$4), df$rt$unitType())
-  anon$17 := ret$4
-  ret$3 := anon$17
+  anon$16 := ret$4
+  ret$3 := anon$16
   inhale df$rt$isSubtype(df$rt$typeOf(ret$3), df$rt$nullable(df$rt$anyType()))
   goto lbl$ret$3
   label lbl$ret$3
-  anon$16 := ret$3
-  anon$15 := anon$16
-  inhale df$rt$isSubtype(df$rt$typeOf(anon$15), df$rt$unitType())
+  anon$15 := ret$3
+  anon$14 := anon$15
+  inhale df$rt$isSubtype(df$rt$typeOf(anon$14), df$rt$unitType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/inlining/scoped_receivers.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/inlining/scoped_receivers.kt
@@ -14,7 +14,8 @@ inline fun Int?.isNotNull() = this != null
 
 @Suppress("LABEL_NAME_CLASH")
 fun Int?.<!VIPER_TEXT!>with_run_extension_labeled<!>() {
-    verify(isNull() || this@with_run_extension_labeled.isNotNull())
+    val cond1 = isNull() || this@with_run_extension_labeled.isNotNull()
+    verify(cond1)
     with(true) {
         with(null) {
             verify(

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/backing_field_getters.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/backing_field_getters.fir.diag.txt
@@ -1,4 +1,4 @@
-/backing_field_getters.kt:(261,271): info: Generated Viper text for cascadeGet:
+/backing_field_getters.kt:(270,280): info: Generated Viper text for cascadeGet:
 field bf$y: Ref
 
 field bf$z: Ref
@@ -18,7 +18,7 @@ method f$cascadeGet$TF$T$X(p$x: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/backing_field_getters.kt:(344,365): info: Generated Viper text for receiverNotNullProved:
+/backing_field_getters.kt:(353,374): info: Generated Viper text for receiverNotNullProved:
 field bf$y: Ref
 
 field bf$z: Ref
@@ -42,7 +42,7 @@ method f$receiverNotNullProved$TF$NT$X(p$x: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/backing_field_getters.kt:(604,622): info: Generated Viper text for cascadeNullableGet:
+/backing_field_getters.kt:(622,640): info: Generated Viper text for cascadeNullableGet:
 field bf$y: Ref
 
 field bf$z: Ref
@@ -70,7 +70,7 @@ method f$cascadeNullableGet$TF$NT$NullableX(p$x: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/backing_field_getters.kt:(773,800): info: Generated Viper text for cascadeNullableSmartcastGet:
+/backing_field_getters.kt:(791,818): info: Generated Viper text for cascadeNullableSmartcastGet:
 field bf$y: Ref
 
 field bf$z: Ref
@@ -108,7 +108,7 @@ method f$cascadeNullableSmartcastGet$TF$NT$NullableX(p$x: Ref)
   label lbl$ret$0
 }
 
-/backing_field_getters.kt:(1008,1038): info: Generated Viper text for nullableReceiverNotNullSafeGet:
+/backing_field_getters.kt:(1030,1060): info: Generated Viper text for nullableReceiverNotNullSafeGet:
 field bf$size: Ref
 
 field bf$x: Ref
@@ -124,6 +124,7 @@ method f$nullableReceiverNotNullSafeGet$TF$() returns (ret$0: Ref)
 {
   var l0$f: Ref
   var anon$0: Ref
+  var l0$cond1: Ref
   var anon$1: Ref
   anon$0 := con$c$Baz$()
   l0$f := anon$0
@@ -134,12 +135,13 @@ method f$nullableReceiverNotNullSafeGet$TF$() returns (ret$0: Ref)
     anon$1 := anon$2
   } else {
     anon$1 := df$rt$nullValue()}
-  assert !(anon$1 == df$rt$nullValue())
+  l0$cond1 := sp$notBool(df$rt$boolToRef(anon$1 == df$rt$nullValue()))
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/backing_field_getters.kt:(1113,1140): info: Generated Viper text for nullableReceiverNullSafeGet:
+/backing_field_getters.kt:(1157,1184): info: Generated Viper text for nullableReceiverNullSafeGet:
 field bf$size: Ref
 
 field bf$x: Ref
@@ -148,6 +150,7 @@ method f$nullableReceiverNullSafeGet$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
+  var l0$cond1: Ref
   var anon$0: Ref
   l0$f := df$rt$nullValue()
   if (l0$f != df$rt$nullValue()) {
@@ -157,12 +160,13 @@ method f$nullableReceiverNullSafeGet$TF$() returns (ret$0: Ref)
     anon$0 := anon$1
   } else {
     anon$0 := df$rt$nullValue()}
-  assert anon$0 == df$rt$nullValue()
+  l0$cond1 := df$rt$boolToRef(anon$0 == df$rt$nullValue())
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/backing_field_getters.kt:(1249,1275): info: Generated Viper text for nonNullableReceiverSafeGet:
+/backing_field_getters.kt:(1315,1341): info: Generated Viper text for nonNullableReceiverSafeGet:
 field bf$size: Ref
 
 field bf$x: Ref
@@ -177,6 +181,7 @@ method f$nonNullableReceiverSafeGet$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
+  var l0$cond1: Ref
   var anon$0: Ref
   l0$f := con$c$Baz$()
   if (l0$f != df$rt$nullValue()) {
@@ -186,12 +191,13 @@ method f$nonNullableReceiverSafeGet$TF$() returns (ret$0: Ref)
     anon$0 := anon$1
   } else {
     anon$0 := df$rt$nullValue()}
-  assert !(anon$0 == df$rt$nullValue())
+  l0$cond1 := sp$notBool(df$rt$boolToRef(anon$0 == df$rt$nullValue()))
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/backing_field_getters.kt:(1477,1489): info: Generated Viper text for checkPrimary:
+/backing_field_getters.kt:(1565,1577): info: Generated Viper text for checkPrimary:
 field bf$size: Ref
 
 field bf$x: Ref
@@ -232,32 +238,35 @@ method f$checkPrimary$TF$T$Int$T$Int(p$x: Ref, p$y: Ref)
 {
   var l0$classI: Ref
   var l0$z: Ref
-  var anon$0: Ref
+  var l0$cond1: Ref
+  var l0$cond2: Ref
+  var anon$2: Ref
   var anon$3: Ref
-  var anon$4: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   l0$classI := con$c$ClassI$T$Int$T$Int(p$x, p$y)
   l0$z := con$c$Z$()
   if (!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y))) {
-    anon$0 := df$rt$boolToRef(true)
+    l0$cond1 := df$rt$boolToRef(true)
   } else {
+    var anon$0: Ref
     var anon$1: Ref
-    var anon$2: Ref
     unfold acc(p$c$ClassI$shared(l0$classI), wildcard)
-    anon$1 := l0$classI.bf$x
+    anon$0 := l0$classI.bf$x
     unfold acc(p$c$ClassI$shared(l0$classI), wildcard)
-    anon$2 := l0$classI.bf$y
-    anon$0 := df$rt$boolToRef(df$rt$intFromRef(anon$1) ==
-      df$rt$intFromRef(anon$2))
+    anon$1 := l0$classI.bf$y
+    l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$0) ==
+      df$rt$intFromRef(anon$1))
   }
-  assert df$rt$boolFromRef(anon$0)
-  anon$4 := con$c$ClassII$T$Z(l0$z)
-  unfold acc(p$c$ClassII$shared(anon$4), wildcard)
-  anon$3 := anon$4.bf$z
-  assert anon$3 == l0$z
+  anon$3 := con$c$ClassII$T$Z(l0$z)
+  unfold acc(p$c$ClassII$shared(anon$3), wildcard)
+  anon$2 := anon$3.bf$z
+  l0$cond2 := df$rt$boolToRef(anon$2 == l0$z)
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 method pg$public$z(this$dispatch: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/backing_field_getters.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/backing_field_getters.kt
@@ -4,8 +4,13 @@ import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
 import org.jetbrains.kotlin.formver.plugin.verify
 
 class Z
-class Y { val z = Z() }
-class X { val y = Y() }
+class Y {
+    val z = Z()
+}
+
+class X {
+    val y = Y()
+}
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>cascadeGet<!>(x: X): Z {
@@ -20,8 +25,13 @@ fun <!VIPER_TEXT!>receiverNotNullProved<!>(x: X?): Boolean {
     return x?.y != null
 }
 
-class NullableY { val z: Z? = Z() }
-class NullableX { val y: NullableY? = NullableY() }
+class NullableY {
+    val z: Z? = Z()
+}
+
+class NullableX {
+    val y: NullableY? = NullableY()
+}
 
 @OptIn(ExperimentalContracts::class)
 fun <!VIPER_TEXT!>cascadeNullableGet<!>(x: NullableX?): Z? {
@@ -39,25 +49,30 @@ fun <!VIPER_TEXT!>cascadeNullableSmartcastGet<!>(x: NullableX?): Z? {
     return if (x == null) null else if (x.y == null) null else x.y.z
 }
 
-class Baz { val x: Int = 4 }
+class Baz {
+    val x: Int = 4
+}
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>nullableReceiverNotNullSafeGet<!>() {
     val f: Baz? = Baz()
-    verify(f?.x != null)
+    val cond1 = f?.x != null
+    verify(cond1)
 }
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>nullableReceiverNullSafeGet<!>() {
     val f: Baz? = null
-    verify(f?.x == null)
+    val cond1 = f?.x == null
+    verify(cond1)
 }
 
 @Suppress("UNNECESSARY_SAFE_CALL")
 @AlwaysVerify
 fun <!VIPER_TEXT!>nonNullableReceiverSafeGet<!>() {
     val f: Baz = Baz()
-    verify(f?.x != null)
+    val cond1 = f?.x != null
+    verify(cond1)
 }
 
 open class ClassI(val x: Int, val y: Int) {
@@ -70,8 +85,10 @@ class ClassII(final override val z: Z) : ClassI(10, 10)
 fun <!VIPER_TEXT!>checkPrimary<!>(x: Int, y: Int) {
     val classI = ClassI(x, y)
     val z = Z()
+    val cond1 = x != y || classI.x == classI.y
+    val cond2 = ClassII(z).z == z
     verify(
-        x != y || classI.x == classI.y,
-        ClassII(z).z == z
+        cond1,
+        cond2
     )
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/multiple_interfaces.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/multiple_interfaces.fir.diag.txt
@@ -1,4 +1,4 @@
-/multiple_interfaces.kt:(798,803): info: Generated Viper text for take1:
+/multiple_interfaces.kt:(799,804): info: Generated Viper text for take1:
 method f$take1$TF$T$InterfaceWithImplementation1(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -17,7 +17,7 @@ method f$take1$TF$T$InterfaceWithImplementation1(p$obj: Ref)
 method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-/multiple_interfaces.kt:(862,867): info: Generated Viper text for take2:
+/multiple_interfaces.kt:(863,868): info: Generated Viper text for take2:
 method f$take2$TF$T$InterfaceWithoutImplementation2(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -36,7 +36,7 @@ method f$take2$TF$T$InterfaceWithoutImplementation2(p$obj: Ref)
 method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-/multiple_interfaces.kt:(929,934): info: Generated Viper text for take3:
+/multiple_interfaces.kt:(930,935): info: Generated Viper text for take3:
 field bf$field: Ref
 
 method f$take3$TF$T$AbstractWithFinalImplementation3(p$obj: Ref)
@@ -49,7 +49,7 @@ method f$take3$TF$T$AbstractWithFinalImplementation3(p$obj: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/multiple_interfaces.kt:(997,1002): info: Generated Viper text for take4:
+/multiple_interfaces.kt:(998,1003): info: Generated Viper text for take4:
 method f$take4$TF$T$AbstractWithOpenImplementation4(p$obj: Ref)
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -68,7 +68,7 @@ method f$take4$TF$T$AbstractWithOpenImplementation4(p$obj: Ref)
 method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-/multiple_interfaces.kt:(1677,1688): info: Generated Viper text for createImpls:
+/multiple_interfaces.kt:(1683,1694): info: Generated Viper text for createImpls:
 field bf$field: Ref
 
 field bf$size: Ref
@@ -140,10 +140,15 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   var l0$start6: Ref
   var anon$15: Ref
   var anon$16: Ref
+  var l0$cond1: Ref
   var anon$17: Ref
+  var l0$cond2: Ref
   var anon$18: Ref
+  var l0$cond3: Ref
   var anon$19: Ref
+  var l0$cond4: Ref
   var anon$20: Ref
+  var l0$cond5: Ref
   l0$impl12 := con$c$Impl12$()
   unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
   anon$0 := l0$impl12.bf$field
@@ -183,19 +188,28 @@ method f$createImpls$TF$() returns (ret$0: Ref)
   l0$start6 := sp$minusInts(sp$plusInts(anon$15, df$rt$intToRef(1)), df$rt$intToRef(1))
   unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
   anon$17 := l0$impl12.bf$field
-  assert df$rt$intFromRef(l0$start12) == df$rt$intFromRef(anon$17)
+  l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(l0$start12) ==
+    df$rt$intFromRef(anon$17))
   unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
   anon$18 := l0$impl23.bf$field
-  assert df$rt$intFromRef(l0$start23) == df$rt$intFromRef(anon$18)
+  l0$cond2 := df$rt$boolToRef(df$rt$intFromRef(l0$start23) ==
+    df$rt$intFromRef(anon$18))
   unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
   anon$19 := l0$impl3.bf$field
-  assert df$rt$intFromRef(l0$start3) == df$rt$intFromRef(anon$19)
+  l0$cond3 := df$rt$boolToRef(df$rt$intFromRef(l0$start3) ==
+    df$rt$intFromRef(anon$19))
   unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
   anon$20 := l0$impl14.bf$field
-  assert df$rt$intFromRef(l0$start14) == df$rt$intFromRef(anon$20)
-  assert df$rt$isSubtype(df$rt$typeOf(l0$start6), df$rt$intType())
+  l0$cond4 := df$rt$boolToRef(df$rt$intFromRef(l0$start14) ==
+    df$rt$intFromRef(anon$20))
+  l0$cond5 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(l0$start6), df$rt$intType()))
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
+  assert df$rt$boolFromRef(l0$cond3)
+  assert df$rt$boolFromRef(l0$cond4)
+  assert df$rt$boolFromRef(l0$cond5)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -221,3 +235,4 @@ method f$take4$TF$T$AbstractWithOpenImplementation4(p$obj: Ref)
 
 
 method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/multiple_interfaces.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/multiple_interfaces.kt
@@ -22,7 +22,7 @@ interface AnyInterfaceWithoutImplementation5 {
     val field: Any
 }
 
-interface InheritingInterfaceWithoutImplementation6:
+interface InheritingInterfaceWithoutImplementation6 :
     AnyInterfaceWithoutImplementation5, InterfaceWithoutImplementation2
 
 abstract class AbstractWithFinalImplementation3 {
@@ -49,16 +49,16 @@ fun <!VIPER_TEXT!>take4<!>(obj: AbstractWithOpenImplementation4) {
     obj.field
 }
 
-class Impl12: InterfaceWithImplementation1, InterfaceWithoutImplementation2 {
+class Impl12 : InterfaceWithImplementation1, InterfaceWithoutImplementation2 {
     override val field: Int = 0
 }
 
-class Impl3: AbstractWithFinalImplementation3()
-class Impl23: InheritingInterfaceWithoutImplementation6, AbstractWithFinalImplementation3()
+class Impl3 : AbstractWithFinalImplementation3()
+class Impl23 : InheritingInterfaceWithoutImplementation6, AbstractWithFinalImplementation3()
 
-class Impl24: InterfaceWithoutImplementation2, AbstractWithOpenImplementation4()
+class Impl24 : InterfaceWithoutImplementation2, AbstractWithOpenImplementation4()
 
-class Impl14: InterfaceWithImplementation1, AbstractWithOpenImplementation4() {
+class Impl14 : InterfaceWithImplementation1, AbstractWithOpenImplementation4() {
     override val field: Int = 0
 }
 
@@ -98,12 +98,17 @@ fun <!VIPER_TEXT!>createImpls<!>() {
     val impl6 = create6()
     val start6 = impl6.field + 1 - 1
 
+    val cond1 = start12 == impl12.field
+    val cond2 = start23 == impl23.field
+    val cond3 = start3 == impl3.field
+    val cond4 = start14 == impl14.field
+    val cond5 = start6 is Int
     verify(
-        start12 == impl12.field,
-        start23 == impl23.field,
-        start3 == impl3.field,
-        start14 == impl14.field,
-        start6 is Int,
+        cond1,
+        cond2,
+        cond3,
+        cond4,
+        cond5,
     )
 }
 

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/private_properties.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/private_properties.fir.diag.txt
@@ -63,8 +63,10 @@ method con$c$D$() returns (ret: Ref)
 method f$extractPublic$TF$() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
+  var l0$cond1: Ref
   var anon$0: Ref
   var anon$1: Ref
+  var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
   anon$1 := con$c$C$()
@@ -72,11 +74,13 @@ method f$extractPublic$TF$() returns (ret$0: Ref)
   anon$0 := anon$1.bf$field
   exhale acc(anon$1.bf$field, write)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+  l0$cond1 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType()))
   anon$3 := con$c$D$()
   unfold acc(p$c$D$shared(anon$3), wildcard)
   anon$2 := anon$3.bf$field
-  assert df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
+  l0$cond2 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType()))
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -86,3 +90,4 @@ method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
 
 method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
+

--- a/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/private_properties.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/properties_and_fields/private_properties.kt
@@ -27,5 +27,7 @@ class D: B() {
 @AlwaysVerify
 @Suppress("USELESS_IS_CHECK")
 fun <!VIPER_TEXT!>extractPublic<!>() {
-    verify(C().field is Int, D().field is Int)
+    val cond1 = C().field is Int
+    val cond2 = D().field is Int
+    verify(cond1, cond2)
 }

--- a/plugins/formal-verification/testData/diagnostics/verifies/stdlib_replacement_tests.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/stdlib_replacement_tests.fir.diag.txt
@@ -22,11 +22,13 @@ field bf$size: Ref
 method f$useRuns$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
+  var l0$cond1: Ref
   var anon$2: Ref
   var anon$3: Ref
   var ret$1: Ref
   var anon$4: Ref
   var ret$2: Ref
+  var l0$cond2: Ref
   var anon$5: Ref
   var anon$6: Ref
   var ret$3: Ref
@@ -46,7 +48,8 @@ method f$useRuns$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   anon$3 := ret$1
   anon$2 := anon$3
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-  assert df$rt$intFromRef(anon$2) == 1 + df$rt$intFromRef(p$x)
+  l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$2) ==
+    1 + df$rt$intFromRef(p$x))
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$x
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -62,12 +65,15 @@ method f$useRuns$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   anon$6 := ret$3
   anon$5 := anon$6
   inhale df$rt$isSubtype(df$rt$typeOf(anon$5), df$rt$intType())
-  assert df$rt$intFromRef(anon$5) == 1 + df$rt$intFromRef(p$x)
+  l0$cond2 := df$rt$boolToRef(df$rt$intFromRef(anon$5) ==
+    1 + df$rt$intFromRef(p$x))
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/stdlib_replacement_tests.kt:(415,422): info: Generated Viper text for useAlso:
+/stdlib_replacement_tests.kt:(459,466): info: Generated Viper text for useAlso:
 field bf$size: Ref
 
 method f$useAlso$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
@@ -97,12 +103,13 @@ method f$useAlso$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/stdlib_replacement_tests.kt:(487,493): info: Generated Viper text for useLet:
+/stdlib_replacement_tests.kt:(531,537): info: Generated Viper text for useLet:
 field bf$size: Ref
 
 method f$useLet$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
+  var l0$cond1: Ref
   var anon$2: Ref
   var anon$3: Ref
   var ret$1: Ref
@@ -126,12 +133,14 @@ method f$useLet$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   anon$3 := ret$1
   anon$2 := anon$3
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-  assert df$rt$intFromRef(anon$2) == 1 + df$rt$intFromRef(p$x)
+  l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$2) ==
+    1 + df$rt$intFromRef(p$x))
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/stdlib_replacement_tests.kt:(555,562): info: Generated Viper text for useWith:
+/stdlib_replacement_tests.kt:(621,628): info: Generated Viper text for useWith:
 field bf$size: Ref
 
 method f$useWith$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
@@ -164,7 +173,7 @@ method f$useWith$TF$T$Int(p$x: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/stdlib_replacement_tests.kt:(628,636): info: Generated Viper text for useApply:
+/stdlib_replacement_tests.kt:(694,702): info: Generated Viper text for useApply:
 field bf$size: Ref
 
 method f$useApply$TF$T$Int(p$x: Ref) returns (ret$0: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/stdlib_replacement_tests.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/stdlib_replacement_tests.kt
@@ -11,9 +11,11 @@ fun <!VIPER_TEXT!>useChecks<!>(): Unit {
 // TODO: add test for `repeat` (we actually have a bug there because we require unsatisfied precondition in loops)
 
 fun <!VIPER_TEXT!>useRuns<!>(x: Int): Unit {
+    val cond1 = run { x + 1 } == 1 + x
+    val cond2 = x.run { plus(1) } == 1 + x
     verify(
-        run { x + 1 } == 1 + x,
-        x.run { plus(1) } == 1 + x,
+        cond1,
+        cond2,
     )
 }
 
@@ -22,7 +24,8 @@ fun <!VIPER_TEXT!>useAlso<!>(x: Int): Unit {
 }
 
 fun <!VIPER_TEXT!>useLet<!>(x: Int): Unit {
-    verify(x.let { it + 1 } == 1 + x)
+    val cond1 = x.let { it + 1 } == 1 + x
+    verify(cond1)
 }
 
 fun <!VIPER_TEXT!>useWith<!>(x: Int): Unit {

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/chars.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/chars.fir.diag.txt
@@ -17,6 +17,7 @@ method f$testChars$TF$T$Char(p$c: Ref) returns (ret$0: Ref)
 {
   var l0$box: Ref
   var l0$charA: Ref
+  var l0$cond1: Ref
   var anon$0: Ref
   var l0$charZ: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
@@ -24,7 +25,9 @@ method f$testChars$TF$T$Char(p$c: Ref) returns (ret$0: Ref)
   l0$charA := df$rt$charToRef(97)
   unfold acc(p$c$CharBox$shared(l0$box), wildcard)
   anon$0 := l0$box.bf$char
-  assert df$rt$charFromRef(l0$charA) == df$rt$charFromRef(anon$0)
+  l0$cond1 := df$rt$boolToRef(df$rt$charFromRef(l0$charA) ==
+    df$rt$charFromRef(anon$0))
+  assert df$rt$boolFromRef(l0$cond1)
   l0$charZ := df$rt$charToRef(122)
   assert df$rt$charFromRef(l0$charA) == df$rt$charFromRef(l0$charZ) - 25
   assert df$rt$charFromRef(l0$charA) - df$rt$charFromRef(l0$charZ) == -25

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/chars.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/chars.kt
@@ -8,7 +8,8 @@ class CharBox(val char: Char)
 fun <!VIPER_TEXT!>testChars<!>(c: Char) {
     val box = CharBox('a')
     val charA = 'a'
-    verify(charA == box.char)
+    val cond1 = charA == box.char
+    verify(cond1)
     val charZ = 'z'
     verify(
         charA == charZ - 25,

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.fir.diag.txt
@@ -55,24 +55,30 @@ method con$c$StringBox$T$String(p$str: Ref) returns (ret: Ref)
 method f$testType$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
+  var l0$cond1: Ref
   var anon$0: Ref
   var anon$1: Ref
+  var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   anon$1 := con$c$StringBox$T$String(p$s)
   unfold acc(p$c$StringBox$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$str
-  assert df$rt$stringFromRef(anon$0) == df$rt$stringFromRef(p$s)
+  l0$cond1 := df$rt$boolToRef(df$rt$stringFromRef(anon$0) ==
+    df$rt$stringFromRef(p$s))
   anon$3 := con$c$StringBox$T$String(df$rt$stringToRef(Seq(115, 116, 114)))
   unfold acc(p$c$StringBox$shared(anon$3), wildcard)
   anon$2 := anon$3.bf$str
-  assert df$rt$stringFromRef(anon$2) == Seq(115, 116, 114)
+  l0$cond2 := df$rt$boolToRef(df$rt$stringFromRef(anon$2) ==
+    Seq(115, 116, 114))
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/strings.kt:(368,383): info: Generated Viper text for testLengthField:
+/strings.kt:(412,427): info: Generated Viper text for testLengthField:
 field bf$size: Ref
 
 field bf$str: Ref
@@ -130,6 +136,7 @@ method f$testLengthField$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$len: Ref
+  var l0$cond1: Ref
   var anon$0: Ref
   var anon$1: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
@@ -137,12 +144,13 @@ method f$testLengthField$TF$T$String(p$s: Ref) returns (ret$0: Ref)
   anon$1 := con$c$StringBox$T$String(df$rt$stringToRef(Seq(115, 116, 114)))
   unfold acc(p$c$StringBox$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$str
-  assert |df$rt$stringFromRef(anon$0)| == 3
+  l0$cond1 := df$rt$boolToRef(|df$rt$stringFromRef(anon$0)| == 3)
+  assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/strings.kt:(486,493): info: Generated Viper text for testOps:
+/strings.kt:(552,559): info: Generated Viper text for testOps:
 field bf$size: Ref
 
 predicate p$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {

--- a/plugins/formal-verification/testData/diagnostics/verifies/string/strings.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/string/strings.kt
@@ -8,16 +8,19 @@ class StringBox(val str: String)
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>testType<!>(s: String) {
+    val cond1 = StringBox(s).str == s
+    val cond2 = StringBox("str").str == "str"
     verify(
-        StringBox(s).str == s,
-        StringBox("str").str == "str",
+        cond1,
+        cond2,
     )
 }
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>testLengthField<!>(s: String) {
     val len = s.length
-    verify(StringBox("str").str.length == 3)
+    val cond1 = StringBox("str").str.length == 3
+    verify(cond1)
 }
 
 @AlwaysVerify

--- a/plugins/formal-verification/testData/diagnostics/verifies/while.fir.diag.txt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/while.fir.diag.txt
@@ -24,7 +24,9 @@ method f$test_while$TF$T$ClassWithField(p$param: Ref) returns (ret$0: Ref)
   var l0$initParamField: Ref
   var l0$iteration: Ref
   var anon$1: Ref
+  var l0$cond1: Ref
   var anon$2: Ref
+  var l0$cond2: Ref
   var anon$3: Ref
   inhale df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
   inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
@@ -67,15 +69,18 @@ method f$test_while$TF$T$ClassWithField(p$param: Ref) returns (ret$0: Ref)
     invariant df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
   unfold acc(p$c$ClassWithField$shared(l0$c), wildcard)
   anon$2 := l0$c.bf$field
-  assert df$rt$intFromRef(anon$2) == 13
+  l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$2) == 13)
   unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
   anon$3 := p$param.bf$field
-  assert df$rt$intFromRef(l0$initParamField) == df$rt$intFromRef(anon$3)
+  l0$cond2 := df$rt$boolToRef(df$rt$intFromRef(l0$initParamField) ==
+    df$rt$intFromRef(anon$3))
+  assert df$rt$boolFromRef(l0$cond1)
+  assert df$rt$boolFromRef(l0$cond2)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/while.kt:(855,879): info: Generated Viper text for test_while_with_inlining:
+/while.kt:(899,923): info: Generated Viper text for test_while_with_inlining:
 field bf$field: Ref
 
 field bf$size: Ref
@@ -166,7 +171,7 @@ method f$test_while_with_inlining$TF$T$ClassWithField(p$param: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/while.kt:(1267,1292): info: Generated Viper text for test_while_with_smartcast:
+/while.kt:(1311,1336): info: Generated Viper text for test_while_with_smartcast:
 field bf$field: Ref
 
 method f$test_while_with_smartcast$TF$T$Any$T$Any(p$param: Ref, p$innerParam: Ref)

--- a/plugins/formal-verification/testData/diagnostics/verifies/while.kt
+++ b/plugins/formal-verification/testData/diagnostics/verifies/while.kt
@@ -24,8 +24,10 @@ fun <!VIPER_TEXT!>test_while<!>(param: ClassWithField) {
         val paramField = param.field
         iteration = iteration + 1
     }
-    verify(c.field == 13)
-    verify(initParamField == param.field)
+    val cond1 = c.field == 13
+    val cond2 = initParamField == param.field
+    verify(cond1)
+    verify(cond2)
 }
 
 fun <!VIPER_TEXT!>test_while_with_inlining<!>(param: ClassWithField) {

--- a/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/plugins/formal-verification/tests-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -431,6 +431,22 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
   }
 
   @Nested
+  @TestMetadata("plugins/formal-verification/testData/diagnostics/purity")
+  @TestDataPath("$PROJECT_ROOT")
+  public class Purity {
+    @Test
+    public void testAllFilesPresentInPurity() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("plugins/formal-verification/testData/diagnostics/purity"), Pattern.compile("^(.+)\\.kt$"), null, true);
+    }
+
+    @Test
+    @TestMetadata("assert_statements.kt")
+    public void testAssert_statements() {
+      runTest("plugins/formal-verification/testData/diagnostics/purity/assert_statements.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("plugins/formal-verification/testData/diagnostics/uniqueness")
   @TestDataPath("$PROJECT_ROOT")
   public class Uniqueness {


### PR DESCRIPTION
### Feature: Error Reporting for the Purity Checker

Added a new interface `PurityContext` to the `purity` package. We want to use it for diagnostic information currently, so it stores an `errorCollector` as well as the FIR source of the embedding.

Next, support was implemented for purity errors in the `ErrorCollector`. These are stored similarly to the others, except that they also store positioning information. To be able to store `KtSourceElement`, dependencies in `build.gradle.kts` were updated. The purity errors are iterated over and reported in the `ViperPoweredDeclarationChecker`.

To get the positioning information in the first place, the `preorder` function was reworked slightly to store the closest parent to each node with the node in a new wrapper, `PositionedEmbedding`. When checking validity using `checkValidity()`, we simply decompose this wrapper and call `isValid()` on the node, creating a `PurityContext` instance with both the `errorCollector` and the source, which is contained in the wrapper.

One new test file was also added to test for `PURITY_VIOLATION` in assert statements. For existing test files, inputs and outputs were adapted to match the expected behavior with `PURITY_VIOLATION` errors.